### PR TITLE
Update CDEPS tests with GEFS forcing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,13 @@ Provide a detailed description of what this PR does. What bug does it fix, or wh
 - [ ] stochastic_physics
 - [ ] none
 
+### Library Updates/Changes
+<!-- Library updates take time. If this PR needs updates to libraries, please make sure to accomplish the following tasks -->
+- [ ] Not Needed
+- [ ] Create separate issue in [JCSDA/spack-stack](https://github.com/JCSDA/spack-stack) asking for update to library. Include library name, library version.
+- [ ] Add issue link from JCSDA/spack-stack following this item
+<!-- for example: "- JCSDA/spack-stack/issue/1757" -->
+
 ### Combined with PR's (If Applicable):
 
 ## Commit Queue Checklist:

--- a/tests/bl_date.conf
+++ b/tests/bl_date.conf
@@ -1,2 +1,2 @@
-export BL_DATE=20230616
+export BL_DATE=20230621
 

--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -997,6 +997,7 @@ export mesh_file=cfsr_mesh.nc
 export MESH_ATM=DATM_INPUT/${mesh_file}
 export atm_datamode=${DATM_SRC}
 export stream_files=DATM_INPUT/${FILENAME_BASE}201110.nc
+export STREAM_OFFSET=0
 
 # MOM6 defaults; 1 degree
 export MOM_INPUT=MOM_input_template_100

--- a/tests/logs/RegressionTests_acorn.log
+++ b/tests/logs/RegressionTests_acorn.log
@@ -1,54 +1,54 @@
-Tue Jun 20 15:30:31 UTC 2023
+Thu Jun 22 13:12:04 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: f845b3e43b08cfdd9c1a9b271ef3ab425d47fe6c
+Testing UFSWM Hash: d927a6627cfc1bb9815fa5f37502428bd49a9fe3
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
+ f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 1169 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1928 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1416 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 2342 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1175 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 770 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 2274 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 733 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1000 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 1472 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 551 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 842 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 1301 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 883 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 854 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 2537 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 717 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 477 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 864 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 881 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 658 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 586 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1564 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 1047 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 515 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1542 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 626 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 505 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 1008 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 1028 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 1473 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 594 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 856 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 560 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 1022 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 459 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 229 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 741 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 504 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 224 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 025 elapsed time 628 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 506 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 506 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 029 elapsed time 619 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 146 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 1083 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 755 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 636 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 472 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 559 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 656 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 026 elapsed time 526 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 590 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 029 elapsed time 317 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 117 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 819 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 620 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 657 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 740 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 678 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 323 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_mixedmode_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_p8_mixedmode_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -113,14 +113,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 331.499548
-The maximum resident set size (KB)                   = 2952292
+The total amount of wall time                        = 334.860686
+The maximum resident set size (KB)                   = 2951624
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_gfsv17_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_gfsv17_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -184,14 +184,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 252.293301
-The maximum resident set size (KB)                   = 1562564
+The total amount of wall time                        = 252.364836
+The maximum resident set size (KB)                   = 1561580
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -256,14 +256,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 384.858170
-The maximum resident set size (KB)                   = 2980024
+The total amount of wall time                        = 391.355345
+The maximum resident set size (KB)                   = 2976436
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_restart_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -316,14 +316,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 228.209128
-The maximum resident set size (KB)                   = 2865492
+The total amount of wall time                        = 229.562577
+The maximum resident set size (KB)                   = 2860464
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_qr_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -388,14 +388,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 385.676785
-The maximum resident set size (KB)                   = 2989844
+The total amount of wall time                        = 390.937226
+The maximum resident set size (KB)                   = 2988364
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_restart_qr_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -448,14 +448,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 230.024829
-The maximum resident set size (KB)                   = 2873872
+The total amount of wall time                        = 230.886160
+The maximum resident set size (KB)                   = 2879748
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_2threads_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -508,14 +508,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 365.360583
-The maximum resident set size (KB)                   = 3283968
+The total amount of wall time                        = 361.922362
+The maximum resident set size (KB)                   = 3285600
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_decomp_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -568,14 +568,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 379.464752
-The maximum resident set size (KB)                   = 2979224
+The total amount of wall time                        = 386.112181
+The maximum resident set size (KB)                   = 2976628
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_mpi_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -628,14 +628,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 319.603720
-The maximum resident set size (KB)                   = 2907640
+The total amount of wall time                        = 316.301641
+The maximum resident set size (KB)                   = 2906180
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_ciceC_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_ciceC_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_ciceC_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -700,14 +700,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.053227
-The maximum resident set size (KB)                   = 2977672
+The total amount of wall time                        = 382.179742
+The maximum resident set size (KB)                   = 2977016
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_noaero_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_noaero_p8_intel
 Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -771,14 +771,14 @@ Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 282.989086
-The maximum resident set size (KB)                   = 1564524
+The total amount of wall time                        = 280.474275
+The maximum resident set size (KB)                   = 1565832
 
 Test 011 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_nowave_noaero_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_nowave_noaero_p8_intel
 Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -840,14 +840,14 @@ Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 294.649706
-The maximum resident set size (KB)                   = 1617516
+The total amount of wall time                        = 295.909698
+The maximum resident set size (KB)                   = 1617808
 
 Test 012 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_agrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_noaero_p8_agrid_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_noaero_p8_agrid_intel
 Checking test 013 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -909,14 +909,14 @@ Checking test 013 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 302.090759
-The maximum resident set size (KB)                   = 1619852
+The total amount of wall time                        = 305.295064
+The maximum resident set size (KB)                   = 1619000
 
 Test 013 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_c48_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_c48_intel
 Checking test 014 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -966,14 +966,14 @@ Checking test 014 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 431.086919
-The maximum resident set size (KB)                   = 2638416
+The total amount of wall time                        = 430.808682
+The maximum resident set size (KB)                   = 2636172
 
 Test 014 cpld_control_c48_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_warmstart_c48_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_warmstart_c48_intel
 Checking test 015 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1023,14 +1023,14 @@ Checking test 015 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 121.920678
-The maximum resident set size (KB)                   = 2639060
+The total amount of wall time                        = 122.703831
+The maximum resident set size (KB)                   = 2639320
 
 Test 015 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_restart_c48_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_restart_c48_intel
 Checking test 016 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1080,14 +1080,14 @@ Checking test 016 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 68.032858
-The maximum resident set size (KB)                   = 2050844
+The total amount of wall time                        = 69.224076
+The maximum resident set size (KB)                   = 2051116
 
 Test 016 cpld_restart_c48_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/cpld_control_p8_faster_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/cpld_control_p8_faster_intel
 Checking test 017 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1152,14 +1152,14 @@ Checking test 017 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 379.667933
-The maximum resident set size (KB)                   = 2977928
+The total amount of wall time                        = 374.884058
+The maximum resident set size (KB)                   = 2978260
 
 Test 017 cpld_control_p8_faster_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_flake_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_flake_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_flake_intel
 Checking test 018 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1170,14 +1170,14 @@ Checking test 018 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 213.122086
-The maximum resident set size (KB)                   = 568432
+The total amount of wall time                        = 213.107380
+The maximum resident set size (KB)                   = 568512
 
 Test 018 control_flake_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_CubedSphereGrid_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_CubedSphereGrid_intel
 Checking test 019 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1204,14 +1204,14 @@ Checking test 019 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 129.343062
-The maximum resident set size (KB)                   = 513988
+The total amount of wall time                        = 128.617260
+The maximum resident set size (KB)                   = 513792
 
 Test 019 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_latlon_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_latlon_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_latlon_intel
 Checking test 020 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1222,14 +1222,14 @@ Checking test 020 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 131.527731
-The maximum resident set size (KB)                   = 514212
+The total amount of wall time                        = 131.664311
+The maximum resident set size (KB)                   = 517320
 
 Test 020 control_latlon_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_wrtGauss_netcdf_parallel_intel
 Checking test 021 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 133.952402
-The maximum resident set size (KB)                   = 516728
+The total amount of wall time                        = 133.466119
+The maximum resident set size (KB)                   = 514740
 
 Test 021 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_c48_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_c48_intel
 Checking test 022 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1286,14 +1286,14 @@ Checking test 022 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 327.829837
-The maximum resident set size (KB)                   = 672600
+The total amount of wall time                        = 323.925396
+The maximum resident set size (KB)                   = 672776
 
 Test 022 control_c48_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c192_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_c192_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_c192_intel
 Checking test 023 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1304,14 +1304,14 @@ Checking test 023 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 526.919177
-The maximum resident set size (KB)                   = 615972
+The total amount of wall time                        = 525.790959
+The maximum resident set size (KB)                   = 615764
 
 Test 023 control_c192_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c384_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_c384_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_c384_intel
 Checking test 024 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1322,14 +1322,14 @@ Checking test 024 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 564.378801
-The maximum resident set size (KB)                   = 921672
+The total amount of wall time                        = 561.809524
+The maximum resident set size (KB)                   = 931684
 
 Test 024 control_c384_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c384gdas_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_c384gdas_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_c384gdas_intel
 Checking test 025 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1372,14 +1372,14 @@ Checking test 025 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 494.430803
-The maximum resident set size (KB)                   = 1066344
+The total amount of wall time                        = 509.413014
+The maximum resident set size (KB)                   = 1055464
 
 Test 025 control_c384gdas_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_stochy_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_stochy_intel
 Checking test 026 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1390,28 +1390,28 @@ Checking test 026 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 89.156110
-The maximum resident set size (KB)                   = 521292
+The total amount of wall time                        = 89.015974
+The maximum resident set size (KB)                   = 520020
 
 Test 026 control_stochy_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_stochy_restart_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_stochy_restart_intel
 Checking test 027 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 48.728483
-The maximum resident set size (KB)                   = 289364
+The total amount of wall time                        = 49.225951
+The maximum resident set size (KB)                   = 289116
 
 Test 027 control_stochy_restart_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_lndp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_lndp_intel
 Checking test 028 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1422,14 +1422,14 @@ Checking test 028 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 82.611990
-The maximum resident set size (KB)                   = 520508
+The total amount of wall time                        = 82.908114
+The maximum resident set size (KB)                   = 517572
 
 Test 028 control_lndp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_iovr4_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_iovr4_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_iovr4_intel
 Checking test 029 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1444,14 +1444,14 @@ Checking test 029 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 134.365319
-The maximum resident set size (KB)                   = 515520
+The total amount of wall time                        = 135.066832
+The maximum resident set size (KB)                   = 515468
 
 Test 029 control_iovr4_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_iovr5_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_iovr5_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_iovr5_intel
 Checking test 030 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1466,14 +1466,14 @@ Checking test 030 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 134.628417
-The maximum resident set size (KB)                   = 515948
+The total amount of wall time                        = 134.778792
+The maximum resident set size (KB)                   = 514628
 
 Test 030 control_iovr5_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_p8_intel
 Checking test 031 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1520,14 +1520,14 @@ Checking test 031 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 175.713312
-The maximum resident set size (KB)                   = 1490160
+The total amount of wall time                        = 176.622653
+The maximum resident set size (KB)                   = 1490164
 
 Test 031 control_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_restart_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_restart_p8_intel
 Checking test 032 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1566,14 +1566,14 @@ Checking test 032 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 97.832025
-The maximum resident set size (KB)                   = 654360
+The total amount of wall time                        = 98.701566
+The maximum resident set size (KB)                   = 653820
 
 Test 032 control_restart_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_qr_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_qr_p8_intel
 Checking test 033 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1620,14 +1620,14 @@ Checking test 033 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 174.012872
-The maximum resident set size (KB)                   = 1499728
+The total amount of wall time                        = 175.819513
+The maximum resident set size (KB)                   = 1500872
 
 Test 033 control_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_restart_qr_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_restart_qr_p8_intel
 Checking test 034 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1666,14 +1666,14 @@ Checking test 034 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 98.733586
-The maximum resident set size (KB)                   = 662684
+The total amount of wall time                        = 98.929640
+The maximum resident set size (KB)                   = 669204
 
 Test 034 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_decomp_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_decomp_p8_intel
 Checking test 035 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1716,14 +1716,14 @@ Checking test 035 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.710923
-The maximum resident set size (KB)                   = 1482380
+The total amount of wall time                        = 178.972359
+The maximum resident set size (KB)                   = 1479624
 
 Test 035 control_decomp_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_2threads_p8_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_2threads_p8_intel
 Checking test 036 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1766,14 +1766,14 @@ Checking test 036 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 151.961356
-The maximum resident set size (KB)                   = 1566672
+The total amount of wall time                        = 152.286735
+The maximum resident set size (KB)                   = 1566624
 
 Test 036 control_2threads_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_p8_lndp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_p8_lndp_intel
 Checking test 037 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1792,14 +1792,14 @@ Checking test 037 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 317.074591
-The maximum resident set size (KB)                   = 1488940
+The total amount of wall time                        = 318.288259
+The maximum resident set size (KB)                   = 1483560
 
 Test 037 control_p8_lndp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_rrtmgp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_p8_rrtmgp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_p8_rrtmgp_intel
 Checking test 038 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1846,14 +1846,14 @@ Checking test 038 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 233.099937
-The maximum resident set size (KB)                   = 1546352
+The total amount of wall time                        = 233.010043
+The maximum resident set size (KB)                   = 1537636
 
 Test 038 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_mynn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_p8_mynn_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_p8_mynn_intel
 Checking test 039 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1900,14 +1900,14 @@ Checking test 039 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 176.938525
-The maximum resident set size (KB)                   = 1490076
+The total amount of wall time                        = 178.826701
+The maximum resident set size (KB)                   = 1492976
 
 Test 039 control_p8_mynn_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/merra2_thompson_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/merra2_thompson_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/merra2_thompson_intel
 Checking test 040 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1954,14 +1954,14 @@ Checking test 040 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 200.624681
-The maximum resident set size (KB)                   = 1491036
+The total amount of wall time                        = 202.453192
+The maximum resident set size (KB)                   = 1497688
 
 Test 040 merra2_thompson_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_control_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_control_intel
 Checking test 041 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1972,28 +1972,28 @@ Checking test 041 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 280.972373
-The maximum resident set size (KB)                   = 652856
+The total amount of wall time                        = 280.309151
+The maximum resident set size (KB)                   = 652428
 
 Test 041 regional_control_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_restart_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_restart_intel
 Checking test 042 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 150.844089
-The maximum resident set size (KB)                   = 654048
+The total amount of wall time                        = 151.213712
+The maximum resident set size (KB)                   = 650276
 
 Test 042 regional_restart_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_control_qr_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_control_qr_intel
 Checking test 043 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2004,28 +2004,28 @@ Checking test 043 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 284.927181
-The maximum resident set size (KB)                   = 652092
+The total amount of wall time                        = 281.116918
+The maximum resident set size (KB)                   = 651376
 
 Test 043 regional_control_qr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_restart_qr_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_restart_qr_intel
 Checking test 044 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 149.621752
-The maximum resident set size (KB)                   = 655076
+The total amount of wall time                        = 152.428668
+The maximum resident set size (KB)                   = 653176
 
 Test 044 regional_restart_qr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_decomp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_decomp_intel
 Checking test 045 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2036,14 +2036,14 @@ Checking test 045 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 291.617053
-The maximum resident set size (KB)                   = 652488
+The total amount of wall time                        = 295.364623
+The maximum resident set size (KB)                   = 653572
 
 Test 045 regional_decomp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_2threads_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_2threads_intel
 Checking test 046 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2054,14 +2054,14 @@ Checking test 046 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 168.217246
-The maximum resident set size (KB)                   = 698388
+The total amount of wall time                        = 168.496708
+The maximum resident set size (KB)                   = 696468
 
 Test 046 regional_2threads_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_noquilt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_noquilt_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_noquilt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_noquilt_intel
 Checking test 047 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2069,14 +2069,14 @@ Checking test 047 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 275.305659
-The maximum resident set size (KB)                   = 644836
+The total amount of wall time                        = 277.852805
+The maximum resident set size (KB)                   = 648584
 
 Test 047 regional_noquilt_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_2dwrtdecomp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_2dwrtdecomp_intel
 Checking test 048 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2087,14 +2087,14 @@ Checking test 048 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 278.717642
-The maximum resident set size (KB)                   = 651416
+The total amount of wall time                        = 280.791165
+The maximum resident set size (KB)                   = 651772
 
 Test 048 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/fv3_regional_wofs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_wofs_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/fv3_regional_wofs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_wofs_intel
 Checking test 049 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2105,14 +2105,14 @@ Checking test 049 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 355.286240
-The maximum resident set size (KB)                   = 340376
+The total amount of wall time                        = 356.638339
+The maximum resident set size (KB)                   = 339880
 
 Test 049 regional_wofs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_ifi_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_ifi_control_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_ifi_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_ifi_control_intel
 Checking test 050 regional_ifi_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2123,14 +2123,14 @@ Checking test 050 regional_ifi_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 313.328932
-The maximum resident set size (KB)                   = 652152
+The total amount of wall time                        = 311.251446
+The maximum resident set size (KB)                   = 649736
 
 Test 050 regional_ifi_control_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_ifi_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_ifi_decomp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_ifi_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_ifi_decomp_intel
 Checking test 051 regional_ifi_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2141,14 +2141,14 @@ Checking test 051 regional_ifi_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 332.085833
-The maximum resident set size (KB)                   = 652364
+The total amount of wall time                        = 325.535693
+The maximum resident set size (KB)                   = 650168
 
 Test 051 regional_ifi_decomp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_ifi_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_ifi_2threads_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_ifi_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_ifi_2threads_intel
 Checking test 052 regional_ifi_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2159,14 +2159,14 @@ Checking test 052 regional_ifi_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 193.930957
-The maximum resident set size (KB)                   = 690760
+The total amount of wall time                        = 189.499656
+The maximum resident set size (KB)                   = 691224
 
 Test 052 regional_ifi_2threads_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_control_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_control_intel
 Checking test 053 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2213,14 +2213,14 @@ Checking test 053 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 403.991210
-The maximum resident set size (KB)                   = 897480
+The total amount of wall time                        = 403.216529
+The maximum resident set size (KB)                   = 895084
 
 Test 053 rap_control_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_spp_sppt_shum_skeb_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_spp_sppt_shum_skeb_intel
 Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2231,14 +2231,14 @@ Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 239.698443
-The maximum resident set size (KB)                   = 977980
+The total amount of wall time                        = 238.251736
+The maximum resident set size (KB)                   = 982076
 
 Test 054 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_decomp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_decomp_intel
 Checking test 055 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2285,14 +2285,14 @@ Checking test 055 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 417.477425
-The maximum resident set size (KB)                   = 893636
+The total amount of wall time                        = 417.309502
+The maximum resident set size (KB)                   = 896788
 
 Test 055 rap_decomp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_2threads_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_2threads_intel
 Checking test 056 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2339,14 +2339,14 @@ Checking test 056 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 364.176998
-The maximum resident set size (KB)                   = 967392
+The total amount of wall time                        = 363.252953
+The maximum resident set size (KB)                   = 979732
 
 Test 056 rap_2threads_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_restart_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_restart_intel
 Checking test 057 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2385,14 +2385,14 @@ Checking test 057 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 206.184793
-The maximum resident set size (KB)                   = 636272
+The total amount of wall time                        = 205.905684
+The maximum resident set size (KB)                   = 637576
 
 Test 057 rap_restart_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_sfcdiff_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_sfcdiff_intel
 Checking test 058 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2439,14 +2439,14 @@ Checking test 058 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 407.512915
-The maximum resident set size (KB)                   = 896900
+The total amount of wall time                        = 406.489391
+The maximum resident set size (KB)                   = 895000
 
 Test 058 rap_sfcdiff_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_sfcdiff_decomp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_sfcdiff_decomp_intel
 Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2493,14 +2493,14 @@ Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 422.890310
-The maximum resident set size (KB)                   = 894660
+The total amount of wall time                        = 421.172112
+The maximum resident set size (KB)                   = 893776
 
 Test 059 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_sfcdiff_restart_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_sfcdiff_restart_intel
 Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2539,14 +2539,14 @@ Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 299.486124
-The maximum resident set size (KB)                   = 641764
+The total amount of wall time                        = 300.111619
+The maximum resident set size (KB)                   = 641972
 
 Test 060 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_intel
 Checking test 061 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2562,30 +2562,30 @@ Checking test 061 hrrr_control_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
@@ -2593,14 +2593,14 @@ Checking test 061 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 389.776881
-The maximum resident set size (KB)                   = 890968
+The total amount of wall time                        = 390.402058
+The maximum resident set size (KB)                   = 893924
 
-Test 061 hrrr_control_intel FAIL Tries: 2
+Test 061 hrrr_control_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_qr_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_qr_intel
 Checking test 062 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2617,8 +2617,8 @@ Checking test 062 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
@@ -2628,7 +2628,7 @@ Checking test 062 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
@@ -2647,14 +2647,14 @@ Checking test 062 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 385.172670
-The maximum resident set size (KB)                   = 901428
+The total amount of wall time                        = 383.758203
+The maximum resident set size (KB)                   = 900300
 
-Test 062 hrrr_control_qr_intel FAIL Tries: 2
+Test 062 hrrr_control_qr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_decomp_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_decomp_intel
 Checking test 063 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2670,30 +2670,30 @@ Checking test 063 hrrr_control_decomp_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
@@ -2701,14 +2701,14 @@ Checking test 063 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 403.493267
-The maximum resident set size (KB)                   = 891984
+The total amount of wall time                        = 402.994479
+The maximum resident set size (KB)                   = 892884
 
-Test 063 hrrr_control_decomp_intel FAIL Tries: 2
+Test 063 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_2threads_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_2threads_intel
 Checking test 064 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2724,30 +2724,30 @@ Checking test 064 hrrr_control_2threads_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
@@ -2755,14 +2755,42 @@ Checking test 064 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 349.528395
-The maximum resident set size (KB)                   = 963168
+The total amount of wall time                        = 349.269745
+The maximum resident set size (KB)                   = 962376
 
-Test 064 hrrr_control_2threads_intel FAIL Tries: 2
+Test 064 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_v1beta_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_restart_intel
+Checking test 065 hrrr_control_restart_intel results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+The total amount of wall time                        = 287.349154
+The maximum resident set size (KB)                   = 636384
+
+Test 065 hrrr_control_restart_intel PASS
+
+
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_restart_qr_intel
+Checking test 066 hrrr_control_restart_qr_intel results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+The total amount of wall time                        = 288.623363
+The maximum resident set size (KB)                   = 648776
+
+Test 066 hrrr_control_restart_qr_intel PASS
+
+
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_v1beta_intel
 Checking test 067 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2809,14 +2837,14 @@ Checking test 067 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 399.957846
-The maximum resident set size (KB)                   = 890872
+The total amount of wall time                        = 398.755130
+The maximum resident set size (KB)                   = 894132
 
 Test 067 rrfs_v1beta_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_v1nssl_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_v1nssl_intel
 Checking test 068 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2831,14 +2859,14 @@ Checking test 068 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 465.467835
-The maximum resident set size (KB)                   = 578004
+The total amount of wall time                        = 464.231171
+The maximum resident set size (KB)                   = 577700
 
 Test 068 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_v1nssl_nohailnoccn_intel
 Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2853,14 +2881,14 @@ Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 455.093912
-The maximum resident set size (KB)                   = 574516
+The total amount of wall time                        = 454.188453
+The maximum resident set size (KB)                   = 572776
 
 Test 069 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2876,15 +2904,31 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 146.914101
-The maximum resident set size (KB)                   = 795312
+The total amount of wall time                        = 148.083346
+The maximum resident set size (KB)                   = 796012
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_hrrr_warm_qr_intel
-Checking test 071 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+The total amount of wall time                        = 103.893753
+The maximum resident set size (KB)                   = 799168
+
+Test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
+
+
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_conus13km_hrrr_warm_intel
+Checking test 072 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2899,15 +2943,15 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 146.930967
-The maximum resident set size (KB)                   = 799188
+The total amount of wall time                        = 134.932428
+The maximum resident set size (KB)                   = 779788
 
-Test 071 rrfs_smoke_conus13km_hrrr_warm_qr_intel PASS
+Test 072 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
-Checking test 072 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_smoke_conus13km_radar_tten_warm_intel
+Checking test 073 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2915,78 +2959,27 @@ Checking test 072 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 102.959911
-The maximum resident set size (KB)                   = 800388
+The total amount of wall time                        = 147.618895
+The maximum resident set size (KB)                   = 797420
 
-Test 072 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_conus13km_hrrr_warm_intel
-Checking test 073 rrfs_conus13km_hrrr_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-The total amount of wall time                        = 133.366078
-The maximum resident set size (KB)                   = 778524
-
-Test 073 rrfs_conus13km_hrrr_warm_intel PASS
+Test 073 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_radar_tten_warm_intel
-Checking test 074 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-The total amount of wall time                        = 148.204365
-The maximum resident set size (KB)                   = 798640
-
-Test 074 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-Checking test 075 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+Checking test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 93.465157
-The maximum resident set size (KB)                   = 793444
+The total amount of wall time                        = 93.462105
+The maximum resident set size (KB)                   = 792596
 
-Test 075 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel
-Checking test 076 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-The total amount of wall time                        = 92.007170
-The maximum resident set size (KB)                   = 790652
-
-Test 076 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel PASS
+Test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmg_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_csawmg_intel
-Checking test 077 control_csawmg_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmg_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_csawmg_intel
+Checking test 075 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -2996,15 +2989,15 @@ Checking test 077 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 339.749995
-The maximum resident set size (KB)                   = 582012
+The total amount of wall time                        = 337.751977
+The maximum resident set size (KB)                   = 582608
 
-Test 077 control_csawmg_intel PASS
+Test 075 control_csawmg_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_csawmgt_intel
-Checking test 078 control_csawmgt_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_csawmgt_intel
+Checking test 076 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3014,15 +3007,15 @@ Checking test 078 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 335.922793
-The maximum resident set size (KB)                   = 581412
+The total amount of wall time                        = 334.448859
+The maximum resident set size (KB)                   = 581444
 
-Test 078 control_csawmgt_intel PASS
+Test 076 control_csawmgt_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_ras_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_ras_intel
-Checking test 079 control_ras_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_ras_intel
+Checking test 077 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3032,27 +3025,27 @@ Checking test 079 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 181.865929
-The maximum resident set size (KB)                   = 549480
+The total amount of wall time                        = 181.023134
+The maximum resident set size (KB)                   = 548320
 
-Test 079 control_ras_intel PASS
+Test 077 control_ras_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wam_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_wam_intel
-Checking test 080 control_wam_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_wam_intel
+Checking test 078 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 117.080636
-The maximum resident set size (KB)                   = 270360
+The total amount of wall time                        = 117.006436
+The maximum resident set size (KB)                   = 271820
 
-Test 080 control_wam_intel PASS
+Test 078 control_wam_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_p8_faster_intel
-Checking test 081 control_p8_faster_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_p8_faster_intel
+Checking test 079 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3098,15 +3091,15 @@ Checking test 081 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 175.095779
-The maximum resident set size (KB)                   = 1490652
+The total amount of wall time                        = 170.611534
+The maximum resident set size (KB)                   = 1495904
 
-Test 081 control_p8_faster_intel PASS
+Test 079 control_p8_faster_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_control_faster_intel
-Checking test 082 regional_control_faster_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_control_faster_intel
+Checking test 080 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3116,57 +3109,57 @@ Checking test 082 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 273.731126
-The maximum resident set size (KB)                   = 652444
+The total amount of wall time                        = 274.097578
+The maximum resident set size (KB)                   = 651352
 
-Test 082 regional_control_faster_intel PASS
+Test 080 regional_control_faster_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-Checking test 083 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 898.270781
-The maximum resident set size (KB)                   = 823096
+The total amount of wall time                        = 902.630206
+The maximum resident set size (KB)                   = 821500
 
-Test 083 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
+Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
-Checking test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 518.886738
-The maximum resident set size (KB)                   = 834304
+The total amount of wall time                        = 519.352780
+The maximum resident set size (KB)                   = 826284
 
-Test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
+Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_conus13km_hrrr_warm_debug_intel
-Checking test 085 rrfs_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_conus13km_hrrr_warm_debug_intel
+Checking test 083 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 804.979849
-The maximum resident set size (KB)                   = 807192
+The total amount of wall time                        = 805.348358
+The maximum resident set size (KB)                   = 806448
 
-Test 085 rrfs_conus13km_hrrr_warm_debug_intel PASS
+Test 083 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_CubedSphereGrid_debug_intel
-Checking test 086 control_CubedSphereGrid_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_CubedSphereGrid_debug_intel
+Checking test 084 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3192,349 +3185,349 @@ Checking test 086 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 156.773032
-The maximum resident set size (KB)                   = 676892
+The total amount of wall time                        = 156.283697
+The maximum resident set size (KB)                   = 678920
 
-Test 086 control_CubedSphereGrid_debug_intel PASS
+Test 084 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_wrtGauss_netcdf_parallel_debug_intel
-Checking test 087 control_wrtGauss_netcdf_parallel_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_wrtGauss_netcdf_parallel_debug_intel
+Checking test 085 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 156.738071
-The maximum resident set size (KB)                   = 673684
+The total amount of wall time                        = 156.934728
+The maximum resident set size (KB)                   = 675828
 
-Test 087 control_wrtGauss_netcdf_parallel_debug_intel PASS
+Test 085 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_stochy_debug_intel
-Checking test 088 control_stochy_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_stochy_debug_intel
+Checking test 086 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 176.813754
-The maximum resident set size (KB)                   = 678236
+The total amount of wall time                        = 176.751211
+The maximum resident set size (KB)                   = 681768
 
-Test 088 control_stochy_debug_intel PASS
+Test 086 control_stochy_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_lndp_debug_intel
-Checking test 089 control_lndp_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_lndp_debug_intel
+Checking test 087 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 158.410668
-The maximum resident set size (KB)                   = 682392
+The total amount of wall time                        = 159.002666
+The maximum resident set size (KB)                   = 679508
 
-Test 089 control_lndp_debug_intel PASS
+Test 087 control_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_csawmg_debug_intel
-Checking test 090 control_csawmg_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_csawmg_debug_intel
+Checking test 088 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 252.421435
-The maximum resident set size (KB)                   = 717660
+The total amount of wall time                        = 252.438951
+The maximum resident set size (KB)                   = 717500
 
-Test 090 control_csawmg_debug_intel PASS
+Test 088 control_csawmg_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_csawmgt_debug_intel
-Checking test 091 control_csawmgt_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_csawmgt_debug_intel
+Checking test 089 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 248.380530
-The maximum resident set size (KB)                   = 715708
+The total amount of wall time                        = 248.008174
+The maximum resident set size (KB)                   = 718508
 
-Test 091 control_csawmgt_debug_intel PASS
+Test 089 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_ras_debug_intel
-Checking test 092 control_ras_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_ras_debug_intel
+Checking test 090 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.082705
-The maximum resident set size (KB)                   = 687836
+The total amount of wall time                        = 162.136881
+The maximum resident set size (KB)                   = 689028
 
-Test 092 control_ras_debug_intel PASS
+Test 090 control_ras_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_diag_debug_intel
-Checking test 093 control_diag_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_diag_debug_intel
+Checking test 091 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.307241
-The maximum resident set size (KB)                   = 732448
+The total amount of wall time                        = 161.083547
+The maximum resident set size (KB)                   = 730160
 
-Test 093 control_diag_debug_intel PASS
+Test 091 control_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_debug_p8_intel
-Checking test 094 control_debug_p8_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_debug_p8_intel
+Checking test 092 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 184.698406
-The maximum resident set size (KB)                   = 1507020
+The total amount of wall time                        = 182.915035
+The maximum resident set size (KB)                   = 1504668
 
-Test 094 control_debug_p8_intel PASS
+Test 092 control_debug_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_debug_intel
-Checking test 095 regional_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_debug_intel
+Checking test 093 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1035.750067
-The maximum resident set size (KB)                   = 678624
+The total amount of wall time                        = 1039.607186
+The maximum resident set size (KB)                   = 673796
 
-Test 095 regional_debug_intel PASS
+Test 093 regional_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_control_debug_intel
-Checking test 096 rap_control_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_control_debug_intel
+Checking test 094 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.195907
-The maximum resident set size (KB)                   = 1050260
+The total amount of wall time                        = 295.122553
+The maximum resident set size (KB)                   = 1050468
 
-Test 096 rap_control_debug_intel PASS
+Test 094 rap_control_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_debug_intel
-Checking test 097 hrrr_control_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_debug_intel
+Checking test 095 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.722046
-The maximum resident set size (KB)                   = 1047312
+The total amount of wall time                        = 287.249659
+The maximum resident set size (KB)                   = 1051608
 
-Test 097 hrrr_control_debug_intel PASS
+Test 095 hrrr_control_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_unified_drag_suite_debug_intel
-Checking test 098 rap_unified_drag_suite_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_unified_drag_suite_debug_intel
+Checking test 096 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.173720
-The maximum resident set size (KB)                   = 1050180
+The total amount of wall time                        = 294.844433
+The maximum resident set size (KB)                   = 1048508
 
-Test 098 rap_unified_drag_suite_debug_intel PASS
+Test 096 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_diag_debug_intel
-Checking test 099 rap_diag_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_diag_debug_intel
+Checking test 097 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 305.505570
-The maximum resident set size (KB)                   = 1136368
+The total amount of wall time                        = 306.567727
+The maximum resident set size (KB)                   = 1135464
 
-Test 099 rap_diag_debug_intel PASS
+Test 097 rap_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_cires_ugwp_debug_intel
-Checking test 100 rap_cires_ugwp_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_cires_ugwp_debug_intel
+Checking test 098 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.010575
-The maximum resident set size (KB)                   = 1051040
+The total amount of wall time                        = 302.219985
+The maximum resident set size (KB)                   = 1053304
 
-Test 100 rap_cires_ugwp_debug_intel PASS
+Test 098 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_unified_ugwp_debug_intel
-Checking test 101 rap_unified_ugwp_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_unified_ugwp_debug_intel
+Checking test 099 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.422319
-The maximum resident set size (KB)                   = 1047992
+The total amount of wall time                        = 301.885548
+The maximum resident set size (KB)                   = 1053096
 
-Test 101 rap_unified_ugwp_debug_intel PASS
+Test 099 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_lndp_debug_intel
-Checking test 102 rap_lndp_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_lndp_debug_intel
+Checking test 100 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.728213
-The maximum resident set size (KB)                   = 1049804
+The total amount of wall time                        = 297.010319
+The maximum resident set size (KB)                   = 1050944
 
-Test 102 rap_lndp_debug_intel PASS
+Test 100 rap_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_progcld_thompson_debug_intel
-Checking test 103 rap_progcld_thompson_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_progcld_thompson_debug_intel
+Checking test 101 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.468676
-The maximum resident set size (KB)                   = 1051272
+The total amount of wall time                        = 294.449228
+The maximum resident set size (KB)                   = 1053276
 
-Test 103 rap_progcld_thompson_debug_intel PASS
+Test 101 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_noah_debug_intel
-Checking test 104 rap_noah_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_noah_debug_intel
+Checking test 102 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 289.443763
-The maximum resident set size (KB)                   = 1057896
+The total amount of wall time                        = 290.760819
+The maximum resident set size (KB)                   = 1049524
 
-Test 104 rap_noah_debug_intel PASS
+Test 102 rap_noah_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_sfcdiff_debug_intel
-Checking test 105 rap_sfcdiff_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_sfcdiff_debug_intel
+Checking test 103 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.886229
-The maximum resident set size (KB)                   = 1052076
+The total amount of wall time                        = 295.586886
+The maximum resident set size (KB)                   = 1052680
 
-Test 105 rap_sfcdiff_debug_intel PASS
+Test 103 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_noah_sfcdiff_cires_ugwp_debug_intel
-Checking test 106 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_noah_sfcdiff_cires_ugwp_debug_intel
+Checking test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 484.765500
-The maximum resident set size (KB)                   = 1052296
+The total amount of wall time                        = 484.002974
+The maximum resident set size (KB)                   = 1052448
 
-Test 106 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
+Test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rrfs_v1beta_debug_intel
-Checking test 107 rrfs_v1beta_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rrfs_v1beta_debug_intel
+Checking test 105 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 289.905072
-The maximum resident set size (KB)                   = 1048288
+The total amount of wall time                        = 289.639953
+The maximum resident set size (KB)                   = 1048484
 
-Test 107 rrfs_v1beta_debug_intel PASS
+Test 105 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_clm_lake_debug_intel
-Checking test 108 rap_clm_lake_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_clm_lake_debug_intel
+Checking test 106 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 351.700553
-The maximum resident set size (KB)                   = 1056752
+The total amount of wall time                        = 351.992479
+The maximum resident set size (KB)                   = 1055024
 
-Test 108 rap_clm_lake_debug_intel PASS
+Test 106 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_flake_debug_intel
-Checking test 109 rap_flake_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_flake_debug_intel
+Checking test 107 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.164910
-The maximum resident set size (KB)                   = 1053772
+The total amount of wall time                        = 295.091327
+The maximum resident set size (KB)                   = 1053968
 
-Test 109 rap_flake_debug_intel PASS
+Test 107 rap_flake_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_wam_debug_intel
-Checking test 110 control_wam_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_wam_debug_intel
+Checking test 108 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 294.983785
-The maximum resident set size (KB)                   = 300500
+The total amount of wall time                        = 295.315575
+The maximum resident set size (KB)                   = 299436
 
-Test 110 control_wam_debug_intel PASS
+Test 108 control_wam_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3544,15 +3537,15 @@ Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 226.506170
-The maximum resident set size (KB)                   = 886556
+The total amount of wall time                        = 225.144518
+The maximum resident set size (KB)                   = 889144
 
-Test 111 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+Test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_control_dyn32_phy32_intel
-Checking test 112 rap_control_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_control_dyn32_phy32_intel
+Checking test 110 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3598,15 +3591,15 @@ Checking test 112 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 337.494220
-The maximum resident set size (KB)                   = 772584
+The total amount of wall time                        = 338.239034
+The maximum resident set size (KB)                   = 771000
 
-Test 112 rap_control_dyn32_phy32_intel PASS
+Test 110 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_dyn32_phy32_intel
-Checking test 113 hrrr_control_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_dyn32_phy32_intel
+Checking test 111 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3652,15 +3645,15 @@ Checking test 113 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 178.069330
-The maximum resident set size (KB)                   = 773544
+The total amount of wall time                        = 178.845414
+The maximum resident set size (KB)                   = 774352
 
-Test 113 hrrr_control_dyn32_phy32_intel PASS
+Test 111 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_qr_dyn32_phy32_intel
-Checking test 114 hrrr_control_qr_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_qr_dyn32_phy32_intel
+Checking test 112 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3706,15 +3699,15 @@ Checking test 114 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.833495
-The maximum resident set size (KB)                   = 780688
+The total amount of wall time                        = 175.147318
+The maximum resident set size (KB)                   = 775372
 
-Test 114 hrrr_control_qr_dyn32_phy32_intel PASS
+Test 112 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_2threads_dyn32_phy32_intel
-Checking test 115 rap_2threads_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_2threads_dyn32_phy32_intel
+Checking test 113 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3760,15 +3753,15 @@ Checking test 115 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 306.439182
-The maximum resident set size (KB)                   = 826764
+The total amount of wall time                        = 307.198460
+The maximum resident set size (KB)                   = 830048
 
-Test 115 rap_2threads_dyn32_phy32_intel PASS
+Test 113 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 116 hrrr_control_2threads_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_2threads_dyn32_phy32_intel
+Checking test 114 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3814,15 +3807,15 @@ Checking test 116 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 159.876439
-The maximum resident set size (KB)                   = 813520
+The total amount of wall time                        = 159.903121
+The maximum resident set size (KB)                   = 815012
 
-Test 116 hrrr_control_2threads_dyn32_phy32_intel PASS
+Test 114 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 117 hrrr_control_decomp_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_decomp_dyn32_phy32_intel
+Checking test 115 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3868,15 +3861,15 @@ Checking test 117 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 185.450982
-The maximum resident set size (KB)                   = 772400
+The total amount of wall time                        = 185.668759
+The maximum resident set size (KB)                   = 773300
 
-Test 117 hrrr_control_decomp_dyn32_phy32_intel PASS
+Test 115 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_restart_dyn32_phy32_intel
-Checking test 118 rap_restart_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_restart_dyn32_phy32_intel
+Checking test 116 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -3914,43 +3907,43 @@ Checking test 118 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 246.744769
-The maximum resident set size (KB)                   = 607664
+The total amount of wall time                        = 247.707852
+The maximum resident set size (KB)                   = 611988
 
-Test 118 rap_restart_dyn32_phy32_intel PASS
+Test 116 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_restart_dyn32_phy32_intel
-Checking test 119 hrrr_control_restart_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_restart_dyn32_phy32_intel
+Checking test 117 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 92.637579
-The maximum resident set size (KB)                   = 600708
+The total amount of wall time                        = 92.635802
+The maximum resident set size (KB)                   = 602716
 
-Test 119 hrrr_control_restart_dyn32_phy32_intel PASS
+Test 117 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_restart_qr_dyn32_phy32_intel
-Checking test 120 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 118 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 92.649850
-The maximum resident set size (KB)                   = 618876
+The total amount of wall time                        = 93.168721
+The maximum resident set size (KB)                   = 622800
 
-Test 120 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+Test 118 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_control_dyn64_phy32_intel
-Checking test 121 rap_control_dyn64_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_control_dyn64_phy32_intel
+Checking test 119 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3996,82 +3989,82 @@ Checking test 121 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 227.526645
-The maximum resident set size (KB)                   = 792260
+The total amount of wall time                        = 228.618666
+The maximum resident set size (KB)                   = 793764
 
-Test 121 rap_control_dyn64_phy32_intel PASS
+Test 119 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_control_debug_dyn32_phy32_intel
-Checking test 122 rap_control_debug_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_control_debug_dyn32_phy32_intel
+Checking test 120 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 288.122954
-The maximum resident set size (KB)                   = 940316
+The total amount of wall time                        = 287.738779
+The maximum resident set size (KB)                   = 937796
 
-Test 122 rap_control_debug_dyn32_phy32_intel PASS
+Test 120 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hrrr_control_debug_dyn32_phy32_intel
-Checking test 123 hrrr_control_debug_dyn32_phy32_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hrrr_control_debug_dyn32_phy32_intel
+Checking test 121 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 281.800254
-The maximum resident set size (KB)                   = 936624
+The total amount of wall time                        = 282.037470
+The maximum resident set size (KB)                   = 929248
 
-Test 123 hrrr_control_debug_dyn32_phy32_intel PASS
+Test 121 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/rap_control_dyn64_phy32_debug_intel
-Checking test 124 rap_control_dyn64_phy32_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/rap_control_dyn64_phy32_debug_intel
+Checking test 122 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.551120
-The maximum resident set size (KB)                   = 952832
+The total amount of wall time                        = 293.700359
+The maximum resident set size (KB)                   = 958856
 
-Test 124 rap_control_dyn64_phy32_debug_intel PASS
+Test 122 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_atm_intel
-Checking test 125 hafs_regional_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_atm_intel
+Checking test 123 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 253.635147
-The maximum resident set size (KB)                   = 821224
+The total amount of wall time                        = 253.387176
+The maximum resident set size (KB)                   = 820308
 
-Test 125 hafs_regional_atm_intel PASS
+Test 123 hafs_regional_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_atm_thompson_gfdlsf_intel
-Checking test 126 hafs_regional_atm_thompson_gfdlsf_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_atm_thompson_gfdlsf_intel
+Checking test 124 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 304.905916
-The maximum resident set size (KB)                   = 1173488
+The total amount of wall time                        = 304.992218
+The maximum resident set size (KB)                   = 1175676
 
-Test 126 hafs_regional_atm_thompson_gfdlsf_intel PASS
+Test 124 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_atm_ocn_intel
-Checking test 127 hafs_regional_atm_ocn_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_atm_ocn_intel
+Checking test 125 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4079,15 +4072,15 @@ Checking test 127 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 383.373877
-The maximum resident set size (KB)                   = 855708
+The total amount of wall time                        = 382.089536
+The maximum resident set size (KB)                   = 858624
 
-Test 127 hafs_regional_atm_ocn_intel PASS
+Test 125 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_atm_wav_intel
-Checking test 128 hafs_regional_atm_wav_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_atm_wav_intel
+Checking test 126 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4095,15 +4088,15 @@ Checking test 128 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 701.245536
-The maximum resident set size (KB)                   = 886356
+The total amount of wall time                        = 703.732818
+The maximum resident set size (KB)                   = 887420
 
-Test 128 hafs_regional_atm_wav_intel PASS
+Test 126 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_atm_ocn_wav_intel
-Checking test 129 hafs_regional_atm_ocn_wav_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_atm_ocn_wav_intel
+Checking test 127 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4113,15 +4106,15 @@ Checking test 129 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 898.609862
-The maximum resident set size (KB)                   = 910380
+The total amount of wall time                        = 897.281402
+The maximum resident set size (KB)                   = 912716
 
-Test 129 hafs_regional_atm_ocn_wav_intel PASS
+Test 127 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_1nest_atm_intel
-Checking test 130 hafs_regional_1nest_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_1nest_atm_intel
+Checking test 128 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4142,15 +4135,15 @@ Checking test 130 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 305.929729
-The maximum resident set size (KB)                   = 392132
+The total amount of wall time                        = 306.655620
+The maximum resident set size (KB)                   = 393084
 
-Test 130 hafs_regional_1nest_atm_intel PASS
+Test 128 hafs_regional_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_1nest_atm_qr_intel
-Checking test 131 hafs_regional_1nest_atm_qr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_1nest_atm_qr_intel
+Checking test 129 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4171,15 +4164,15 @@ Checking test 131 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 328.179208
-The maximum resident set size (KB)                   = 369920
+The total amount of wall time                        = 327.702757
+The maximum resident set size (KB)                   = 371016
 
-Test 131 hafs_regional_1nest_atm_qr_intel PASS
+Test 129 hafs_regional_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_telescopic_2nests_atm_intel
-Checking test 132 hafs_regional_telescopic_2nests_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_telescopic_2nests_atm_intel
+Checking test 130 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4187,15 +4180,15 @@ Checking test 132 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 372.486175
-The maximum resident set size (KB)                   = 400176
+The total amount of wall time                        = 373.267885
+The maximum resident set size (KB)                   = 400580
 
-Test 132 hafs_regional_telescopic_2nests_atm_intel PASS
+Test 130 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_global_1nest_atm_intel
-Checking test 133 hafs_global_1nest_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_global_1nest_atm_intel
+Checking test 131 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4241,15 +4234,15 @@ Checking test 133 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 161.401489
-The maximum resident set size (KB)                   = 263288
+The total amount of wall time                        = 160.227509
+The maximum resident set size (KB)                   = 265560
 
-Test 133 hafs_global_1nest_atm_intel PASS
+Test 131 hafs_global_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_global_1nest_atm_qr_intel
-Checking test 134 hafs_global_1nest_atm_qr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_global_1nest_atm_qr_intel
+Checking test 132 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4295,15 +4288,15 @@ Checking test 134 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 166.110199
-The maximum resident set size (KB)                   = 271740
+The total amount of wall time                        = 165.904553
+The maximum resident set size (KB)                   = 269572
 
-Test 134 hafs_global_1nest_atm_qr_intel PASS
+Test 132 hafs_global_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_global_multiple_4nests_atm_intel
-Checking test 135 hafs_global_multiple_4nests_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_global_multiple_4nests_atm_intel
+Checking test 133 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4384,15 +4377,15 @@ Checking test 135 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 460.720941
-The maximum resident set size (KB)                   = 342424
+The total amount of wall time                        = 460.333762
+The maximum resident set size (KB)                   = 342532
 
-Test 135 hafs_global_multiple_4nests_atm_intel PASS
+Test 133 hafs_global_multiple_4nests_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_global_multiple_4nests_atm_qr_intel
-Checking test 136 hafs_global_multiple_4nests_atm_qr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_global_multiple_4nests_atm_qr_intel
+Checking test 134 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4473,15 +4466,15 @@ Checking test 136 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 505.802188
-The maximum resident set size (KB)                   = 370652
+The total amount of wall time                        = 507.917857
+The maximum resident set size (KB)                   = 375428
 
-Test 136 hafs_global_multiple_4nests_atm_qr_intel PASS
+Test 134 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_specified_moving_1nest_atm_intel
-Checking test 137 hafs_regional_specified_moving_1nest_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_specified_moving_1nest_atm_intel
+Checking test 135 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4489,15 +4482,15 @@ Checking test 137 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 204.755367
-The maximum resident set size (KB)                   = 404640
+The total amount of wall time                        = 206.271571
+The maximum resident set size (KB)                   = 406376
 
-Test 137 hafs_regional_specified_moving_1nest_atm_intel PASS
+Test 135 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_storm_following_1nest_atm_intel
-Checking test 138 hafs_regional_storm_following_1nest_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_storm_following_1nest_atm_intel
+Checking test 136 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4518,15 +4511,15 @@ Checking test 138 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 192.626655
-The maximum resident set size (KB)                   = 404392
+The total amount of wall time                        = 191.531598
+The maximum resident set size (KB)                   = 403996
 
-Test 138 hafs_regional_storm_following_1nest_atm_intel PASS
+Test 136 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_storm_following_1nest_atm_qr_intel
-Checking test 139 hafs_regional_storm_following_1nest_atm_qr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_storm_following_1nest_atm_qr_intel
+Checking test 137 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4547,15 +4540,15 @@ Checking test 139 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 217.354796
-The maximum resident set size (KB)                   = 392000
+The total amount of wall time                        = 216.260381
+The maximum resident set size (KB)                   = 394504
 
-Test 139 hafs_regional_storm_following_1nest_atm_qr_intel PASS
+Test 137 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_storm_following_1nest_atm_ocn_intel
-Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_storm_following_1nest_atm_ocn_intel
+Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4563,43 +4556,43 @@ Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 246.842110
-The maximum resident set size (KB)                   = 465192
+The total amount of wall time                        = 248.219158
+The maximum resident set size (KB)                   = 468656
 
-Test 140 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
+Test 138 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_global_storm_following_1nest_atm_intel
-Checking test 141 hafs_global_storm_following_1nest_atm_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_global_storm_following_1nest_atm_intel
+Checking test 139 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 81.250283
-The maximum resident set size (KB)                   = 285004
+The total amount of wall time                        = 81.070214
+The maximum resident set size (KB)                   = 280676
 
-Test 141 hafs_global_storm_following_1nest_atm_intel PASS
+Test 139 hafs_global_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 802.384664
-The maximum resident set size (KB)                   = 491664
+The total amount of wall time                        = 800.439462
+The maximum resident set size (KB)                   = 488884
 
-Test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
+Test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4609,162 +4602,162 @@ Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 502.779025
-The maximum resident set size (KB)                   = 519684
+The total amount of wall time                        = 505.710669
+The maximum resident set size (KB)                   = 520148
 
-Test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
+Test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_docn_intel
-Checking test 144 hafs_regional_docn_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_docn_intel
+Checking test 142 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 350.733956
-The maximum resident set size (KB)                   = 856492
+The total amount of wall time                        = 350.127595
+The maximum resident set size (KB)                   = 856864
 
-Test 144 hafs_regional_docn_intel PASS
+Test 142 hafs_regional_docn_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_oisst_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_docn_oisst_intel
-Checking test 145 hafs_regional_docn_oisst_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_oisst_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_docn_oisst_intel
+Checking test 143 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 351.246292
-The maximum resident set size (KB)                   = 845012
+The total amount of wall time                        = 350.877935
+The maximum resident set size (KB)                   = 844828
 
-Test 145 hafs_regional_docn_oisst_intel PASS
+Test 143 hafs_regional_docn_oisst_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_datm_cdeps_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/hafs_regional_datm_cdeps_intel
-Checking test 146 hafs_regional_datm_cdeps_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_datm_cdeps_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/hafs_regional_datm_cdeps_intel
+Checking test 144 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-The total amount of wall time                        = 948.460119
-The maximum resident set size (KB)                   = 866024
+The total amount of wall time                        = 943.300612
+The maximum resident set size (KB)                   = 869668
 
-Test 146 hafs_regional_datm_cdeps_intel PASS
+Test 144 hafs_regional_datm_cdeps_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_control_cfsr_intel
-Checking test 147 datm_cdeps_control_cfsr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_control_cfsr_intel
+Checking test 145 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 142.032157
-The maximum resident set size (KB)                   = 733544
+The total amount of wall time                        = 142.383711
+The maximum resident set size (KB)                   = 732508
 
-Test 147 datm_cdeps_control_cfsr_intel PASS
+Test 145 datm_cdeps_control_cfsr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_restart_cfsr_intel
-Checking test 148 datm_cdeps_restart_cfsr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_restart_cfsr_intel
+Checking test 146 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 85.918456
-The maximum resident set size (KB)                   = 728084
+The total amount of wall time                        = 86.911166
+The maximum resident set size (KB)                   = 708140
 
-Test 148 datm_cdeps_restart_cfsr_intel PASS
+Test 146 datm_cdeps_restart_cfsr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_control_gefs_intel
-Checking test 149 datm_cdeps_control_gefs_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_control_gefs_intel
+Checking test 147 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 134.359763
-The maximum resident set size (KB)                   = 614828
+The total amount of wall time                        = 135.566050
+The maximum resident set size (KB)                   = 616732
 
-Test 149 datm_cdeps_control_gefs_intel PASS
+Test 147 datm_cdeps_control_gefs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_iau_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_iau_gefs_intel
-Checking test 150 datm_cdeps_iau_gefs_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_iau_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_iau_gefs_intel
+Checking test 148 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 136.792561
-The maximum resident set size (KB)                   = 615792
+The total amount of wall time                        = 137.064856
+The maximum resident set size (KB)                   = 614704
 
-Test 150 datm_cdeps_iau_gefs_intel PASS
+Test 148 datm_cdeps_iau_gefs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_stochy_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_stochy_gefs_intel
-Checking test 151 datm_cdeps_stochy_gefs_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_stochy_gefs_intel
+Checking test 149 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 138.213704
-The maximum resident set size (KB)                   = 615964
+The total amount of wall time                        = 138.732060
+The maximum resident set size (KB)                   = 611964
 
-Test 151 datm_cdeps_stochy_gefs_intel PASS
+Test 149 datm_cdeps_stochy_gefs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_ciceC_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_ciceC_cfsr_intel
-Checking test 152 datm_cdeps_ciceC_cfsr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_ciceC_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_ciceC_cfsr_intel
+Checking test 150 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 141.907964
-The maximum resident set size (KB)                   = 735020
+The total amount of wall time                        = 142.841668
+The maximum resident set size (KB)                   = 732100
 
-Test 152 datm_cdeps_ciceC_cfsr_intel PASS
+Test 150 datm_cdeps_ciceC_cfsr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_bulk_cfsr_intel
-Checking test 153 datm_cdeps_bulk_cfsr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_bulk_cfsr_intel
+Checking test 151 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 142.311690
-The maximum resident set size (KB)                   = 733340
+The total amount of wall time                        = 143.166484
+The maximum resident set size (KB)                   = 733604
 
-Test 153 datm_cdeps_bulk_cfsr_intel PASS
+Test 151 datm_cdeps_bulk_cfsr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_bulk_gefs_intel
-Checking test 154 datm_cdeps_bulk_gefs_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_bulk_gefs_intel
+Checking test 152 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 135.155214
-The maximum resident set size (KB)                   = 614852
+The total amount of wall time                        = 136.004831
+The maximum resident set size (KB)                   = 618900
 
-Test 154 datm_cdeps_bulk_gefs_intel PASS
+Test 152 datm_cdeps_bulk_gefs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_mx025_cfsr_intel
-Checking test 155 datm_cdeps_mx025_cfsr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_mx025_cfsr_intel
+Checking test 153 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4772,15 +4765,15 @@ Checking test 155 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 427.195747
-The maximum resident set size (KB)                   = 568704
+The total amount of wall time                        = 433.182372
+The maximum resident set size (KB)                   = 570980
 
-Test 155 datm_cdeps_mx025_cfsr_intel PASS
+Test 153 datm_cdeps_mx025_cfsr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_mx025_gefs_intel
-Checking test 156 datm_cdeps_mx025_gefs_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_mx025_gefs_intel
+Checking test 154 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4788,65 +4781,65 @@ Checking test 156 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 429.644263
-The maximum resident set size (KB)                   = 549868
+The total amount of wall time                        = 427.456881
+The maximum resident set size (KB)                   = 551252
 
-Test 156 datm_cdeps_mx025_gefs_intel PASS
+Test 154 datm_cdeps_mx025_gefs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_multiple_files_cfsr_intel
-Checking test 157 datm_cdeps_multiple_files_cfsr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_multiple_files_cfsr_intel
+Checking test 155 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 141.631800
-The maximum resident set size (KB)                   = 730844
+The total amount of wall time                        = 143.065580
+The maximum resident set size (KB)                   = 732540
 
-Test 157 datm_cdeps_multiple_files_cfsr_intel PASS
+Test 155 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_3072x1536_cfsr_intel
-Checking test 158 datm_cdeps_3072x1536_cfsr_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_3072x1536_cfsr_intel
+Checking test 156 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 256.947097
-The maximum resident set size (KB)                   = 1984204
+The total amount of wall time                        = 249.402252
+The maximum resident set size (KB)                   = 1982108
 
-Test 158 datm_cdeps_3072x1536_cfsr_intel PASS
+Test 156 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_gfs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_gfs_intel
-Checking test 159 datm_cdeps_gfs_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_gfs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_gfs_intel
+Checking test 157 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 257.113969
-The maximum resident set size (KB)                   = 1983968
+The total amount of wall time                        = 249.754734
+The maximum resident set size (KB)                   = 1982944
 
-Test 159 datm_cdeps_gfs_intel PASS
+Test 157 datm_cdeps_gfs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_control_cfsr_faster_intel
-Checking test 160 datm_cdeps_control_cfsr_faster_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_control_cfsr_faster_intel
+Checking test 158 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 141.726175
-The maximum resident set size (KB)                   = 733940
+The total amount of wall time                        = 142.336984
+The maximum resident set size (KB)                   = 732456
 
-Test 160 datm_cdeps_control_cfsr_faster_intel PASS
+Test 158 datm_cdeps_control_cfsr_faster_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_lnd_gswp3_intel
-Checking test 161 datm_cdeps_lnd_gswp3_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_lnd_gswp3_intel
+Checking test 159 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4854,15 +4847,15 @@ Checking test 161 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 21.790331
-The maximum resident set size (KB)                   = 231264
+The total amount of wall time                        = 21.818852
+The maximum resident set size (KB)                   = 226488
 
-Test 161 datm_cdeps_lnd_gswp3_intel PASS
+Test 159 datm_cdeps_lnd_gswp3_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/datm_cdeps_lnd_gswp3_rst_intel
-Checking test 162 datm_cdeps_lnd_gswp3_rst_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/datm_cdeps_lnd_gswp3_rst_intel
+Checking test 160 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4870,15 +4863,15 @@ Checking test 162 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 27.360208
-The maximum resident set size (KB)                   = 228472
+The total amount of wall time                        = 27.320840
+The maximum resident set size (KB)                   = 236256
 
-Test 162 datm_cdeps_lnd_gswp3_rst_intel PASS
+Test 160 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_atmlnd_sbs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_p8_atmlnd_sbs_intel
-Checking test 163 control_p8_atmlnd_sbs_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_p8_atmlnd_sbs_intel
+Checking test 161 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -4962,15 +4955,15 @@ Checking test 163 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 234.996695
-The maximum resident set size (KB)                   = 1545440
+The total amount of wall time                        = 234.988840
+The maximum resident set size (KB)                   = 1541148
 
-Test 163 control_p8_atmlnd_sbs_intel PASS
+Test 161 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/atmwav_control_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/atmwav_control_noaero_p8_intel
-Checking test 164 atmwav_control_noaero_p8_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/atmwav_control_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/atmwav_control_noaero_p8_intel
+Checking test 162 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5012,15 +5005,15 @@ Checking test 164 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-The total amount of wall time                        = 109.795463
-The maximum resident set size (KB)                   = 1529668
+The total amount of wall time                        = 110.972142
+The maximum resident set size (KB)                   = 1524248
 
-Test 164 atmwav_control_noaero_p8_intel PASS
+Test 162 atmwav_control_noaero_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_atmwav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/control_atmwav_intel
-Checking test 165 control_atmwav_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_atmwav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/control_atmwav_intel
+Checking test 163 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5063,15 +5056,15 @@ Checking test 165 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 91.208768
-The maximum resident set size (KB)                   = 540392
+The total amount of wall time                        = 90.324628
+The maximum resident set size (KB)                   = 540912
 
-Test 165 control_atmwav_intel PASS
+Test 163 control_atmwav_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/atmaero_control_p8_intel
-Checking test 166 atmaero_control_p8_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/atmaero_control_p8_intel
+Checking test 164 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5114,15 +5107,15 @@ Checking test 166 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.109834
-The maximum resident set size (KB)                   = 2811872
+The total amount of wall time                        = 241.403843
+The maximum resident set size (KB)                   = 2811908
 
-Test 166 atmaero_control_p8_intel PASS
+Test 164 atmaero_control_p8_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/atmaero_control_p8_rad_intel
-Checking test 167 atmaero_control_p8_rad_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/atmaero_control_p8_rad_intel
+Checking test 165 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5165,15 +5158,15 @@ Checking test 167 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 280.477240
-The maximum resident set size (KB)                   = 2875904
+The total amount of wall time                        = 280.841351
+The maximum resident set size (KB)                   = 2873280
 
-Test 167 atmaero_control_p8_rad_intel PASS
+Test 165 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_micro_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/atmaero_control_p8_rad_micro_intel
-Checking test 168 atmaero_control_p8_rad_micro_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/atmaero_control_p8_rad_micro_intel
+Checking test 166 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5216,15 +5209,15 @@ Checking test 168 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 287.022203
-The maximum resident set size (KB)                   = 2881988
+The total amount of wall time                        = 285.960043
+The maximum resident set size (KB)                   = 2885628
 
-Test 168 atmaero_control_p8_rad_micro_intel PASS
+Test 166 atmaero_control_p8_rad_micro_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_atmaq_intel
-Checking test 169 regional_atmaq_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_atmaq_intel
+Checking test 167 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5239,15 +5232,15 @@ Checking test 169 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 681.332076
-The maximum resident set size (KB)                   = 1259968
+The total amount of wall time                        = 677.303144
+The maximum resident set size (KB)                   = 1253840
 
-Test 169 regional_atmaq_intel PASS
+Test 167 regional_atmaq_intel PASS
 
 
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_146426/regional_atmaq_debug_intel
-Checking test 170 regional_atmaq_debug_intel results ....
+baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_252553/regional_atmaq_debug_intel
+Checking test 168 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5260,259 +5253,12 @@ Checking test 170 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1309.146210
-The maximum resident set size (KB)                   = 1285584
+The total amount of wall time                        = 1314.615828
+The maximum resident set size (KB)                   = 1287996
 
-Test 170 regional_atmaq_debug_intel PASS
-
-FAILED TESTS: 
-061 hrrr_control_intel failed in check_result
-hrrr_control_intel 061 failed in run_test
-062 hrrr_control_qr_intel failed in check_result
-hrrr_control_qr_intel 062 failed in run_test
-063 hrrr_control_decomp_intel failed in check_result
-hrrr_control_decomp_intel 063 failed in run_test
-064 hrrr_control_2threads_intel failed in check_result
-hrrr_control_2threads_intel 064 failed in run_test
-
-REGRESSION TEST FAILED
-Tue Jun 20 17:22:41 UTC 2023
-Elapsed time: 01h:52m:11s. Have a nice day!
-Tue Jun 20 19:14:13 UTC 2023
-Start Regression test
-
-Testing UFSWM Hash: f845b3e43b08cfdd9c1a9b271ef3ab425d47fe6c
-Testing With Submodule Hashes:
- 37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
- 2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
- 5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
- cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
- cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
- b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
- 24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
- fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
- e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
- c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
- 3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 013 elapsed time 486 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_105915/hrrr_control_intel
-Checking test 001 hrrr_control_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-The total amount of wall time                        = 390.578767
-The maximum resident set size (KB)                   = 889752
-
-Test 001 hrrr_control_intel PASS
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_105915/hrrr_control_qr_intel
-Checking test 002 hrrr_control_qr_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
-
-The total amount of wall time                        = 384.924121
-The maximum resident set size (KB)                   = 899676
-
-Test 002 hrrr_control_qr_intel PASS
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_105915/hrrr_control_decomp_intel
-Checking test 003 hrrr_control_decomp_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-The total amount of wall time                        = 404.087108
-The maximum resident set size (KB)                   = 894696
-
-Test 003 hrrr_control_decomp_intel PASS
-
-
-baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_105915/hrrr_control_2threads_intel
-Checking test 004 hrrr_control_2threads_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-The total amount of wall time                        = 350.246460
-The maximum resident set size (KB)                   = 958812
-
-Test 004 hrrr_control_2threads_intel PASS
+Test 168 regional_atmaq_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jun 20 19:32:05 UTC 2023
-Elapsed time: 00h:17m:53s. Have a nice day!
+Thu Jun 22 15:23:22 UTC 2023
+Elapsed time: 02h:11m:18s. Have a nice day!

--- a/tests/logs/RegressionTests_cheyenne.log
+++ b/tests/logs/RegressionTests_cheyenne.log
@@ -1,71 +1,71 @@
-Fri Jun 16 21:01:42 MDT 2023
+Thu Jun 22 21:10:12 MDT 2023
 Start Regression test
 
-Testing UFSWM Hash: 14ad1f50700400e4152cab9dfcbf54152e4865fc
+Testing UFSWM Hash: 2d5a7ba68ca795af5ce01c7619099940d309bfde
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
+ f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 1466 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1499 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1415 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 486 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 429 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1131 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1132 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 1434 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 422 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 011 elapsed time 1142 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1037 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 963 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 850 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 1236 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 448 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 289 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 901 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 902 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 305 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 312 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 1176 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 366 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 1548 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 1168 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 447 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 1560 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1575 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1448 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 461 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 425 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1180 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1140 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 1496 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 429 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 011 elapsed time 1150 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 1069 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 1024 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 895 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 1235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 446 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 320 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 905 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 893 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 311 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 298 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 1177 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 367 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 1549 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 1169 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 444 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 028 elapsed time 203 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 443 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 119 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 1010 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 1039 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 1069 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 938 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 918 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 037 elapsed time 993 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 038 elapsed time 406 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 039 elapsed time 413 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 040 elapsed time 886 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 041 elapsed time 182 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 042 elapsed time 398 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 043 elapsed time 1150 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 044 elapsed time 894 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 045 elapsed time 897 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 046 elapsed time 632 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 047 elapsed time 576 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 048 elapsed time 345 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 049 elapsed time 566 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 050 elapsed time 296 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 051 elapsed time 299 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 029 elapsed time 482 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 113 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 1016 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 1020 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 1059 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 992 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 900 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 037 elapsed time 1034 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 038 elapsed time 444 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 039 elapsed time 415 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 040 elapsed time 895 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 041 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 042 elapsed time 402 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 043 elapsed time 1178 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 044 elapsed time 887 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 045 elapsed time 891 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 046 elapsed time 717 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 047 elapsed time 611 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 048 elapsed time 347 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 049 elapsed time 573 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 050 elapsed time 285 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 051 elapsed time 296 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_mixedmode_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_p8_mixedmode_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -130,14 +130,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 309.282137
-0:The maximum resident set size (KB)                   = 2698548
+0:The total amount of wall time                        = 321.719844
+0:The maximum resident set size (KB)                   = 2698328
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_gfsv17_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_gfsv17_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -201,14 +201,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 282.726238
-0:The maximum resident set size (KB)                   = 1427304
+0:The total amount of wall time                        = 277.159578
+0:The maximum resident set size (KB)                   = 1427228
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -273,14 +273,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 322.821849
-0:The maximum resident set size (KB)                   = 2715696
+0:The total amount of wall time                        = 321.354100
+0:The maximum resident set size (KB)                   = 2715584
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_restart_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -333,14 +333,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 186.423662
-0:The maximum resident set size (KB)                   = 2575296
+0:The total amount of wall time                        = 186.985101
+0:The maximum resident set size (KB)                   = 2575424
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_qr_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -405,14 +405,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 315.077804
-0:The maximum resident set size (KB)                   = 2719564
+0:The total amount of wall time                        = 327.148517
+0:The maximum resident set size (KB)                   = 2719100
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_restart_qr_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -465,14 +465,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 201.768698
-0:The maximum resident set size (KB)                   = 2591904
+0:The total amount of wall time                        = 199.974486
+0:The maximum resident set size (KB)                   = 2592140
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_2threads_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -525,14 +525,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 247.589936
-0:The maximum resident set size (KB)                   = 3177360
+0:The total amount of wall time                        = 253.245080
+0:The maximum resident set size (KB)                   = 3176764
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_decomp_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -585,14 +585,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 322.815323
-0:The maximum resident set size (KB)                   = 2720300
+0:The total amount of wall time                        = 324.876615
+0:The maximum resident set size (KB)                   = 2720080
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_mpi_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -645,14 +645,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 280.794534
-0:The maximum resident set size (KB)                   = 2680192
+0:The total amount of wall time                        = 278.833758
+0:The maximum resident set size (KB)                   = 2679704
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_ciceC_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_ciceC_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_ciceC_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -717,14 +717,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 314.755312
-0:The maximum resident set size (KB)                   = 2715640
+0:The total amount of wall time                        = 322.132925
+0:The maximum resident set size (KB)                   = 2715660
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_c192_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_c192_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_c192_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_c192_p8_intel
 Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -777,14 +777,14 @@ Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 778.796098
-0:The maximum resident set size (KB)                   = 3351060
+0:The total amount of wall time                        = 621.029774
+0:The maximum resident set size (KB)                   = 3351364
 
 Test 011 cpld_control_c192_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_c192_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_restart_c192_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_c192_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_restart_c192_p8_intel
 Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -837,14 +837,14 @@ Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 381.918807
-0:The maximum resident set size (KB)                   = 3271916
+0:The total amount of wall time                        = 382.699961
+0:The maximum resident set size (KB)                   = 3272948
 
 Test 012 cpld_restart_c192_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_noaero_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_noaero_p8_intel
 Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -908,14 +908,14 @@ Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 298.632191
-0:The maximum resident set size (KB)                   = 1435800
+0:The total amount of wall time                        = 286.136821
+0:The maximum resident set size (KB)                   = 1435852
 
 Test 013 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_nowave_noaero_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_nowave_noaero_p8_intel
 Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -977,14 +977,14 @@ Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 196.458000
-0:The maximum resident set size (KB)                   = 1451872
+0:The total amount of wall time                        = 196.241332
+0:The maximum resident set size (KB)                   = 1451876
 
 Test 014 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_debug_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_debug_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_debug_p8_intel
 Checking test 015 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1037,14 +1037,14 @@ Checking test 015 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 350.310209
-0:The maximum resident set size (KB)                   = 2779056
+0:The total amount of wall time                        = 352.942904
+0:The maximum resident set size (KB)                   = 2779224
 
 Test 015 cpld_debug_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_debug_noaero_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_debug_noaero_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_debug_noaero_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_debug_noaero_p8_intel
 Checking test 016 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1096,14 +1096,14 @@ Checking test 016 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 303.069343
-0:The maximum resident set size (KB)                   = 1454332
+0:The total amount of wall time                        = 362.432821
+0:The maximum resident set size (KB)                   = 1454340
 
 Test 016 cpld_debug_noaero_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_agrid_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_noaero_p8_agrid_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_noaero_p8_agrid_intel
 Checking test 017 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1165,14 +1165,14 @@ Checking test 017 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 266.460725
-0:The maximum resident set size (KB)                   = 1455580
+0:The total amount of wall time                        = 261.759512
+0:The maximum resident set size (KB)                   = 1455524
 
 Test 017 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_c48_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_c48_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_c48_intel
 Checking test 018 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1222,14 +1222,14 @@ Checking test 018 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 606.524099
-0:The maximum resident set size (KB)                   = 2583952
+0:The total amount of wall time                        = 601.941638
+0:The maximum resident set size (KB)                   = 2584664
 
 Test 018 cpld_control_c48_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_warmstart_c48_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_warmstart_c48_intel
 Checking test 019 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1279,14 +1279,14 @@ Checking test 019 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 162.774283
-0:The maximum resident set size (KB)                   = 2590344
+0:The total amount of wall time                        = 161.046068
+0:The maximum resident set size (KB)                   = 2589776
 
 Test 019 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_restart_c48_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_restart_c48_intel
 Checking test 020 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1336,14 +1336,14 @@ Checking test 020 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 84.465433
-0:The maximum resident set size (KB)                   = 2014020
+0:The total amount of wall time                        = 84.223801
+0:The maximum resident set size (KB)                   = 2013908
 
 Test 020 cpld_restart_c48_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_pdlib_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_pdlib_p8_intel
 Checking test 021 cpld_control_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1407,14 +1407,14 @@ Checking test 021 cpld_control_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1188.552861
-0:The maximum resident set size (KB)                   = 1497948
+0:The total amount of wall time                        = 1166.660915
+0:The maximum resident set size (KB)                   = 1497652
 
 Test 021 cpld_control_pdlib_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_restart_pdlib_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_restart_pdlib_p8_intel
 Checking test 022 cpld_restart_pdlib_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1466,14 +1466,14 @@ Checking test 022 cpld_restart_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 558.597899
-0:The maximum resident set size (KB)                   = 676496
+0:The total amount of wall time                        = 560.838060
+0:The maximum resident set size (KB)                   = 676788
 
 Test 022 cpld_restart_pdlib_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_mpi_pdlib_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_mpi_pdlib_p8_intel
 Checking test 023 cpld_mpi_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1537,14 +1537,14 @@ Checking test 023 cpld_mpi_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1074.955062
-0:The maximum resident set size (KB)                   = 1471948
+0:The total amount of wall time                        = 1075.853182
+0:The maximum resident set size (KB)                   = 1472248
 
 Test 023 cpld_mpi_pdlib_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_debug_pdlib_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_debug_pdlib_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_debug_pdlib_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_debug_pdlib_p8_intel
 Checking test 024 cpld_debug_pdlib_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1596,14 +1596,14 @@ Checking test 024 cpld_debug_pdlib_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1488.176813
-0:The maximum resident set size (KB)                   = 1514948
+0:The total amount of wall time                        = 1495.828323
+0:The maximum resident set size (KB)                   = 1514864
 
 Test 024 cpld_debug_pdlib_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_flake_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_flake_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_flake_intel
 Checking test 025 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1614,14 +1614,14 @@ Checking test 025 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 218.048089
-0:The maximum resident set size (KB)                   = 503204
+0:The total amount of wall time                        = 219.421269
+0:The maximum resident set size (KB)                   = 503156
 
 Test 025 control_flake_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_CubedSphereGrid_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_CubedSphereGrid_intel
 Checking test 026 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1648,28 +1648,28 @@ Checking test 026 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 142.043209
-0:The maximum resident set size (KB)                   = 454008
+0:The total amount of wall time                        = 144.039778
+0:The maximum resident set size (KB)                   = 454020
 
 Test 026 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_parallel_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_CubedSphereGrid_parallel_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_parallel_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_CubedSphereGrid_parallel_intel
 Checking test 027 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 140.963500
-0:The maximum resident set size (KB)                   = 454196
+0:The total amount of wall time                        = 140.017575
+0:The maximum resident set size (KB)                   = 454044
 
 Test 027 control_CubedSphereGrid_parallel_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_latlon_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_latlon_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_latlon_intel
 Checking test 028 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1680,32 +1680,32 @@ Checking test 028 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 146.990674
-0:The maximum resident set size (KB)                   = 455028
+0:The total amount of wall time                        = 146.329478
+0:The maximum resident set size (KB)                   = 454952
 
 Test 028 control_latlon_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_wrtGauss_netcdf_parallel_intel
 Checking test 029 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.906883
-0:The maximum resident set size (KB)                   = 454948
+0:The total amount of wall time                        = 150.155596
+0:The maximum resident set size (KB)                   = 454992
 
 Test 029 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_c48_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_c48_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_c48_intel
 Checking test 030 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1744,14 +1744,14 @@ Checking test 030 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 443.916336
-0:The maximum resident set size (KB)                   = 632448
+0:The total amount of wall time                        = 443.679196
+0:The maximum resident set size (KB)                   = 632428
 
 Test 030 control_c48_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_c192_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_c192_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_c192_intel
 Checking test 031 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1762,14 +1762,14 @@ Checking test 031 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 592.402806
-0:The maximum resident set size (KB)                   = 560680
+0:The total amount of wall time                        = 595.468471
+0:The maximum resident set size (KB)                   = 560640
 
 Test 031 control_c192_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_c384_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_c384_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_c384_intel
 Checking test 032 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1780,14 +1780,14 @@ Checking test 032 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 568.038818
-0:The maximum resident set size (KB)                   = 897956
+0:The total amount of wall time                        = 586.172119
+0:The maximum resident set size (KB)                   = 898844
 
 Test 032 control_c384_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_c384gdas_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_c384gdas_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_c384gdas_intel
 Checking test 033 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1830,14 +1830,14 @@ Checking test 033 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 512.857924
-0:The maximum resident set size (KB)                   = 1027364
+0:The total amount of wall time                        = 514.396338
+0:The maximum resident set size (KB)                   = 1027340
 
 Test 033 control_c384gdas_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_stochy_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_stochy_intel
 Checking test 034 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1848,28 +1848,28 @@ Checking test 034 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 97.279812
-0:The maximum resident set size (KB)                   = 456656
+0:The total amount of wall time                        = 98.259586
+0:The maximum resident set size (KB)                   = 456636
 
 Test 034 control_stochy_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_stochy_restart_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_stochy_restart_intel
 Checking test 035 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 54.675887
-0:The maximum resident set size (KB)                   = 226244
+0:The total amount of wall time                        = 53.053658
+0:The maximum resident set size (KB)                   = 226280
 
 Test 035 control_stochy_restart_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_lndp_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_lndp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_lndp_intel
 Checking test 036 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1880,14 +1880,14 @@ Checking test 036 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 90.490768
-0:The maximum resident set size (KB)                   = 458304
+0:The total amount of wall time                        = 90.814604
+0:The maximum resident set size (KB)                   = 458368
 
 Test 036 control_lndp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_iovr4_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_iovr4_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_iovr4_intel
 Checking test 037 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1902,14 +1902,14 @@ Checking test 037 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 146.992266
-0:The maximum resident set size (KB)                   = 454936
+0:The total amount of wall time                        = 148.114947
+0:The maximum resident set size (KB)                   = 454892
 
 Test 037 control_iovr4_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_iovr5_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_iovr5_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_iovr5_intel
 Checking test 038 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 038 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.728466
-0:The maximum resident set size (KB)                   = 454904
+0:The total amount of wall time                        = 148.041542
+0:The maximum resident set size (KB)                   = 454872
 
 Test 038 control_iovr5_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_p8_intel
 Checking test 039 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1978,14 +1978,14 @@ Checking test 039 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 175.326260
-0:The maximum resident set size (KB)                   = 1425524
+0:The total amount of wall time                        = 178.567779
+0:The maximum resident set size (KB)                   = 1425572
 
 Test 039 control_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_restart_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_restart_p8_intel
 Checking test 040 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 040 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 95.703498
-0:The maximum resident set size (KB)                   = 582940
+0:The total amount of wall time                        = 96.125453
+0:The maximum resident set size (KB)                   = 582988
 
 Test 040 control_restart_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_qr_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_qr_p8_intel
 Checking test 041 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2078,14 +2078,14 @@ Checking test 041 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 182.996456
-0:The maximum resident set size (KB)                   = 1429224
+0:The total amount of wall time                        = 183.602827
+0:The maximum resident set size (KB)                   = 1429212
 
 Test 041 control_qr_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_restart_qr_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_restart_qr_p8_intel
 Checking test 042 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 042 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 98.246687
-0:The maximum resident set size (KB)                   = 596360
+0:The total amount of wall time                        = 97.817543
+0:The maximum resident set size (KB)                   = 596376
 
 Test 042 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_decomp_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_decomp_p8_intel
 Checking test 043 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2174,14 +2174,14 @@ Checking test 043 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 187.270271
-0:The maximum resident set size (KB)                   = 1419496
+0:The total amount of wall time                        = 187.371324
+0:The maximum resident set size (KB)                   = 1419476
 
 Test 043 control_decomp_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_2threads_p8_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_2threads_p8_intel
 Checking test 044 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2224,14 +2224,14 @@ Checking test 044 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 170.730755
-0:The maximum resident set size (KB)                   = 1509428
+0:The total amount of wall time                        = 168.829114
+0:The maximum resident set size (KB)                   = 1510564
 
 Test 044 control_2threads_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_lndp_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_p8_lndp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_p8_lndp_intel
 Checking test 045 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2250,14 +2250,14 @@ Checking test 045 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 326.141696
-0:The maximum resident set size (KB)                   = 1426120
+0:The total amount of wall time                        = 333.243433
+0:The maximum resident set size (KB)                   = 1426084
 
 Test 045 control_p8_lndp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_rrtmgp_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_p8_rrtmgp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_p8_rrtmgp_intel
 Checking test 046 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2304,14 +2304,14 @@ Checking test 046 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 248.298187
-0:The maximum resident set size (KB)                   = 1479176
+0:The total amount of wall time                        = 246.414446
+0:The maximum resident set size (KB)                   = 1479204
 
 Test 046 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_mynn_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_p8_mynn_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_p8_mynn_intel
 Checking test 047 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2358,14 +2358,14 @@ Checking test 047 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 187.690753
-0:The maximum resident set size (KB)                   = 1429924
+0:The total amount of wall time                        = 185.668974
+0:The maximum resident set size (KB)                   = 1429896
 
 Test 047 control_p8_mynn_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/merra2_thompson_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/merra2_thompson_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/merra2_thompson_intel
 Checking test 048 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2412,14 +2412,14 @@ Checking test 048 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 208.917939
-0:The maximum resident set size (KB)                   = 1429464
+0:The total amount of wall time                        = 202.269652
+0:The maximum resident set size (KB)                   = 1429508
 
 Test 048 merra2_thompson_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_control_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_control_intel
 Checking test 049 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2430,28 +2430,28 @@ Checking test 049 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 340.304902
-0:The maximum resident set size (KB)                   = 604316
+0:The total amount of wall time                        = 335.061594
+0:The maximum resident set size (KB)                   = 604280
 
 Test 049 regional_control_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_restart_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_restart_intel
 Checking test 050 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 171.671964
-0:The maximum resident set size (KB)                   = 596632
+0:The total amount of wall time                        = 171.334954
+0:The maximum resident set size (KB)                   = 596668
 
 Test 050 regional_restart_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_control_qr_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_control_qr_intel
 Checking test 051 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2462,28 +2462,28 @@ Checking test 051 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 336.308743
-0:The maximum resident set size (KB)                   = 604332
+0:The total amount of wall time                        = 334.421345
+0:The maximum resident set size (KB)                   = 604352
 
 Test 051 regional_control_qr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_restart_qr_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_restart_qr_intel
 Checking test 052 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 173.233397
-0:The maximum resident set size (KB)                   = 596608
+0:The total amount of wall time                        = 171.117629
+0:The maximum resident set size (KB)                   = 596616
 
 Test 052 regional_restart_qr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_decomp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_decomp_intel
 Checking test 053 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2494,14 +2494,14 @@ Checking test 053 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 359.074370
-0:The maximum resident set size (KB)                   = 597688
+0:The total amount of wall time                        = 353.473324
+0:The maximum resident set size (KB)                   = 597712
 
 Test 053 regional_decomp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_2threads_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_2threads_intel
 Checking test 054 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2512,14 +2512,14 @@ Checking test 054 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 201.151492
-0:The maximum resident set size (KB)                   = 610684
+0:The total amount of wall time                        = 195.573916
+0:The maximum resident set size (KB)                   = 610656
 
 Test 054 regional_2threads_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_noquilt_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_noquilt_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_noquilt_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_noquilt_intel
 Checking test 055 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2527,28 +2527,28 @@ Checking test 055 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 335.624510
-0:The maximum resident set size (KB)                   = 599148
+0:The total amount of wall time                        = 331.510267
+0:The maximum resident set size (KB)                   = 599136
 
 Test 055 regional_noquilt_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_netcdf_parallel_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_netcdf_parallel_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_netcdf_parallel_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_netcdf_parallel_intel
 Checking test 056 regional_netcdf_parallel_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf006.nc ............ALT CHECK......OK
  Comparing phyf000.nc ............ALT CHECK......OK
  Comparing phyf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 331.870720
-0:The maximum resident set size (KB)                   = 596456
+0:The total amount of wall time                        = 331.343950
+0:The maximum resident set size (KB)                   = 596504
 
 Test 056 regional_netcdf_parallel_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_2dwrtdecomp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_2dwrtdecomp_intel
 Checking test 057 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2559,14 +2559,14 @@ Checking test 057 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 325.407052
-0:The maximum resident set size (KB)                   = 604260
+0:The total amount of wall time                        = 341.321439
+0:The maximum resident set size (KB)                   = 604292
 
 Test 057 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/fv3_regional_wofs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_wofs_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/fv3_regional_wofs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_wofs_intel
 Checking test 058 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2577,14 +2577,14 @@ Checking test 058 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 424.173195
-0:The maximum resident set size (KB)                   = 276184
+0:The total amount of wall time                        = 420.861917
+0:The maximum resident set size (KB)                   = 276180
 
 Test 058 regional_wofs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_intel
 Checking test 059 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2631,14 +2631,14 @@ Checking test 059 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 468.025937
-0:The maximum resident set size (KB)                   = 822120
+0:The total amount of wall time                        = 467.761436
+0:The maximum resident set size (KB)                   = 822052
 
 Test 059 rap_control_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_spp_sppt_shum_skeb_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_spp_sppt_shum_skeb_intel
 Checking test 060 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2649,14 +2649,14 @@ Checking test 060 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 250.152750
-0:The maximum resident set size (KB)                   = 954632
+0:The total amount of wall time                        = 256.420722
+0:The maximum resident set size (KB)                   = 954640
 
 Test 060 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_decomp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_decomp_intel
 Checking test 061 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2703,14 +2703,14 @@ Checking test 061 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 486.607570
-0:The maximum resident set size (KB)                   = 821908
+0:The total amount of wall time                        = 485.655078
+0:The maximum resident set size (KB)                   = 821948
 
 Test 061 rap_decomp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_2threads_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_2threads_intel
 Checking test 062 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2757,14 +2757,14 @@ Checking test 062 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 436.653834
-0:The maximum resident set size (KB)                   = 901432
+0:The total amount of wall time                        = 442.799934
+0:The maximum resident set size (KB)                   = 897660
 
 Test 062 rap_2threads_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_restart_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_restart_intel
 Checking test 063 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2803,14 +2803,14 @@ Checking test 063 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 233.266194
-0:The maximum resident set size (KB)                   = 564956
+0:The total amount of wall time                        = 235.736741
+0:The maximum resident set size (KB)                   = 564976
 
 Test 063 rap_restart_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_sfcdiff_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_sfcdiff_intel
 Checking test 064 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2857,14 +2857,14 @@ Checking test 064 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 464.776446
-0:The maximum resident set size (KB)                   = 822184
+0:The total amount of wall time                        = 465.365192
+0:The maximum resident set size (KB)                   = 822040
 
 Test 064 rap_sfcdiff_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_sfcdiff_decomp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_sfcdiff_decomp_intel
 Checking test 065 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2911,14 +2911,14 @@ Checking test 065 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 491.802357
-0:The maximum resident set size (KB)                   = 821596
+0:The total amount of wall time                        = 498.251428
+0:The maximum resident set size (KB)                   = 821796
 
 Test 065 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_sfcdiff_restart_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_sfcdiff_restart_intel
 Checking test 066 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2957,14 +2957,14 @@ Checking test 066 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 349.844131
-0:The maximum resident set size (KB)                   = 569704
+0:The total amount of wall time                        = 344.285806
+0:The maximum resident set size (KB)                   = 569720
 
 Test 066 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_intel
 Checking test 067 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3011,14 +3011,14 @@ Checking test 067 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 448.314613
-0:The maximum resident set size (KB)                   = 819888
+0:The total amount of wall time                        = 443.688388
+0:The maximum resident set size (KB)                   = 819880
 
 Test 067 hrrr_control_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_qr_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_qr_intel
 Checking test 068 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3065,14 +3065,14 @@ Checking test 068 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 447.503331
-0:The maximum resident set size (KB)                   = 829928
+0:The total amount of wall time                        = 446.100621
+0:The maximum resident set size (KB)                   = 829924
 
 Test 068 hrrr_control_qr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_decomp_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_decomp_intel
 Checking test 069 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3119,14 +3119,14 @@ Checking test 069 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 469.983511
-0:The maximum resident set size (KB)                   = 819128
+0:The total amount of wall time                        = 466.113172
+0:The maximum resident set size (KB)                   = 819060
 
 Test 069 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_2threads_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_2threads_intel
 Checking test 070 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3173,42 +3173,42 @@ Checking test 070 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 505.756690
-0:The maximum resident set size (KB)                   = 893192
+0:The total amount of wall time                        = 508.442023
+0:The maximum resident set size (KB)                   = 893036
 
 Test 070 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_intel
 Checking test 071 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 331.739477
-0:The maximum resident set size (KB)                   = 565344
+0:The total amount of wall time                        = 332.111137
+0:The maximum resident set size (KB)                   = 565408
 
 Test 071 hrrr_control_restart_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_qr_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_qr_intel
 Checking test 072 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 337.355752
-0:The maximum resident set size (KB)                   = 597404
+0:The total amount of wall time                        = 334.198512
+0:The maximum resident set size (KB)                   = 597408
 
 Test 072 hrrr_control_restart_qr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_v1beta_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_v1beta_intel
 Checking test 073 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3255,14 +3255,14 @@ Checking test 073 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 458.309441
-0:The maximum resident set size (KB)                   = 820152
+0:The total amount of wall time                        = 449.003657
+0:The maximum resident set size (KB)                   = 820360
 
 Test 073 rrfs_v1beta_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_v1nssl_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_v1nssl_intel
 Checking test 074 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3277,14 +3277,14 @@ Checking test 074 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 568.349418
-0:The maximum resident set size (KB)                   = 508924
+0:The total amount of wall time                        = 568.682608
+0:The maximum resident set size (KB)                   = 508880
 
 Test 074 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_v1nssl_nohailnoccn_intel
 Checking test 075 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3299,14 +3299,14 @@ Checking test 075 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 551.468344
-0:The maximum resident set size (KB)                   = 502228
+0:The total amount of wall time                        = 549.420117
+0:The maximum resident set size (KB)                   = 502336
 
 Test 075 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 076 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3322,15 +3322,31 @@ Checking test 076 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 155.938186
-0:The maximum resident set size (KB)                   = 666968
+0:The total amount of wall time                        = 154.518786
+0:The maximum resident set size (KB)                   = 667020
 
 Test 076 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_qr_intel
-Checking test 077 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+Checking test 077 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+0:The total amount of wall time                        = 95.650473
+0:The maximum resident set size (KB)                   = 690632
+
+Test 077 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_conus13km_hrrr_warm_intel
+Checking test 078 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3345,15 +3361,15 @@ Checking test 077 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 155.692964
-0:The maximum resident set size (KB)                   = 666984
+0:The total amount of wall time                        = 138.936327
+0:The maximum resident set size (KB)                   = 656108
 
-Test 077 rrfs_smoke_conus13km_hrrr_warm_qr_intel PASS
+Test 078 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
-Checking test 078 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_radar_tten_warm_intel
+Checking test 079 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3361,78 +3377,27 @@ Checking test 078 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 93.060826
-0:The maximum resident set size (KB)                   = 690568
+0:The total amount of wall time                        = 156.490081
+0:The maximum resident set size (KB)                   = 669008
 
-Test 078 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_conus13km_hrrr_warm_intel
-Checking test 079 rrfs_conus13km_hrrr_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-0:The total amount of wall time                        = 139.619641
-0:The maximum resident set size (KB)                   = 656152
-
-Test 079 rrfs_conus13km_hrrr_warm_intel PASS
+Test 079 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_radar_tten_warm_intel
-Checking test 080 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-0:The total amount of wall time                        = 155.658678
-0:The maximum resident set size (KB)                   = 668952
-
-Test 080 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-Checking test 081 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+Checking test 080 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 87.003319
-0:The maximum resident set size (KB)                   = 661260
+0:The total amount of wall time                        = 87.456012
+0:The maximum resident set size (KB)                   = 661268
 
-Test 081 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel
-Checking test 082 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-0:The total amount of wall time                        = 86.519506
-0:The maximum resident set size (KB)                   = 661176
-
-Test 082 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel PASS
+Test 080 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_csawmg_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_csawmg_intel
-Checking test 083 control_csawmg_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_csawmg_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_csawmg_intel
+Checking test 081 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3442,15 +3407,15 @@ Checking test 083 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 390.160272
-0:The maximum resident set size (KB)                   = 528508
+0:The total amount of wall time                        = 390.265950
+0:The maximum resident set size (KB)                   = 528536
 
-Test 083 control_csawmg_intel PASS
+Test 081 control_csawmg_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_csawmgt_intel
-Checking test 084 control_csawmgt_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_csawmgt_intel
+Checking test 082 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3460,15 +3425,15 @@ Checking test 084 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 384.467987
-0:The maximum resident set size (KB)                   = 528712
+0:The total amount of wall time                        = 385.194239
+0:The maximum resident set size (KB)                   = 528728
 
-Test 084 control_csawmgt_intel PASS
+Test 082 control_csawmgt_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_ras_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_ras_intel
-Checking test 085 control_ras_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_ras_intel
+Checking test 083 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3478,27 +3443,27 @@ Checking test 085 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 207.236465
-0:The maximum resident set size (KB)                   = 489796
+0:The total amount of wall time                        = 205.924545
+0:The maximum resident set size (KB)                   = 489656
 
-Test 085 control_ras_intel PASS
+Test 083 control_ras_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_wam_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_wam_intel
-Checking test 086 control_wam_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_wam_intel
+Checking test 084 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 128.713179
-0:The maximum resident set size (KB)                   = 206460
+0:The total amount of wall time                        = 129.034697
+0:The maximum resident set size (KB)                   = 206448
 
-Test 086 control_wam_intel PASS
+Test 084 control_wam_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_faster_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_p8_faster_intel
-Checking test 087 control_p8_faster_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_p8_faster_intel
+Checking test 085 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3544,15 +3509,15 @@ Checking test 087 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 169.729071
-0:The maximum resident set size (KB)                   = 1425464
+0:The total amount of wall time                        = 171.711189
+0:The maximum resident set size (KB)                   = 1425500
 
-Test 087 control_p8_faster_intel PASS
+Test 085 control_p8_faster_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_control_faster_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_control_faster_intel
-Checking test 088 regional_control_faster_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_control_faster_intel
+Checking test 086 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3562,57 +3527,57 @@ Checking test 088 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 317.036713
-0:The maximum resident set size (KB)                   = 604280
+0:The total amount of wall time                        = 317.170569
+0:The maximum resident set size (KB)                   = 604168
 
-Test 088 regional_control_faster_intel PASS
+Test 086 regional_control_faster_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-Checking test 089 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+Checking test 087 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 879.597202
-0:The maximum resident set size (KB)                   = 697860
+0:The total amount of wall time                        = 883.238238
+0:The maximum resident set size (KB)                   = 697868
 
-Test 089 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
+Test 087 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
-Checking test 090 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+Checking test 088 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 503.388433
-0:The maximum resident set size (KB)                   = 722180
+0:The total amount of wall time                        = 502.300336
+0:The maximum resident set size (KB)                   = 722060
 
-Test 090 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
+Test 088 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_conus13km_hrrr_warm_debug_intel
-Checking test 091 rrfs_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_conus13km_hrrr_warm_debug_intel
+Checking test 089 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 785.474868
-0:The maximum resident set size (KB)                   = 683832
+0:The total amount of wall time                        = 782.774288
+0:The maximum resident set size (KB)                   = 683840
 
-Test 091 rrfs_conus13km_hrrr_warm_debug_intel PASS
+Test 089 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_CubedSphereGrid_debug_intel
-Checking test 092 control_CubedSphereGrid_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_CubedSphereGrid_debug_intel
+Checking test 090 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3638,349 +3603,349 @@ Checking test 092 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 155.241652
-0:The maximum resident set size (KB)                   = 617732
+0:The total amount of wall time                        = 155.083135
+0:The maximum resident set size (KB)                   = 617648
 
-Test 092 control_CubedSphereGrid_debug_intel PASS
+Test 090 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_wrtGauss_netcdf_parallel_debug_intel
-Checking test 093 control_wrtGauss_netcdf_parallel_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_wrtGauss_netcdf_parallel_debug_intel
+Checking test 091 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 154.811973
-0:The maximum resident set size (KB)                   = 613728
+0:The total amount of wall time                        = 156.049753
+0:The maximum resident set size (KB)                   = 613744
 
-Test 093 control_wrtGauss_netcdf_parallel_debug_intel PASS
+Test 091 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_stochy_debug_intel
-Checking test 094 control_stochy_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_stochy_debug_intel
+Checking test 092 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 175.929936
-0:The maximum resident set size (KB)                   = 620968
+0:The total amount of wall time                        = 174.573261
+0:The maximum resident set size (KB)                   = 621008
 
-Test 094 control_stochy_debug_intel PASS
+Test 092 control_stochy_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_lndp_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_lndp_debug_intel
-Checking test 095 control_lndp_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_lndp_debug_intel
+Checking test 093 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 157.372089
-0:The maximum resident set size (KB)                   = 621464
+0:The total amount of wall time                        = 157.293513
+0:The maximum resident set size (KB)                   = 621500
 
-Test 095 control_lndp_debug_intel PASS
+Test 093 control_lndp_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_csawmg_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_csawmg_debug_intel
-Checking test 096 control_csawmg_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_csawmg_debug_intel
+Checking test 094 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 248.698777
-0:The maximum resident set size (KB)                   = 663448
+0:The total amount of wall time                        = 247.421446
+0:The maximum resident set size (KB)                   = 663496
 
-Test 096 control_csawmg_debug_intel PASS
+Test 094 control_csawmg_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_csawmgt_debug_intel
-Checking test 097 control_csawmgt_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_csawmgt_debug_intel
+Checking test 095 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 242.413490
-0:The maximum resident set size (KB)                   = 663644
+0:The total amount of wall time                        = 244.082475
+0:The maximum resident set size (KB)                   = 663632
 
-Test 097 control_csawmgt_debug_intel PASS
+Test 095 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_ras_debug_intel
-Checking test 098 control_ras_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_ras_debug_intel
+Checking test 096 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 157.483858
-0:The maximum resident set size (KB)                   = 628456
+0:The total amount of wall time                        = 157.954269
+0:The maximum resident set size (KB)                   = 628416
 
-Test 098 control_ras_debug_intel PASS
+Test 096 control_ras_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_diag_debug_intel
-Checking test 099 control_diag_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_diag_debug_intel
+Checking test 097 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 159.213182
-0:The maximum resident set size (KB)                   = 671948
+0:The total amount of wall time                        = 158.692854
+0:The maximum resident set size (KB)                   = 671920
 
-Test 099 control_diag_debug_intel PASS
+Test 097 control_diag_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_debug_p8_intel
-Checking test 100 control_debug_p8_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_debug_p8_intel
+Checking test 098 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 175.498435
-0:The maximum resident set size (KB)                   = 1442852
+0:The total amount of wall time                        = 175.398174
+0:The maximum resident set size (KB)                   = 1442876
 
-Test 100 control_debug_p8_intel PASS
+Test 098 control_debug_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_debug_intel
-Checking test 101 regional_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_debug_intel
+Checking test 099 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 1034.451791
-0:The maximum resident set size (KB)                   = 625828
+0:The total amount of wall time                        = 1034.424826
+0:The maximum resident set size (KB)                   = 625832
 
-Test 101 regional_debug_intel PASS
+Test 099 regional_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_debug_intel
-Checking test 102 rap_control_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_debug_intel
+Checking test 100 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.573190
-0:The maximum resident set size (KB)                   = 986392
+0:The total amount of wall time                        = 286.006430
+0:The maximum resident set size (KB)                   = 986428
 
-Test 102 rap_control_debug_intel PASS
+Test 100 rap_control_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_debug_intel
-Checking test 103 hrrr_control_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_debug_intel
+Checking test 101 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 279.562914
-0:The maximum resident set size (KB)                   = 983324
+0:The total amount of wall time                        = 279.637889
+0:The maximum resident set size (KB)                   = 983312
 
-Test 103 hrrr_control_debug_intel PASS
+Test 101 hrrr_control_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_unified_drag_suite_debug_intel
-Checking test 104 rap_unified_drag_suite_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_unified_drag_suite_debug_intel
+Checking test 102 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.931564
-0:The maximum resident set size (KB)                   = 986488
+0:The total amount of wall time                        = 284.213176
+0:The maximum resident set size (KB)                   = 986504
 
-Test 104 rap_unified_drag_suite_debug_intel PASS
+Test 102 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_diag_debug_intel
-Checking test 105 rap_diag_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_diag_debug_intel
+Checking test 103 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 297.751679
-0:The maximum resident set size (KB)                   = 1069040
+0:The total amount of wall time                        = 297.264064
+0:The maximum resident set size (KB)                   = 1069004
 
-Test 105 rap_diag_debug_intel PASS
+Test 103 rap_diag_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_cires_ugwp_debug_intel
-Checking test 106 rap_cires_ugwp_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_cires_ugwp_debug_intel
+Checking test 104 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.820475
+0:The total amount of wall time                        = 291.324488
+0:The maximum resident set size (KB)                   = 986512
+
+Test 104 rap_cires_ugwp_debug_intel PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_unified_ugwp_debug_intel
+Checking test 105 rap_unified_ugwp_debug_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+0:The total amount of wall time                        = 291.992644
+0:The maximum resident set size (KB)                   = 986748
+
+Test 105 rap_unified_ugwp_debug_intel PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_lndp_debug_intel
+Checking test 106 rap_lndp_debug_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+0:The total amount of wall time                        = 288.820721
+0:The maximum resident set size (KB)                   = 987332
+
+Test 106 rap_lndp_debug_intel PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_progcld_thompson_debug_intel
+Checking test 107 rap_progcld_thompson_debug_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+0:The total amount of wall time                        = 285.955625
 0:The maximum resident set size (KB)                   = 986528
 
-Test 106 rap_cires_ugwp_debug_intel PASS
+Test 107 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_unified_ugwp_debug_intel
-Checking test 107 rap_unified_ugwp_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_noah_debug_intel
+Checking test 108 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 290.430401
-0:The maximum resident set size (KB)                   = 986728
+0:The total amount of wall time                        = 279.714129
+0:The maximum resident set size (KB)                   = 985068
 
-Test 107 rap_unified_ugwp_debug_intel PASS
+Test 108 rap_noah_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_lndp_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_lndp_debug_intel
-Checking test 108 rap_lndp_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_sfcdiff_debug_intel
+Checking test 109 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.190506
-0:The maximum resident set size (KB)                   = 987200
+0:The total amount of wall time                        = 285.968521
+0:The maximum resident set size (KB)                   = 986568
 
-Test 108 rap_lndp_debug_intel PASS
+Test 109 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_progcld_thompson_debug_intel
-Checking test 109 rap_progcld_thompson_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_noah_sfcdiff_cires_ugwp_debug_intel
+Checking test 110 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.248640
-0:The maximum resident set size (KB)                   = 986492
+0:The total amount of wall time                        = 470.467369
+0:The maximum resident set size (KB)                   = 984752
 
-Test 109 rap_progcld_thompson_debug_intel PASS
+Test 110 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_noah_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_noah_debug_intel
-Checking test 110 rap_noah_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_v1beta_debug_intel
+Checking test 111 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 279.851036
-0:The maximum resident set size (KB)                   = 985004
+0:The total amount of wall time                        = 283.447394
+0:The maximum resident set size (KB)                   = 983272
 
-Test 110 rap_noah_debug_intel PASS
+Test 111 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_sfcdiff_debug_intel
-Checking test 111 rap_sfcdiff_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_clm_lake_debug_intel
+Checking test 112 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.220347
-0:The maximum resident set size (KB)                   = 986420
+0:The total amount of wall time                        = 349.606994
+0:The maximum resident set size (KB)                   = 989080
 
-Test 111 rap_sfcdiff_debug_intel PASS
+Test 112 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_noah_sfcdiff_cires_ugwp_debug_intel
-Checking test 112 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_flake_debug_intel
+Checking test 113 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 470.751504
-0:The maximum resident set size (KB)                   = 984916
+0:The total amount of wall time                        = 286.398759
+0:The maximum resident set size (KB)                   = 986700
 
-Test 112 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_v1beta_debug_intel
-Checking test 113 rrfs_v1beta_debug_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-0:The total amount of wall time                        = 281.524737
-0:The maximum resident set size (KB)                   = 983296
-
-Test 113 rrfs_v1beta_debug_intel PASS
+Test 113 rap_flake_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_clm_lake_debug_intel
-Checking test 114 rap_clm_lake_debug_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-0:The total amount of wall time                        = 349.961148
-0:The maximum resident set size (KB)                   = 988972
-
-Test 114 rap_clm_lake_debug_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_flake_debug_intel
-Checking test 115 rap_flake_debug_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-0:The total amount of wall time                        = 287.318537
-0:The maximum resident set size (KB)                   = 986732
-
-Test 115 rap_flake_debug_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_wam_debug_intel
-Checking test 116 control_wam_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_wam_debug_intel
+Checking test 114 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 290.184547
-0:The maximum resident set size (KB)                   = 236076
+0:The total amount of wall time                        = 293.187614
+0:The maximum resident set size (KB)                   = 236272
 
-Test 116 control_wam_debug_intel PASS
+Test 114 control_wam_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 117 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+Checking test 115 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3990,15 +3955,15 @@ Checking test 117 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 239.909048
-0:The maximum resident set size (KB)                   = 852012
+0:The total amount of wall time                        = 239.757019
+0:The maximum resident set size (KB)                   = 851984
 
-Test 117 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+Test 115 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_dyn32_phy32_intel
-Checking test 118 rap_control_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_dyn32_phy32_intel
+Checking test 116 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4044,15 +4009,15 @@ Checking test 118 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 387.005942
-0:The maximum resident set size (KB)                   = 706476
+0:The total amount of wall time                        = 384.175656
+0:The maximum resident set size (KB)                   = 706444
 
-Test 118 rap_control_dyn32_phy32_intel PASS
+Test 116 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_dyn32_phy32_intel
-Checking test 119 hrrr_control_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_dyn32_phy32_intel
+Checking test 117 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4098,15 +4063,15 @@ Checking test 119 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 198.812654
-0:The maximum resident set size (KB)                   = 705784
+0:The total amount of wall time                        = 200.511236
+0:The maximum resident set size (KB)                   = 705768
 
-Test 119 hrrr_control_dyn32_phy32_intel PASS
+Test 117 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_qr_dyn32_phy32_intel
-Checking test 120 hrrr_control_qr_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_qr_dyn32_phy32_intel
+Checking test 118 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4152,15 +4117,15 @@ Checking test 120 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 200.416654
-0:The maximum resident set size (KB)                   = 712920
+0:The total amount of wall time                        = 200.690149
+0:The maximum resident set size (KB)                   = 712856
 
-Test 120 hrrr_control_qr_dyn32_phy32_intel PASS
+Test 118 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_2threads_dyn32_phy32_intel
-Checking test 121 rap_2threads_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_2threads_dyn32_phy32_intel
+Checking test 119 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4206,15 +4171,15 @@ Checking test 121 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 365.719489
-0:The maximum resident set size (KB)                   = 756852
+0:The total amount of wall time                        = 364.386812
+0:The maximum resident set size (KB)                   = 756528
 
-Test 121 rap_2threads_dyn32_phy32_intel PASS
+Test 119 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 122 hrrr_control_2threads_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_2threads_dyn32_phy32_intel
+Checking test 120 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4260,15 +4225,15 @@ Checking test 122 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 272.997421
-0:The maximum resident set size (KB)                   = 751984
+0:The total amount of wall time                        = 275.022942
+0:The maximum resident set size (KB)                   = 749920
 
-Test 122 hrrr_control_2threads_dyn32_phy32_intel PASS
+Test 120 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 123 hrrr_control_decomp_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_decomp_dyn32_phy32_intel
+Checking test 121 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4314,15 +4279,15 @@ Checking test 123 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 209.861177
-0:The maximum resident set size (KB)                   = 705044
+0:The total amount of wall time                        = 208.650359
+0:The maximum resident set size (KB)                   = 705096
 
-Test 123 hrrr_control_decomp_dyn32_phy32_intel PASS
+Test 121 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_restart_dyn32_phy32_intel
-Checking test 124 rap_restart_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_restart_dyn32_phy32_intel
+Checking test 122 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -4360,43 +4325,43 @@ Checking test 124 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 286.501868
-0:The maximum resident set size (KB)                   = 540240
+0:The total amount of wall time                        = 283.028352
+0:The maximum resident set size (KB)                   = 540128
 
-Test 124 rap_restart_dyn32_phy32_intel PASS
+Test 122 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_dyn32_phy32_intel
-Checking test 125 hrrr_control_restart_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_dyn32_phy32_intel
+Checking test 123 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 103.917123
-0:The maximum resident set size (KB)                   = 533768
+0:The total amount of wall time                        = 101.551472
+0:The maximum resident set size (KB)                   = 533880
 
-Test 125 hrrr_control_restart_dyn32_phy32_intel PASS
+Test 123 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_qr_dyn32_phy32_intel
-Checking test 126 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 124 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 108.455254
-0:The maximum resident set size (KB)                   = 558632
+0:The total amount of wall time                        = 104.353084
+0:The maximum resident set size (KB)                   = 558624
 
-Test 126 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+Test 124 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_dyn64_phy32_intel
-Checking test 127 rap_control_dyn64_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_dyn64_phy32_intel
+Checking test 125 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4442,82 +4407,82 @@ Checking test 127 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 263.542803
-0:The maximum resident set size (KB)                   = 726216
+0:The total amount of wall time                        = 254.155600
+0:The maximum resident set size (KB)                   = 726400
 
-Test 127 rap_control_dyn64_phy32_intel PASS
+Test 125 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_debug_dyn32_phy32_intel
-Checking test 128 rap_control_debug_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_debug_dyn32_phy32_intel
+Checking test 126 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 281.522091
-0:The maximum resident set size (KB)                   = 871940
+0:The total amount of wall time                        = 281.790478
+0:The maximum resident set size (KB)                   = 871984
 
-Test 128 rap_control_debug_dyn32_phy32_intel PASS
+Test 126 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_debug_dyn32_phy32_intel
-Checking test 129 hrrr_control_debug_dyn32_phy32_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_debug_dyn32_phy32_intel
+Checking test 127 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 274.528770
-0:The maximum resident set size (KB)                   = 870012
+0:The total amount of wall time                        = 274.884697
+0:The maximum resident set size (KB)                   = 870188
 
-Test 129 hrrr_control_debug_dyn32_phy32_intel PASS
+Test 127 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_dyn64_phy32_debug_intel
-Checking test 130 rap_control_dyn64_phy32_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_dyn64_phy32_debug_intel
+Checking test 128 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.934205
-0:The maximum resident set size (KB)                   = 889736
+0:The total amount of wall time                        = 287.241172
+0:The maximum resident set size (KB)                   = 889624
 
-Test 130 rap_control_dyn64_phy32_debug_intel PASS
+Test 128 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_atm_intel
-Checking test 131 hafs_regional_atm_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_atm_intel
+Checking test 129 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 246.733314
-0:The maximum resident set size (KB)                   = 741464
+0:The total amount of wall time                        = 245.531806
+0:The maximum resident set size (KB)                   = 741680
 
-Test 131 hafs_regional_atm_intel PASS
+Test 129 hafs_regional_atm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_atm_thompson_gfdlsf_intel
-Checking test 132 hafs_regional_atm_thompson_gfdlsf_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_atm_thompson_gfdlsf_intel
+Checking test 130 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 279.103984
-0:The maximum resident set size (KB)                   = 1099732
+0:The total amount of wall time                        = 283.039078
+0:The maximum resident set size (KB)                   = 1098632
 
-Test 132 hafs_regional_atm_thompson_gfdlsf_intel PASS
+Test 130 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_atm_ocn_intel
-Checking test 133 hafs_regional_atm_ocn_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_atm_ocn_intel
+Checking test 131 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4525,15 +4490,15 @@ Checking test 133 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 519.447709
-0:The maximum resident set size (KB)                   = 743064
+0:The total amount of wall time                        = 453.906454
+0:The maximum resident set size (KB)                   = 742940
 
-Test 133 hafs_regional_atm_ocn_intel PASS
+Test 131 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_wav_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_atm_wav_intel
-Checking test 134 hafs_regional_atm_wav_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_atm_wav_intel
+Checking test 132 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4541,15 +4506,15 @@ Checking test 134 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1016.686255
-0:The maximum resident set size (KB)                   = 770712
+0:The total amount of wall time                        = 1071.858036
+0:The maximum resident set size (KB)                   = 770476
 
-Test 134 hafs_regional_atm_wav_intel PASS
+Test 132 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_wav_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_atm_ocn_wav_intel
-Checking test 135 hafs_regional_atm_ocn_wav_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_atm_ocn_wav_intel
+Checking test 133 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4559,15 +4524,15 @@ Checking test 135 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1089.536888
-0:The maximum resident set size (KB)                   = 791548
+0:The total amount of wall time                        = 1158.187338
+0:The maximum resident set size (KB)                   = 792796
 
-Test 135 hafs_regional_atm_ocn_wav_intel PASS
+Test 133 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_1nest_atm_intel
-Checking test 136 hafs_regional_1nest_atm_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_1nest_atm_intel
+Checking test 134 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4588,15 +4553,15 @@ Checking test 136 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-0:The total amount of wall time                        = 350.293355
-0:The maximum resident set size (KB)                   = 300204
+0:The total amount of wall time                        = 351.580566
+0:The maximum resident set size (KB)                   = 300700
 
-Test 136 hafs_regional_1nest_atm_intel PASS
+Test 134 hafs_regional_1nest_atm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_telescopic_2nests_atm_intel
-Checking test 137 hafs_regional_telescopic_2nests_atm_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_telescopic_2nests_atm_intel
+Checking test 135 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4604,15 +4569,15 @@ Checking test 137 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 399.834821
-0:The maximum resident set size (KB)                   = 318472
+0:The total amount of wall time                        = 396.696286
+0:The maximum resident set size (KB)                   = 318516
 
-Test 137 hafs_regional_telescopic_2nests_atm_intel PASS
+Test 135 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_global_1nest_atm_intel
-Checking test 138 hafs_global_1nest_atm_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_global_1nest_atm_intel
+Checking test 136 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4658,120 +4623,120 @@ Checking test 138 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-0:The total amount of wall time                        = 160.242645
-0:The maximum resident set size (KB)                   = 214384
+0:The total amount of wall time                        = 159.673481
+0:The maximum resident set size (KB)                   = 214428
 
-Test 138 hafs_global_1nest_atm_intel PASS
+Test 136 hafs_global_1nest_atm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_global_multiple_4nests_atm_intel
-Checking test 139 hafs_global_multiple_4nests_atm_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_global_multiple_4nests_atm_intel
+Checking test 137 hafs_global_multiple_4nests_atm_intel results ....
+ Comparing atmf006.nc ............MISSING baseline
+ Comparing sfcf006.nc ............MISSING baseline
+ Comparing atm.nest02.f006.nc ............MISSING baseline
+ Comparing sfc.nest02.f006.nc ............MISSING baseline
+ Comparing atm.nest03.f006.nc ............MISSING baseline
+ Comparing sfc.nest03.f006.nc ............MISSING baseline
+ Comparing atm.nest04.f006.nc ............MISSING baseline
+ Comparing sfc.nest04.f006.nc ............MISSING baseline
+ Comparing atm.nest05.f006.nc ............MISSING baseline
+ Comparing sfc.nest05.f006.nc ............MISSING baseline
+ Comparing HURPRS.GrbF06 ............MISSING baseline
+ Comparing HURPRS.GrbF06.nest02 ............MISSING baseline
+ Comparing HURPRS.GrbF06.nest03 ............MISSING baseline
+ Comparing HURPRS.GrbF06.nest04 ............MISSING baseline
+ Comparing HURPRS.GrbF06.nest05 ............MISSING baseline
+ Comparing RESTART/20200825.180000.coupler.res ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest02.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest02.tile7.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest03.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest03.tile8.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest04.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest04.tile9.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest05.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.nest05.tile10.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_core.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest02.tile7.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest03.tile8.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest04.tile9.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest05.tile10.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.nest02.tile7.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.nest03.tile8.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.nest04.tile9.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.nest05.tile10.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.tile1.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.tile2.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.tile3.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.tile4.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.tile5.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.fv_tracer.res.tile6.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.nest02.tile7.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.nest03.tile8.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.nest04.tile9.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.nest05.tile10.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.phy_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.nest02.tile7.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.nest03.tile8.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.nest04.tile9.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.nest05.tile10.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.tile1.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.tile2.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.tile3.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.tile4.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.tile5.nc ............MISSING baseline
+ Comparing RESTART/20200825.180000.sfc_data.tile6.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_ne.res.nest02.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_ne.res.nest03.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_ne.res.nest04.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_ne.res.nest05.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_sw.res.nest02.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_sw.res.nest03.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_sw.res.nest04.nc ............MISSING baseline
+ Comparing RESTART/fv_BC_sw.res.nest05.nc ............MISSING baseline
+
+0:The total amount of wall time                        = 457.996248
+0:The maximum resident set size (KB)                   = 302164
+
+Test 137 hafs_global_multiple_4nests_atm_intel FAIL Tries: 2
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_specified_moving_1nest_atm_intel
+Checking test 138 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
- Comparing atm.nest03.f006.nc .........OK
- Comparing sfc.nest03.f006.nc .........OK
- Comparing atm.nest04.f006.nc .........OK
- Comparing sfc.nest04.f006.nc .........OK
- Comparing atm.nest05.f006.nc .........OK
- Comparing sfc.nest05.f006.nc .........OK
- Comparing HURPRS.GrbF06 .........OK
- Comparing HURPRS.GrbF06.nest02 .........OK
- Comparing HURPRS.GrbF06.nest03 .........OK
- Comparing HURPRS.GrbF06.nest04 .........OK
- Comparing HURPRS.GrbF06.nest05 .........OK
- Comparing RESTART/20200825.180000.coupler.res .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest02.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest02.tile7.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest03.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest03.tile8.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest04.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest04.tile9.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest05.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.nest05.tile10.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20200825.180000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest02.tile7.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest03.tile8.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest04.tile9.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.nest05.tile10.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20200825.180000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.nest02.tile7.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.nest03.tile8.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.nest04.tile9.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.nest05.tile10.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20200825.180000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.nest02.tile7.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.nest03.tile8.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.nest04.tile9.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.nest05.tile10.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.tile1.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.tile2.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.tile3.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.tile4.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.tile5.nc .........OK
- Comparing RESTART/20200825.180000.phy_data.tile6.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.nest02.tile7.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.nest03.tile8.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.nest04.tile9.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.nest05.tile10.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20200825.180000.sfc_data.tile6.nc .........OK
- Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
- Comparing RESTART/fv_BC_ne.res.nest03.nc .........OK
- Comparing RESTART/fv_BC_ne.res.nest04.nc .........OK
- Comparing RESTART/fv_BC_ne.res.nest05.nc .........OK
- Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
- Comparing RESTART/fv_BC_sw.res.nest03.nc .........OK
- Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
- Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
-
-0:The total amount of wall time                        = 450.525823
-0:The maximum resident set size (KB)                   = 302260
-
-Test 139 hafs_global_multiple_4nests_atm_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_specified_moving_1nest_atm_intel
-Checking test 140 hafs_regional_specified_moving_1nest_atm_intel results ....
- Comparing atmf006.nc .........OK
- Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
- Comparing sfc.nest02.f006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-0:The total amount of wall time                        = 223.835843
-0:The maximum resident set size (KB)                   = 317452
+0:The total amount of wall time                        = 227.857888
+0:The maximum resident set size (KB)                   = 318160
 
-Test 140 hafs_regional_specified_moving_1nest_atm_intel PASS
+Test 138 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_storm_following_1nest_atm_intel
-Checking test 141 hafs_regional_storm_following_1nest_atm_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_storm_following_1nest_atm_intel
+Checking test 139 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4792,15 +4757,15 @@ Checking test 141 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-0:The total amount of wall time                        = 213.839101
-0:The maximum resident set size (KB)                   = 318140
+0:The total amount of wall time                        = 213.481718
+0:The maximum resident set size (KB)                   = 317260
 
-Test 141 hafs_regional_storm_following_1nest_atm_intel PASS
+Test 139 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_storm_following_1nest_atm_ocn_intel
-Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_storm_following_1nest_atm_ocn_intel
+Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4808,43 +4773,43 @@ Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 276.357461
-0:The maximum resident set size (KB)                   = 376580
+0:The total amount of wall time                        = 274.371046
+0:The maximum resident set size (KB)                   = 376196
 
-Test 142 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
+Test 140 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_global_storm_following_1nest_atm_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_global_storm_following_1nest_atm_intel
-Checking test 143 hafs_global_storm_following_1nest_atm_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_global_storm_following_1nest_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_global_storm_following_1nest_atm_intel
+Checking test 141 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 63.014753
-0:The maximum resident set size (KB)                   = 233104
+0:The total amount of wall time                        = 62.804579
+0:The maximum resident set size (KB)                   = 233180
 
-Test 143 hafs_global_storm_following_1nest_atm_intel PASS
+Test 141 hafs_global_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-Checking test 144 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-0:The total amount of wall time                        = 763.846226
-0:The maximum resident set size (KB)                   = 402872
+0:The total amount of wall time                        = 764.432824
+0:The maximum resident set size (KB)                   = 402672
 
-Test 144 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
+Test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-Checking test 145 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4854,162 +4819,162 @@ Checking test 145 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 729.663661
-0:The maximum resident set size (KB)                   = 425988
+0:The total amount of wall time                        = 786.284488
+0:The maximum resident set size (KB)                   = 427256
 
-Test 145 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
+Test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_docn_intel
-Checking test 146 hafs_regional_docn_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_docn_intel
+Checking test 144 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 370.422203
-0:The maximum resident set size (KB)                   = 756108
+0:The total amount of wall time                        = 371.411486
+0:The maximum resident set size (KB)                   = 756268
 
-Test 146 hafs_regional_docn_intel PASS
+Test 144 hafs_regional_docn_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_oisst_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_docn_oisst_intel
-Checking test 147 hafs_regional_docn_oisst_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_oisst_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_docn_oisst_intel
+Checking test 145 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 371.544619
-0:The maximum resident set size (KB)                   = 738484
+0:The total amount of wall time                        = 373.396815
+0:The maximum resident set size (KB)                   = 738572
 
-Test 147 hafs_regional_docn_oisst_intel PASS
+Test 145 hafs_regional_docn_oisst_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hafs_regional_datm_cdeps_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hafs_regional_datm_cdeps_intel
-Checking test 148 hafs_regional_datm_cdeps_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_regional_datm_cdeps_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hafs_regional_datm_cdeps_intel
+Checking test 146 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1273.065225
-0:The maximum resident set size (KB)                   = 887844
+0:The total amount of wall time                        = 1158.398843
+0:The maximum resident set size (KB)                   = 888020
 
-Test 148 hafs_regional_datm_cdeps_intel PASS
+Test 146 hafs_regional_datm_cdeps_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_control_cfsr_intel
-Checking test 149 datm_cdeps_control_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_control_cfsr_intel
+Checking test 147 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.107804
-0:The maximum resident set size (KB)                   = 716704
+0:The total amount of wall time                        = 159.004648
+0:The maximum resident set size (KB)                   = 727644
 
-Test 149 datm_cdeps_control_cfsr_intel PASS
+Test 147 datm_cdeps_control_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_restart_cfsr_intel
-Checking test 150 datm_cdeps_restart_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_restart_cfsr_intel
+Checking test 148 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 101.513501
-0:The maximum resident set size (KB)                   = 704848
+0:The total amount of wall time                        = 100.008397
+0:The maximum resident set size (KB)                   = 715972
 
-Test 150 datm_cdeps_restart_cfsr_intel PASS
+Test 148 datm_cdeps_restart_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_gefs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_control_gefs_intel
-Checking test 151 datm_cdeps_control_gefs_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_gefs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_control_gefs_intel
+Checking test 149 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.593759
-0:The maximum resident set size (KB)                   = 607492
+0:The total amount of wall time                        = 152.567124
+0:The maximum resident set size (KB)                   = 607496
 
-Test 151 datm_cdeps_control_gefs_intel PASS
+Test 149 datm_cdeps_control_gefs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_iau_gefs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_iau_gefs_intel
-Checking test 152 datm_cdeps_iau_gefs_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_iau_gefs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_iau_gefs_intel
+Checking test 150 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 163.503364
-0:The maximum resident set size (KB)                   = 607544
+0:The total amount of wall time                        = 156.032422
+0:The maximum resident set size (KB)                   = 607524
 
-Test 152 datm_cdeps_iau_gefs_intel PASS
+Test 150 datm_cdeps_iau_gefs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_stochy_gefs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_stochy_gefs_intel
-Checking test 153 datm_cdeps_stochy_gefs_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_stochy_gefs_intel
+Checking test 151 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 159.034642
-0:The maximum resident set size (KB)                   = 607508
+0:The total amount of wall time                        = 162.215923
+0:The maximum resident set size (KB)                   = 607548
 
-Test 153 datm_cdeps_stochy_gefs_intel PASS
+Test 151 datm_cdeps_stochy_gefs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_ciceC_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_ciceC_cfsr_intel
-Checking test 154 datm_cdeps_ciceC_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_ciceC_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_ciceC_cfsr_intel
+Checking test 152 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 168.556364
-0:The maximum resident set size (KB)                   = 716740
+0:The total amount of wall time                        = 166.114595
+0:The maximum resident set size (KB)                   = 716720
 
-Test 154 datm_cdeps_ciceC_cfsr_intel PASS
+Test 152 datm_cdeps_ciceC_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_bulk_cfsr_intel
-Checking test 155 datm_cdeps_bulk_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_bulk_cfsr_intel
+Checking test 153 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 162.268418
-0:The maximum resident set size (KB)                   = 716752
+0:The total amount of wall time                        = 167.010790
+0:The maximum resident set size (KB)                   = 716708
 
-Test 155 datm_cdeps_bulk_cfsr_intel PASS
+Test 153 datm_cdeps_bulk_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_gefs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_bulk_gefs_intel
-Checking test 156 datm_cdeps_bulk_gefs_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_gefs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_bulk_gefs_intel
+Checking test 154 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 160.505643
-0:The maximum resident set size (KB)                   = 607520
+0:The total amount of wall time                        = 158.862261
+0:The maximum resident set size (KB)                   = 607532
 
-Test 156 datm_cdeps_bulk_gefs_intel PASS
+Test 154 datm_cdeps_bulk_gefs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_mx025_cfsr_intel
-Checking test 157 datm_cdeps_mx025_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_mx025_cfsr_intel
+Checking test 155 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -5017,15 +4982,15 @@ Checking test 157 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 726.535318
-0:The maximum resident set size (KB)                   = 514260
+0:The total amount of wall time                        = 424.554806
+0:The maximum resident set size (KB)                   = 514416
 
-Test 157 datm_cdeps_mx025_cfsr_intel PASS
+Test 155 datm_cdeps_mx025_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_gefs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_mx025_gefs_intel
-Checking test 158 datm_cdeps_mx025_gefs_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_gefs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_mx025_gefs_intel
+Checking test 156 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -5033,78 +4998,78 @@ Checking test 158 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 727.784523
-0:The maximum resident set size (KB)                   = 494808
+0:The total amount of wall time                        = 712.398572
+0:The maximum resident set size (KB)                   = 494840
 
-Test 158 datm_cdeps_mx025_gefs_intel PASS
+Test 156 datm_cdeps_mx025_gefs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_multiple_files_cfsr_intel
-Checking test 159 datm_cdeps_multiple_files_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_multiple_files_cfsr_intel
+Checking test 157 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.699680
-0:The maximum resident set size (KB)                   = 727752
+0:The total amount of wall time                        = 159.007654
+0:The maximum resident set size (KB)                   = 716728
 
-Test 159 datm_cdeps_multiple_files_cfsr_intel PASS
+Test 157 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_3072x1536_cfsr_intel
-Checking test 160 datm_cdeps_3072x1536_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_3072x1536_cfsr_intel
+Checking test 158 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 255.717214
-0:The maximum resident set size (KB)                   = 1941140
+0:The total amount of wall time                        = 237.206833
+0:The maximum resident set size (KB)                   = 1941164
 
-Test 160 datm_cdeps_3072x1536_cfsr_intel PASS
+Test 158 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_gfs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_gfs_intel
-Checking test 161 datm_cdeps_gfs_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_gfs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_gfs_intel
+Checking test 159 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 256.922329
-0:The maximum resident set size (KB)                   = 1942044
+0:The total amount of wall time                        = 268.889597
+0:The maximum resident set size (KB)                   = 1941108
 
-Test 161 datm_cdeps_gfs_intel PASS
+Test 159 datm_cdeps_gfs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_debug_cfsr_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_debug_cfsr_intel
-Checking test 162 datm_cdeps_debug_cfsr_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_debug_cfsr_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_debug_cfsr_intel
+Checking test 160 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 372.366649
-0:The maximum resident set size (KB)                   = 700584
+0:The total amount of wall time                        = 371.147722
+0:The maximum resident set size (KB)                   = 711672
 
-Test 162 datm_cdeps_debug_cfsr_intel PASS
+Test 160 datm_cdeps_debug_cfsr_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_faster_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_control_cfsr_faster_intel
-Checking test 163 datm_cdeps_control_cfsr_faster_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_control_cfsr_faster_intel
+Checking test 161 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.277722
-0:The maximum resident set size (KB)                   = 716692
+0:The total amount of wall time                        = 166.004181
+0:The maximum resident set size (KB)                   = 727808
 
-Test 163 datm_cdeps_control_cfsr_faster_intel PASS
+Test 161 datm_cdeps_control_cfsr_faster_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_lnd_gswp3_intel
-Checking test 164 datm_cdeps_lnd_gswp3_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_lnd_gswp3_intel
+Checking test 162 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5112,15 +5077,15 @@ Checking test 164 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 10.891918
-0:The maximum resident set size (KB)                   = 216404
+0:The total amount of wall time                        = 10.445541
+0:The maximum resident set size (KB)                   = 204548
 
-Test 164 datm_cdeps_lnd_gswp3_intel PASS
+Test 162 datm_cdeps_lnd_gswp3_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_lnd_gswp3_rst_intel
-Checking test 165 datm_cdeps_lnd_gswp3_rst_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_lnd_gswp3_rst_intel
+Checking test 163 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5128,15 +5093,15 @@ Checking test 165 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 15.568827
-0:The maximum resident set size (KB)                   = 210128
+0:The total amount of wall time                        = 15.429643
+0:The maximum resident set size (KB)                   = 210144
 
-Test 165 datm_cdeps_lnd_gswp3_rst_intel PASS
+Test 163 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_atmlnd_sbs_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_p8_atmlnd_sbs_intel
-Checking test 166 control_p8_atmlnd_sbs_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_p8_atmlnd_sbs_intel
+Checking test 164 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -5220,15 +5185,15 @@ Checking test 166 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-0:The total amount of wall time                        = 235.239857
-0:The maximum resident set size (KB)                   = 1464008
+0:The total amount of wall time                        = 232.650831
+0:The maximum resident set size (KB)                   = 1464092
 
-Test 166 control_p8_atmlnd_sbs_intel PASS
+Test 164 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/atmwav_control_noaero_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/atmwav_control_noaero_p8_intel
-Checking test 167 atmwav_control_noaero_p8_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/atmwav_control_noaero_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/atmwav_control_noaero_p8_intel
+Checking test 165 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5270,15 +5235,15 @@ Checking test 167 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-0:The total amount of wall time                        = 99.494707
-0:The maximum resident set size (KB)                   = 1437240
+0:The total amount of wall time                        = 96.646647
+0:The maximum resident set size (KB)                   = 1437208
 
-Test 167 atmwav_control_noaero_p8_intel PASS
+Test 165 atmwav_control_noaero_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_atmwav_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_atmwav_intel
-Checking test 168 control_atmwav_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_atmwav_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_atmwav_intel
+Checking test 166 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5321,15 +5286,15 @@ Checking test 168 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 100.613581
-0:The maximum resident set size (KB)                   = 475124
+0:The total amount of wall time                        = 99.762260
+0:The maximum resident set size (KB)                   = 475068
 
-Test 168 control_atmwav_intel PASS
+Test 166 control_atmwav_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/atmaero_control_p8_intel
-Checking test 169 atmaero_control_p8_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/atmaero_control_p8_intel
+Checking test 167 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5372,15 +5337,15 @@ Checking test 169 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 248.873101
-0:The maximum resident set size (KB)                   = 2703956
+0:The total amount of wall time                        = 248.053491
+0:The maximum resident set size (KB)                   = 2703964
 
-Test 169 atmaero_control_p8_intel PASS
+Test 167 atmaero_control_p8_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/atmaero_control_p8_rad_intel
-Checking test 170 atmaero_control_p8_rad_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/atmaero_control_p8_rad_intel
+Checking test 168 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5423,15 +5388,15 @@ Checking test 170 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 301.462096
-0:The maximum resident set size (KB)                   = 2758020
+0:The total amount of wall time                        = 303.208443
+0:The maximum resident set size (KB)                   = 2758028
 
-Test 170 atmaero_control_p8_rad_intel PASS
+Test 168 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_micro_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/atmaero_control_p8_rad_micro_intel
-Checking test 171 atmaero_control_p8_rad_micro_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/atmaero_control_p8_rad_micro_intel
+Checking test 169 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5474,15 +5439,15 @@ Checking test 171 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 308.886432
-0:The maximum resident set size (KB)                   = 2764352
+0:The total amount of wall time                        = 307.314527
+0:The maximum resident set size (KB)                   = 2764400
 
-Test 171 atmaero_control_p8_rad_micro_intel PASS
+Test 169 atmaero_control_p8_rad_micro_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_atmaq_intel
-Checking test 172 regional_atmaq_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_atmaq_intel
+Checking test 170 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5497,15 +5462,15 @@ Checking test 172 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 998.556908
-0:The maximum resident set size (KB)                   = 999336
+0:The total amount of wall time                        = 963.864483
+0:The maximum resident set size (KB)                   = 999420
 
-Test 172 regional_atmaq_intel PASS
+Test 170 regional_atmaq_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_faster_intel
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_atmaq_faster_intel
-Checking test 173 regional_atmaq_faster_intel results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_faster_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_atmaq_faster_intel
+Checking test 171 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5520,15 +5485,15 @@ Checking test 173 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 697.279514
-0:The maximum resident set size (KB)                   = 999388
+0:The total amount of wall time                        = 691.424133
+0:The maximum resident set size (KB)                   = 999316
 
-Test 173 regional_atmaq_faster_intel PASS
+Test 171 regional_atmaq_faster_intel PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_c48_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_c48_gnu
-Checking test 174 control_c48_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_c48_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_c48_gnu
+Checking test 172 control_c48_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5566,15 +5531,15 @@ Checking test 174 control_c48_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 818.046607
-0:The maximum resident set size (KB)                   = 678632
+0:The total amount of wall time                        = 813.868347
+0:The maximum resident set size (KB)                   = 678640
 
-Test 174 control_c48_gnu PASS
+Test 172 control_c48_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_stochy_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_stochy_gnu
-Checking test 175 control_stochy_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_stochy_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_stochy_gnu
+Checking test 173 control_stochy_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5584,15 +5549,15 @@ Checking test 175 control_stochy_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 173.095783
-0:The maximum resident set size (KB)                   = 443188
+0:The total amount of wall time                        = 177.057060
+0:The maximum resident set size (KB)                   = 443444
 
-Test 175 control_stochy_gnu PASS
+Test 173 control_stochy_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_ras_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_ras_gnu
-Checking test 176 control_ras_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_ras_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_ras_gnu
+Checking test 174 control_ras_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5602,87 +5567,15 @@ Checking test 176 control_ras_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 294.416751
-0:The maximum resident set size (KB)                   = 451836
+0:The total amount of wall time                        = 295.087326
+0:The maximum resident set size (KB)                   = 451744
 
-Test 176 control_ras_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_p8_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_p8_gnu
-Checking test 177 control_p8_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-0:The total amount of wall time                        = 301.160536
-0:The maximum resident set size (KB)                   = 1225960
-
-Test 177 control_p8_gnu PASS
+Test 174 control_ras_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_flake_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_flake_gnu
-Checking test 178 control_flake_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-0:The total amount of wall time                        = 350.514062
-0:The maximum resident set size (KB)                   = 490000
-
-Test 178 control_flake_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_gnu
-Checking test 179 rap_control_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_p8_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_p8_gnu
+Checking test 175 control_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5728,15 +5621,33 @@ Checking test 179 rap_control_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 704.952393
-0:The maximum resident set size (KB)                   = 791812
+0:The total amount of wall time                        = 308.845373
+0:The maximum resident set size (KB)                   = 1226112
 
-Test 179 rap_control_gnu PASS
+Test 175 control_p8_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_decomp_gnu
-Checking test 180 rap_decomp_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_flake_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_flake_gnu
+Checking test 176 control_flake_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+0:The total amount of wall time                        = 344.293768
+0:The maximum resident set size (KB)                   = 489828
+
+Test 176 control_flake_gnu PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_gnu
+Checking test 177 rap_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5782,15 +5693,15 @@ Checking test 180 rap_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 712.225893
-0:The maximum resident set size (KB)                   = 791108
+0:The total amount of wall time                        = 708.189343
+0:The maximum resident set size (KB)                   = 791868
 
-Test 180 rap_decomp_gnu PASS
+Test 177 rap_control_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_2threads_gnu
-Checking test 181 rap_2threads_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_decomp_gnu
+Checking test 178 rap_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5836,15 +5747,69 @@ Checking test 181 rap_2threads_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 650.368720
-0:The maximum resident set size (KB)                   = 865192
+0:The total amount of wall time                        = 714.407769
+0:The maximum resident set size (KB)                   = 791104
 
-Test 181 rap_2threads_gnu PASS
+Test 178 rap_decomp_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_restart_gnu
-Checking test 182 rap_restart_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_2threads_gnu
+Checking test 179 rap_2threads_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+0:The total amount of wall time                        = 648.781058
+0:The maximum resident set size (KB)                   = 865440
+
+Test 179 rap_2threads_gnu PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_restart_gnu
+Checking test 180 rap_restart_gnu results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -5882,15 +5847,15 @@ Checking test 182 rap_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 354.371259
-0:The maximum resident set size (KB)                   = 537156
+0:The total amount of wall time                        = 354.253098
+0:The maximum resident set size (KB)                   = 537120
 
-Test 182 rap_restart_gnu PASS
+Test 180 rap_restart_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_sfcdiff_gnu
-Checking test 183 rap_sfcdiff_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_sfcdiff_gnu
+Checking test 181 rap_sfcdiff_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5936,15 +5901,15 @@ Checking test 183 rap_sfcdiff_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 709.955896
-0:The maximum resident set size (KB)                   = 791652
+0:The total amount of wall time                        = 711.329224
+0:The maximum resident set size (KB)                   = 791680
 
-Test 183 rap_sfcdiff_gnu PASS
+Test 181 rap_sfcdiff_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_sfcdiff_decomp_gnu
-Checking test 184 rap_sfcdiff_decomp_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_sfcdiff_decomp_gnu
+Checking test 182 rap_sfcdiff_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5990,15 +5955,15 @@ Checking test 184 rap_sfcdiff_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 719.751236
-0:The maximum resident set size (KB)                   = 790928
+0:The total amount of wall time                        = 719.213797
+0:The maximum resident set size (KB)                   = 790912
 
-Test 184 rap_sfcdiff_decomp_gnu PASS
+Test 182 rap_sfcdiff_decomp_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_sfcdiff_restart_gnu
-Checking test 185 rap_sfcdiff_restart_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_sfcdiff_restart_gnu
+Checking test 183 rap_sfcdiff_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -6036,15 +6001,15 @@ Checking test 185 rap_sfcdiff_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 525.725552
-0:The maximum resident set size (KB)                   = 543984
+0:The total amount of wall time                        = 524.615211
+0:The maximum resident set size (KB)                   = 544060
 
-Test 185 rap_sfcdiff_restart_gnu PASS
+Test 183 rap_sfcdiff_restart_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_gnu
-Checking test 186 hrrr_control_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_gnu
+Checking test 184 hrrr_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6090,15 +6055,15 @@ Checking test 186 hrrr_control_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 688.285809
-0:The maximum resident set size (KB)                   = 788460
+0:The total amount of wall time                        = 683.711795
+0:The maximum resident set size (KB)                   = 788472
 
-Test 186 hrrr_control_gnu PASS
+Test 184 hrrr_control_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_qr_gnu
-Checking test 187 hrrr_control_qr_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_qr_gnu
+Checking test 185 hrrr_control_qr_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6144,15 +6109,15 @@ Checking test 187 hrrr_control_qr_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 685.264501
-0:The maximum resident set size (KB)                   = 801844
+0:The total amount of wall time                        = 687.379858
+0:The maximum resident set size (KB)                   = 801820
 
-Test 187 hrrr_control_qr_gnu PASS
+Test 185 hrrr_control_qr_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_2threads_gnu
-Checking test 188 hrrr_control_2threads_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_2threads_gnu
+Checking test 186 hrrr_control_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6198,15 +6163,15 @@ Checking test 188 hrrr_control_2threads_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 706.629727
-0:The maximum resident set size (KB)                   = 854924
+0:The total amount of wall time                        = 706.600208
+0:The maximum resident set size (KB)                   = 855004
 
-Test 188 hrrr_control_2threads_gnu PASS
+Test 186 hrrr_control_2threads_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_decomp_gnu
-Checking test 189 hrrr_control_decomp_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_decomp_gnu
+Checking test 187 hrrr_control_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6252,43 +6217,43 @@ Checking test 189 hrrr_control_decomp_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 682.121750
-0:The maximum resident set size (KB)                   = 787908
+0:The total amount of wall time                        = 684.098014
+0:The maximum resident set size (KB)                   = 788000
 
-Test 189 hrrr_control_decomp_gnu PASS
+Test 187 hrrr_control_decomp_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_gnu
-Checking test 190 hrrr_control_restart_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_gnu
+Checking test 188 hrrr_control_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 508.834933
-0:The maximum resident set size (KB)                   = 538804
+0:The total amount of wall time                        = 509.159544
+0:The maximum resident set size (KB)                   = 538864
 
-Test 190 hrrr_control_restart_gnu PASS
+Test 188 hrrr_control_restart_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_qr_gnu
-Checking test 191 hrrr_control_restart_qr_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_qr_gnu
+Checking test 189 hrrr_control_restart_qr_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 515.794276
-0:The maximum resident set size (KB)                   = 568908
+0:The total amount of wall time                        = 517.836090
+0:The maximum resident set size (KB)                   = 568896
 
-Test 191 hrrr_control_restart_qr_gnu PASS
+Test 189 hrrr_control_restart_qr_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_v1beta_gnu
-Checking test 192 rrfs_v1beta_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_v1beta_gnu
+Checking test 190 rrfs_v1beta_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6334,15 +6299,15 @@ Checking test 192 rrfs_v1beta_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 693.301810
-0:The maximum resident set size (KB)                   = 788380
+0:The total amount of wall time                        = 697.817788
+0:The maximum resident set size (KB)                   = 788396
 
-Test 192 rrfs_v1beta_gnu PASS
+Test 190 rrfs_v1beta_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_gnu
-Checking test 193 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_gnu
+Checking test 191 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -6357,15 +6322,47 @@ Checking test 193 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 239.824686
-0:The maximum resident set size (KB)                   = 638664
+0:The total amount of wall time                        = 240.626985
+0:The maximum resident set size (KB)                   = 638264
 
-Test 193 rrfs_smoke_conus13km_hrrr_warm_gnu PASS
+Test 191 rrfs_smoke_conus13km_hrrr_warm_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_qr_gnu
-Checking test 194 rrfs_smoke_conus13km_hrrr_warm_qr_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
+Checking test 192 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+0:The total amount of wall time                        = 150.430466
+0:The maximum resident set size (KB)                   = 662820
+
+Test 192 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_radar_tten_warm_gnu
+Checking test 193 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+0:The total amount of wall time                        = 241.018145
+0:The maximum resident set size (KB)                   = 641036
+
+Test 193 rrfs_smoke_conus13km_radar_tten_warm_gnu PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_conus13km_hrrr_warm_gnu
+Checking test 194 rrfs_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -6380,330 +6377,263 @@ Checking test 194 rrfs_smoke_conus13km_hrrr_warm_qr_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 239.507658
-0:The maximum resident set size (KB)                   = 638296
+0:The total amount of wall time                        = 217.213715
+0:The maximum resident set size (KB)                   = 613248
 
-Test 194 rrfs_smoke_conus13km_hrrr_warm_qr_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
-Checking test 195 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-0:The total amount of wall time                        = 149.553069
-0:The maximum resident set size (KB)                   = 662772
-
-Test 195 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu PASS
+Test 194 rrfs_conus13km_hrrr_warm_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_radar_tten_warm_gnu
-Checking test 196 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-0:The total amount of wall time                        = 240.421000
-0:The maximum resident set size (KB)                   = 641056
-
-Test 196 rrfs_smoke_conus13km_radar_tten_warm_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_conus13km_hrrr_warm_gnu
-Checking test 197 rrfs_conus13km_hrrr_warm_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-0:The total amount of wall time                        = 219.860304
-0:The maximum resident set size (KB)                   = 613236
-
-Test 197 rrfs_conus13km_hrrr_warm_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-Checking test 198 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
+Checking test 195 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 132.510024
-0:The maximum resident set size (KB)                   = 613524
+0:The total amount of wall time                        = 132.425684
+0:The maximum resident set size (KB)                   = 613536
 
-Test 198 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_gnu
-Checking test 199 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_gnu results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-0:The total amount of wall time                        = 131.757216
-0:The maximum resident set size (KB)                   = 613488
-
-Test 199 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_gnu PASS
+Test 195 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_diag_debug_gnu
-Checking test 200 control_diag_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_diag_debug_gnu
+Checking test 196 control_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 81.666355
-0:The maximum resident set size (KB)                   = 491568
+0:The total amount of wall time                        = 82.003280
+0:The maximum resident set size (KB)                   = 492088
 
-Test 200 control_diag_debug_gnu PASS
+Test 196 control_diag_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/regional_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/regional_debug_gnu
-Checking test 201 regional_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/regional_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/regional_debug_gnu
+Checking test 197 regional_debug_gnu results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 471.526329
-0:The maximum resident set size (KB)                   = 566868
+0:The total amount of wall time                        = 472.428282
+0:The maximum resident set size (KB)                   = 566852
 
-Test 201 regional_debug_gnu PASS
+Test 197 regional_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_debug_gnu
-Checking test 202 rap_control_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_debug_gnu
+Checking test 198 rap_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 143.575732
-0:The maximum resident set size (KB)                   = 805800
+0:The total amount of wall time                        = 143.954131
+0:The maximum resident set size (KB)                   = 805784
 
-Test 202 rap_control_debug_gnu PASS
+Test 198 rap_control_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_debug_gnu
-Checking test 203 hrrr_control_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_debug_gnu
+Checking test 199 hrrr_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 140.240855
-0:The maximum resident set size (KB)                   = 801160
+0:The total amount of wall time                        = 140.532721
+0:The maximum resident set size (KB)                   = 801080
 
-Test 203 hrrr_control_debug_gnu PASS
+Test 199 hrrr_control_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_diag_debug_gnu
-Checking test 204 rap_diag_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_diag_debug_gnu
+Checking test 200 rap_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 149.913085
-0:The maximum resident set size (KB)                   = 888860
+0:The total amount of wall time                        = 151.149089
+0:The maximum resident set size (KB)                   = 888908
 
-Test 204 rap_diag_debug_gnu PASS
+Test 200 rap_diag_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_noah_sfcdiff_cires_ugwp_debug_gnu
-Checking test 205 rap_noah_sfcdiff_cires_ugwp_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_noah_sfcdiff_cires_ugwp_debug_gnu
+Checking test 201 rap_noah_sfcdiff_cires_ugwp_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 231.006897
-0:The maximum resident set size (KB)                   = 804164
+0:The total amount of wall time                        = 231.516438
+0:The maximum resident set size (KB)                   = 804384
 
-Test 205 rap_noah_sfcdiff_cires_ugwp_debug_gnu PASS
+Test 201 rap_noah_sfcdiff_cires_ugwp_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_progcld_thompson_debug_gnu
-Checking test 206 rap_progcld_thompson_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_progcld_thompson_debug_gnu
+Checking test 202 rap_progcld_thompson_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 142.978312
-0:The maximum resident set size (KB)                   = 805772
+0:The total amount of wall time                        = 143.971493
+0:The maximum resident set size (KB)                   = 805748
 
-Test 206 rap_progcld_thompson_debug_gnu PASS
+Test 202 rap_progcld_thompson_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_v1beta_debug_gnu
-Checking test 207 rrfs_v1beta_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_v1beta_debug_gnu
+Checking test 203 rrfs_v1beta_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 142.398359
-0:The maximum resident set size (KB)                   = 800824
+0:The total amount of wall time                        = 142.636504
+0:The maximum resident set size (KB)                   = 800880
 
-Test 207 rrfs_v1beta_debug_gnu PASS
+Test 203 rrfs_v1beta_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_ras_debug_gnu
-Checking test 208 control_ras_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_ras_debug_gnu
+Checking test 204 control_ras_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 79.293519
-0:The maximum resident set size (KB)                   = 446140
+0:The total amount of wall time                        = 80.157216
+0:The maximum resident set size (KB)                   = 446312
 
-Test 208 control_ras_debug_gnu PASS
+Test 204 control_ras_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_stochy_debug_gnu
-Checking test 209 control_stochy_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_stochy_debug_gnu
+Checking test 205 control_stochy_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 87.100799
-0:The maximum resident set size (KB)                   = 438516
+0:The total amount of wall time                        = 87.544508
+0:The maximum resident set size (KB)                   = 438520
 
-Test 209 control_stochy_debug_gnu PASS
+Test 205 control_stochy_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_debug_p8_gnu
-Checking test 210 control_debug_p8_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_debug_p8_gnu
+Checking test 206 control_debug_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.100910
-0:The maximum resident set size (KB)                   = 1221220
+0:The total amount of wall time                        = 89.255173
+0:The maximum resident set size (KB)                   = 1221124
 
-Test 210 control_debug_p8_gnu PASS
+Test 206 control_debug_p8_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-Checking test 211 rrfs_smoke_conus13km_hrrr_warm_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+Checking test 207 rrfs_smoke_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 440.792167
-0:The maximum resident set size (KB)                   = 643824
+0:The total amount of wall time                        = 439.167491
+0:The maximum resident set size (KB)                   = 643736
 
-Test 211 rrfs_smoke_conus13km_hrrr_warm_debug_gnu PASS
+Test 207 rrfs_smoke_conus13km_hrrr_warm_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
-Checking test 212 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
+Checking test 208 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 255.633261
-0:The maximum resident set size (KB)                   = 668448
+0:The total amount of wall time                        = 257.289509
+0:The maximum resident set size (KB)                   = 668412
 
-Test 212 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu PASS
+Test 208 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rrfs_conus13km_hrrr_warm_debug_gnu
-Checking test 213 rrfs_conus13km_hrrr_warm_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rrfs_conus13km_hrrr_warm_debug_gnu
+Checking test 209 rrfs_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 397.823310
-0:The maximum resident set size (KB)                   = 617960
+0:The total amount of wall time                        = 397.504638
+0:The maximum resident set size (KB)                   = 618280
 
-Test 213 rrfs_conus13km_hrrr_warm_debug_gnu PASS
+Test 209 rrfs_conus13km_hrrr_warm_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_flake_debug_gnu
-Checking test 214 rap_flake_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_flake_debug_gnu
+Checking test 210 rap_flake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 143.752694
-0:The maximum resident set size (KB)                   = 805624
+0:The total amount of wall time                        = 143.227486
+0:The maximum resident set size (KB)                   = 805508
 
-Test 214 rap_flake_debug_gnu PASS
+Test 210 rap_flake_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_clm_lake_debug_gnu
-Checking test 215 rap_clm_lake_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_clm_lake_debug_gnu
+Checking test 211 rap_clm_lake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 162.462411
-0:The maximum resident set size (KB)                   = 807272
+0:The total amount of wall time                        = 162.872046
+0:The maximum resident set size (KB)                   = 807336
 
-Test 215 rap_clm_lake_debug_gnu PASS
+Test 211 rap_clm_lake_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/control_wam_debug_gnu
-Checking test 216 control_wam_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/control_wam_debug_gnu
+Checking test 212 control_wam_debug_gnu results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 140.117344
-0:The maximum resident set size (KB)                   = 182312
+0:The total amount of wall time                        = 140.692110
+0:The maximum resident set size (KB)                   = 182824
 
-Test 216 control_wam_debug_gnu PASS
+Test 212 control_wam_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_dyn32_phy32_gnu
-Checking test 217 rap_control_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_dyn32_phy32_gnu
+Checking test 213 rap_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6749,15 +6679,15 @@ Checking test 217 rap_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 697.083081
-0:The maximum resident set size (KB)                   = 672260
+0:The total amount of wall time                        = 699.184894
+0:The maximum resident set size (KB)                   = 672200
 
-Test 217 rap_control_dyn32_phy32_gnu PASS
+Test 213 rap_control_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_dyn32_phy32_gnu
-Checking test 218 hrrr_control_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_dyn32_phy32_gnu
+Checking test 214 hrrr_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6803,15 +6733,15 @@ Checking test 218 hrrr_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 349.676198
-0:The maximum resident set size (KB)                   = 670760
+0:The total amount of wall time                        = 352.848704
+0:The maximum resident set size (KB)                   = 670748
 
-Test 218 hrrr_control_dyn32_phy32_gnu PASS
+Test 214 hrrr_control_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_qr_dyn32_phy32_gnu
-Checking test 219 hrrr_control_qr_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_qr_dyn32_phy32_gnu
+Checking test 215 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6857,15 +6787,15 @@ Checking test 219 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 351.497935
-0:The maximum resident set size (KB)                   = 681212
+0:The total amount of wall time                        = 352.921819
+0:The maximum resident set size (KB)                   = 681120
 
-Test 219 hrrr_control_qr_dyn32_phy32_gnu PASS
+Test 215 hrrr_control_qr_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_2threads_dyn32_phy32_gnu
-Checking test 220 rap_2threads_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_2threads_dyn32_phy32_gnu
+Checking test 216 rap_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6911,15 +6841,15 @@ Checking test 220 rap_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 636.802615
-0:The maximum resident set size (KB)                   = 719660
+0:The total amount of wall time                        = 634.958674
+0:The maximum resident set size (KB)                   = 719732
 
-Test 220 rap_2threads_dyn32_phy32_gnu PASS
+Test 216 rap_2threads_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_2threads_dyn32_phy32_gnu
-Checking test 221 hrrr_control_2threads_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_2threads_dyn32_phy32_gnu
+Checking test 217 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6965,15 +6895,15 @@ Checking test 221 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 403.638151
-0:The maximum resident set size (KB)                   = 710872
+0:The total amount of wall time                        = 403.451916
+0:The maximum resident set size (KB)                   = 710876
 
-Test 221 hrrr_control_2threads_dyn32_phy32_gnu PASS
+Test 217 hrrr_control_2threads_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_decomp_dyn32_phy32_gnu
-Checking test 222 hrrr_control_decomp_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_decomp_dyn32_phy32_gnu
+Checking test 218 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7019,15 +6949,15 @@ Checking test 222 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 350.983291
-0:The maximum resident set size (KB)                   = 669596
+0:The total amount of wall time                        = 348.965817
+0:The maximum resident set size (KB)                   = 669620
 
-Test 222 hrrr_control_decomp_dyn32_phy32_gnu PASS
+Test 218 hrrr_control_decomp_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_restart_dyn32_phy32_gnu
-Checking test 223 rap_restart_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_restart_dyn32_phy32_gnu
+Checking test 219 rap_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -7065,43 +6995,43 @@ Checking test 223 rap_restart_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 519.340413
-0:The maximum resident set size (KB)                   = 509132
+0:The total amount of wall time                        = 520.638010
+0:The maximum resident set size (KB)                   = 508928
 
-Test 223 rap_restart_dyn32_phy32_gnu PASS
+Test 219 rap_restart_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_dyn32_phy32_gnu
-Checking test 224 hrrr_control_restart_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_dyn32_phy32_gnu
+Checking test 220 hrrr_control_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 178.918204
-0:The maximum resident set size (KB)                   = 503264
+0:The total amount of wall time                        = 178.918889
+0:The maximum resident set size (KB)                   = 503292
 
-Test 224 hrrr_control_restart_dyn32_phy32_gnu PASS
+Test 220 hrrr_control_restart_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_restart_qr_dyn32_phy32_gnu
-Checking test 225 hrrr_control_restart_qr_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_restart_qr_dyn32_phy32_gnu
+Checking test 221 hrrr_control_restart_qr_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 181.720522
-0:The maximum resident set size (KB)                   = 531212
+0:The total amount of wall time                        = 182.008422
+0:The maximum resident set size (KB)                   = 531204
 
-Test 225 hrrr_control_restart_qr_dyn32_phy32_gnu PASS
+Test 221 hrrr_control_restart_qr_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_dyn64_phy32_gnu
-Checking test 226 rap_control_dyn64_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_dyn64_phy32_gnu
+Checking test 222 rap_control_dyn64_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7147,57 +7077,57 @@ Checking test 226 rap_control_dyn64_phy32_gnu results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 412.089184
-0:The maximum resident set size (KB)                   = 693580
+0:The total amount of wall time                        = 408.522470
+0:The maximum resident set size (KB)                   = 692608
 
-Test 226 rap_control_dyn64_phy32_gnu PASS
+Test 222 rap_control_dyn64_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_debug_dyn32_phy32_gnu
-Checking test 227 rap_control_debug_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_debug_dyn32_phy32_gnu
+Checking test 223 rap_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 142.966688
-0:The maximum resident set size (KB)                   = 686532
+0:The total amount of wall time                        = 142.938706
+0:The maximum resident set size (KB)                   = 686868
 
-Test 227 rap_control_debug_dyn32_phy32_gnu PASS
+Test 223 rap_control_debug_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/hrrr_control_debug_dyn32_phy32_gnu
-Checking test 228 hrrr_control_debug_dyn32_phy32_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/hrrr_control_debug_dyn32_phy32_gnu
+Checking test 224 hrrr_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 139.725775
-0:The maximum resident set size (KB)                   = 683924
+0:The total amount of wall time                        = 139.952583
+0:The maximum resident set size (KB)                   = 684028
 
-Test 228 hrrr_control_debug_dyn32_phy32_gnu PASS
+Test 224 hrrr_control_debug_dyn32_phy32_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/rap_control_dyn64_phy32_debug_gnu
-Checking test 229 rap_control_dyn64_phy32_debug_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/rap_control_dyn64_phy32_debug_gnu
+Checking test 225 rap_control_dyn64_phy32_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 147.876312
-0:The maximum resident set size (KB)                   = 707904
+0:The total amount of wall time                        = 147.937970
+0:The maximum resident set size (KB)                   = 707768
 
-Test 229 rap_control_dyn64_phy32_debug_gnu PASS
+Test 225 rap_control_dyn64_phy32_debug_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_p8_gnu
-Checking test 230 cpld_control_p8_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_p8_gnu
+Checking test 226 cpld_control_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -7261,15 +7191,15 @@ Checking test 230 cpld_control_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 487.748450
-0:The maximum resident set size (KB)                   = 3160428
+0:The total amount of wall time                        = 489.260445
+0:The maximum resident set size (KB)                   = 3158748
 
-Test 230 cpld_control_p8_gnu PASS
+Test 226 cpld_control_p8_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_nowave_noaero_p8_gnu
-Checking test 231 cpld_control_nowave_noaero_p8_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_nowave_noaero_p8_gnu
+Checking test 227 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -7330,15 +7260,15 @@ Checking test 231 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 240.243980
-0:The maximum resident set size (KB)                   = 1244384
+0:The total amount of wall time                        = 246.727569
+0:The maximum resident set size (KB)                   = 1239924
 
-Test 231 cpld_control_nowave_noaero_p8_gnu PASS
+Test 227 cpld_control_nowave_noaero_p8_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_debug_p8_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_debug_p8_gnu
-Checking test 232 cpld_debug_p8_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_debug_p8_gnu
+Checking test 228 cpld_debug_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
  Comparing sfcf003.tile3.nc .........OK
@@ -7390,15 +7320,15 @@ Checking test 232 cpld_debug_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 196.361484
-0:The maximum resident set size (KB)                   = 3172300
+0:The total amount of wall time                        = 199.159924
+0:The maximum resident set size (KB)                   = 3172848
 
-Test 232 cpld_debug_p8_gnu PASS
+Test 228 cpld_debug_p8_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_control_pdlib_p8_gnu
-Checking test 233 cpld_control_pdlib_p8_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_control_pdlib_p8_gnu
+Checking test 229 cpld_control_pdlib_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -7461,15 +7391,15 @@ Checking test 233 cpld_control_pdlib_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1374.484362
-0:The maximum resident set size (KB)                   = 1430704
+0:The total amount of wall time                        = 1387.020784
+0:The maximum resident set size (KB)                   = 1431836
 
-Test 233 cpld_control_pdlib_p8_gnu PASS
+Test 229 cpld_control_pdlib_p8_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/cpld_debug_pdlib_p8_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/cpld_debug_pdlib_p8_gnu
-Checking test 234 cpld_debug_pdlib_p8_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/cpld_debug_pdlib_p8_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/cpld_debug_pdlib_p8_gnu
+Checking test 230 cpld_debug_pdlib_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
  Comparing sfcf003.tile3.nc .........OK
@@ -7520,25 +7450,114 @@ Checking test 234 cpld_debug_pdlib_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 690.428868
-0:The maximum resident set size (KB)                   = 1298304
+0:The total amount of wall time                        = 692.547027
+0:The maximum resident set size (KB)                   = 1298340
 
-Test 234 cpld_debug_pdlib_p8_gnu PASS
+Test 230 cpld_debug_pdlib_p8_gnu PASS
 
 
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_gnu
-working dir  = /glade/scratch/zshrader/FV3_RT/rt_38115/datm_cdeps_control_cfsr_gnu
-Checking test 235 datm_cdeps_control_cfsr_gnu results ....
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_gnu
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_40914/datm_cdeps_control_cfsr_gnu
+Checking test 231 datm_cdeps_control_cfsr_gnu results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 173.147792
-0:The maximum resident set size (KB)                   = 669548
+0:The total amount of wall time                        = 173.937932
+0:The maximum resident set size (KB)                   = 674568
 
-Test 235 datm_cdeps_control_cfsr_gnu PASS
+Test 231 datm_cdeps_control_cfsr_gnu PASS
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /glade/scratch/zshrader/FV3_RT/rt_22295/hafs_global_multiple_4nests_atm_intel
+Checking test 001 hafs_global_multiple_4nests_atm_intel results ....
+Moving baseline 001 hafs_global_multiple_4nests_atm_intel files ....
+ Moving atmf006.nc .........OK
+ Moving sfcf006.nc .........OK
+ Moving atm.nest02.f006.nc .........OK
+ Moving sfc.nest02.f006.nc .........OK
+ Moving atm.nest03.f006.nc .........OK
+ Moving sfc.nest03.f006.nc .........OK
+ Moving atm.nest04.f006.nc .........OK
+ Moving sfc.nest04.f006.nc .........OK
+ Moving atm.nest05.f006.nc .........OK
+ Moving sfc.nest05.f006.nc .........OK
+ Moving HURPRS.GrbF06 .........OK
+ Moving HURPRS.GrbF06.nest02 .........OK
+ Moving HURPRS.GrbF06.nest03 .........OK
+ Moving HURPRS.GrbF06.nest04 .........OK
+ Moving HURPRS.GrbF06.nest05 .........OK
+ Moving RESTART/20200825.180000.coupler.res .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest02.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest02.tile7.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest03.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest03.tile8.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest04.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest04.tile9.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest05.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.nest05.tile10.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.tile1.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.tile2.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.tile3.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.tile4.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.tile5.nc .........OK
+ Moving RESTART/20200825.180000.fv_core.res.tile6.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.nest02.tile7.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.nest03.tile8.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.nest04.tile9.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.nest05.tile10.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.tile1.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.tile2.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.tile3.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.tile4.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.tile5.nc .........OK
+ Moving RESTART/20200825.180000.fv_srf_wnd.res.tile6.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.nest02.tile7.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.nest03.tile8.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.nest04.tile9.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.nest05.tile10.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.tile1.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.tile2.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.tile3.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.tile4.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.tile5.nc .........OK
+ Moving RESTART/20200825.180000.fv_tracer.res.tile6.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.nest02.tile7.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.nest03.tile8.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.nest04.tile9.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.nest05.tile10.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.tile1.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.tile2.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.tile3.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.tile4.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.tile5.nc .........OK
+ Moving RESTART/20200825.180000.phy_data.tile6.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.nest02.tile7.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.nest03.tile8.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.nest04.tile9.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.nest05.tile10.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.tile1.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.tile2.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.tile3.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.tile4.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.tile5.nc .........OK
+ Moving RESTART/20200825.180000.sfc_data.tile6.nc .........OK
+ Moving RESTART/fv_BC_ne.res.nest02.nc .........OK
+ Moving RESTART/fv_BC_ne.res.nest03.nc .........OK
+ Moving RESTART/fv_BC_ne.res.nest04.nc .........OK
+ Moving RESTART/fv_BC_ne.res.nest05.nc .........OK
+ Moving RESTART/fv_BC_sw.res.nest02.nc .........OK
+ Moving RESTART/fv_BC_sw.res.nest03.nc .........OK
+ Moving RESTART/fv_BC_sw.res.nest04.nc .........OK
+ Moving RESTART/fv_BC_sw.res.nest05.nc .........OK
+
+0:The total amount of wall time                        = 454.051259
+0:The maximum resident set size (KB)                   = 301896
+
+Test 001 hafs_global_multiple_4nests_atm_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 16 22:40:51 MDT 2023
-Elapsed time: 01h:39m:10s. Have a nice day!
+Fri Jun 23 07:41:38 MDT 2023
+Elapsed time: 00h:29m:57s. Have a nice day!

--- a/tests/logs/RegressionTests_gaea.log
+++ b/tests/logs/RegressionTests_gaea.log
@@ -1,56 +1,56 @@
-Fri 16 Jun 2023 04:53:58 PM EDT
+Fri 23 Jun 2023 04:19:31 PM EDT
 Start Regression test
 
-Testing UFSWM Hash: cf35d10cc851f55af57a5d786ae2f025aa8a20f2
+Testing UFSWM Hash: 0d2c766542ce6aee569e2dd163be6b4b3c052001
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
+ f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 864 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 872 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 852 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 304 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 280 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 781 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 800 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 949 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 805 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 740 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 724 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 613 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 808 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 274 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 644 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 718 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 209 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 193 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 730 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 227 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 897 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 711 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 248 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 151 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 241 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 79 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 699 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 684 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 681 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 644 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 634 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 037 elapsed time 731 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 947 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1000 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 869 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 399 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 356 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 852 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 852 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1030 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 852 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 794 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 681 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 657 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 806 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 291 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 706 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 656 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 241 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 760 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 251 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 875 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 721 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 270 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 028 elapsed time 142 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 271 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 84 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 687 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 705 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 701 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 717 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 647 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 037 elapsed time 720 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_mixedmode_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_p8_mixedmode_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -115,14 +115,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 315.493899
-  0: The maximum resident set size (KB)                   = 1532300
+  0: The total amount of wall time                        = 315.891466
+  0: The maximum resident set size (KB)                   = 1531948
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_gfsv17_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_gfsv17_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -186,14 +186,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 228.075723
-  0: The maximum resident set size (KB)                   = 1449088
+  0: The total amount of wall time                        = 227.463938
+  0: The maximum resident set size (KB)                   = 1448664
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -258,14 +258,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 356.448756
-  0: The maximum resident set size (KB)                   = 1566788
+  0: The total amount of wall time                        = 356.747029
+  0: The maximum resident set size (KB)                   = 1566344
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_restart_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -318,14 +318,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 205.511551
-  0: The maximum resident set size (KB)                   = 1282176
+  0: The total amount of wall time                        = 205.060663
+  0: The maximum resident set size (KB)                   = 1282360
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_qr_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -390,14 +390,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 358.180115
-  0: The maximum resident set size (KB)                   = 1578024
+  0: The total amount of wall time                        = 358.314411
+  0: The maximum resident set size (KB)                   = 1577760
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_restart_qr_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -450,14 +450,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 205.745407
-  0: The maximum resident set size (KB)                   = 1295156
+  0: The total amount of wall time                        = 207.853616
+  0: The maximum resident set size (KB)                   = 1295176
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_2threads_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -510,14 +510,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 370.804923
-  0: The maximum resident set size (KB)                   = 1756948
+  0: The total amount of wall time                        = 370.822155
+  0: The maximum resident set size (KB)                   = 1756928
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_decomp_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -570,14 +570,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 356.447207
-  0: The maximum resident set size (KB)                   = 1559428
+  0: The total amount of wall time                        = 361.774128
+  0: The maximum resident set size (KB)                   = 1560048
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_mpi_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -630,14 +630,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 295.585593
-  0: The maximum resident set size (KB)                   = 1523252
+  0: The total amount of wall time                        = 293.606846
+  0: The maximum resident set size (KB)                   = 1523360
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_bmark_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_bmark_p8_intel
 Checking test 010 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -685,14 +685,14 @@ Checking test 010 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 716.981684
-   0: The maximum resident set size (KB)                   = 2497864
+   0: The total amount of wall time                        = 726.948383
+   0: The maximum resident set size (KB)                   = 2498368
 
 Test 010 cpld_bmark_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_restart_bmark_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_restart_bmark_p8_intel
 Checking test 011 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -740,14 +740,14 @@ Checking test 011 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 429.690087
-   0: The maximum resident set size (KB)                   = 2305588
+   0: The total amount of wall time                        = 429.046325
+   0: The maximum resident set size (KB)                   = 2328584
 
 Test 011 cpld_restart_bmark_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_noaero_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_noaero_p8_intel
 Checking test 012 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -811,14 +811,14 @@ Checking test 012 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 269.990201
-  0: The maximum resident set size (KB)                   = 1464364
+  0: The total amount of wall time                        = 271.595602
+  0: The maximum resident set size (KB)                   = 1464008
 
 Test 012 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_nowave_noaero_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_nowave_noaero_p8_intel
 Checking test 013 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -880,14 +880,14 @@ Checking test 013 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 277.120502
-  0: The maximum resident set size (KB)                   = 1502276
+  0: The total amount of wall time                        = 278.076292
+  0: The maximum resident set size (KB)                   = 1502392
 
 Test 013 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_debug_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_debug_p8_intel
 Checking test 014 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -940,14 +940,14 @@ Checking test 014 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 543.617129
-  0: The maximum resident set size (KB)                   = 1594684
+  0: The total amount of wall time                        = 544.845999
+  0: The maximum resident set size (KB)                   = 1595320
 
 Test 014 cpld_debug_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_debug_noaero_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_debug_noaero_p8_intel
 Checking test 015 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -999,14 +999,14 @@ Checking test 015 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 376.374835
-  0: The maximum resident set size (KB)                   = 1483488
+  0: The total amount of wall time                        = 376.631429
+  0: The maximum resident set size (KB)                   = 1483008
 
 Test 015 cpld_debug_noaero_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_agrid_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_noaero_p8_agrid_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_noaero_p8_agrid_intel
 Checking test 016 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1068,14 +1068,14 @@ Checking test 016 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 286.880460
-  0: The maximum resident set size (KB)                   = 1503000
+  0: The total amount of wall time                        = 286.417048
+  0: The maximum resident set size (KB)                   = 1503840
 
 Test 016 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c48_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_c48_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_c48_intel
 Checking test 017 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1125,14 +1125,14 @@ Checking test 017 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 598.853855
- 0: The maximum resident set size (KB)                   = 2560412
+ 0: The total amount of wall time                        = 599.387352
+ 0: The maximum resident set size (KB)                   = 2560432
 
 Test 017 cpld_control_c48_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_warmstart_c48_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_warmstart_c48_intel
 Checking test 018 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1182,14 +1182,14 @@ Checking test 018 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 158.144059
- 0: The maximum resident set size (KB)                   = 2563424
+ 0: The total amount of wall time                        = 158.494307
+ 0: The maximum resident set size (KB)                   = 2563736
 
 Test 018 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_restart_c48_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_restart_c48_intel
 Checking test 019 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1239,14 +1239,14 @@ Checking test 019 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 82.829348
- 0: The maximum resident set size (KB)                   = 1982124
+ 0: The total amount of wall time                        = 82.519235
+ 0: The maximum resident set size (KB)                   = 1982768
 
 Test 019 cpld_restart_c48_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_faster_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/cpld_control_p8_faster_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_faster_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/cpld_control_p8_faster_intel
 Checking test 020 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1311,14 +1311,14 @@ Checking test 020 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 346.594507
-  0: The maximum resident set size (KB)                   = 1565684
+  0: The total amount of wall time                        = 346.230720
+  0: The maximum resident set size (KB)                   = 1566156
 
 Test 020 cpld_control_p8_faster_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_flake_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_flake_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_flake_intel
 Checking test 021 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1329,14 +1329,14 @@ Checking test 021 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 204.116204
-  0: The maximum resident set size (KB)                   = 483472
+  0: The total amount of wall time                        = 204.734670
+  0: The maximum resident set size (KB)                   = 483500
 
 Test 021 control_flake_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_CubedSphereGrid_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_CubedSphereGrid_intel
 Checking test 022 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1363,28 +1363,28 @@ Checking test 022 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 133.641603
-  0: The maximum resident set size (KB)                   = 434940
+  0: The total amount of wall time                        = 133.722973
+  0: The maximum resident set size (KB)                   = 435188
 
 Test 022 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_parallel_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_CubedSphereGrid_parallel_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_parallel_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_CubedSphereGrid_parallel_intel
 Checking test 023 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 134.739835
-  0: The maximum resident set size (KB)                   = 434960
+  0: The total amount of wall time                        = 140.067810
+  0: The maximum resident set size (KB)                   = 435028
 
 Test 023 control_CubedSphereGrid_parallel_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_latlon_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_latlon_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_latlon_intel
 Checking test 024 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1395,14 +1395,14 @@ Checking test 024 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.053249
-  0: The maximum resident set size (KB)                   = 434680
+  0: The total amount of wall time                        = 137.094595
+  0: The maximum resident set size (KB)                   = 434832
 
 Test 024 control_latlon_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_wrtGauss_netcdf_parallel_intel
 Checking test 025 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 025 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.035740
-  0: The maximum resident set size (KB)                   = 435024
+  0: The total amount of wall time                        = 145.755794
+  0: The maximum resident set size (KB)                   = 434932
 
 Test 025 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c48_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_c48_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_c48_intel
 Checking test 026 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1459,14 +1459,14 @@ Checking test 026 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 417.655240
-0: The maximum resident set size (KB)                   = 631528
+0: The total amount of wall time                        = 418.017366
+0: The maximum resident set size (KB)                   = 632240
 
 Test 026 control_c48_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c192_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_c192_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_c192_intel
 Checking test 027 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1477,14 +1477,14 @@ Checking test 027 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 566.723953
-  0: The maximum resident set size (KB)                   = 541924
+  0: The total amount of wall time                        = 568.237579
+  0: The maximum resident set size (KB)                   = 542012
 
 Test 027 control_c192_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c384_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_c384_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_c384_intel
 Checking test 028 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1495,14 +1495,14 @@ Checking test 028 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1079.493061
-  0: The maximum resident set size (KB)                   = 821820
+  0: The total amount of wall time                        = 1080.214933
+  0: The maximum resident set size (KB)                   = 821864
 
 Test 028 control_c384_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c384gdas_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_c384gdas_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_c384gdas_intel
 Checking test 029 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1545,14 +1545,14 @@ Checking test 029 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 898.474271
-  0: The maximum resident set size (KB)                   = 954716
+  0: The total amount of wall time                        = 894.861330
+  0: The maximum resident set size (KB)                   = 954824
 
 Test 029 control_c384gdas_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_stochy_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_stochy_intel
 Checking test 030 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1563,28 +1563,28 @@ Checking test 030 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 90.599425
-  0: The maximum resident set size (KB)                   = 439172
+  0: The total amount of wall time                        = 90.874238
+  0: The maximum resident set size (KB)                   = 439348
 
 Test 030 control_stochy_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_stochy_restart_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_stochy_restart_intel
 Checking test 031 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.737119
+  0: The total amount of wall time                        = 48.907846
   0: The maximum resident set size (KB)                   = 193344
 
 Test 031 control_stochy_restart_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_lndp_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_lndp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_lndp_intel
 Checking test 032 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1595,14 +1595,14 @@ Checking test 032 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 83.860813
-  0: The maximum resident set size (KB)                   = 441792
+  0: The total amount of wall time                        = 84.203360
+  0: The maximum resident set size (KB)                   = 441676
 
 Test 032 control_lndp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_iovr4_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_iovr4_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_iovr4_intel
 Checking test 033 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1617,14 +1617,14 @@ Checking test 033 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.437312
-  0: The maximum resident set size (KB)                   = 434864
+  0: The total amount of wall time                        = 139.084724
+  0: The maximum resident set size (KB)                   = 434924
 
 Test 033 control_iovr4_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_iovr5_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_iovr5_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_iovr5_intel
 Checking test 034 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1639,14 +1639,14 @@ Checking test 034 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.482473
-  0: The maximum resident set size (KB)                   = 435020
+  0: The total amount of wall time                        = 139.314256
+  0: The maximum resident set size (KB)                   = 434964
 
 Test 034 control_iovr5_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_p8_intel
 Checking test 035 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1693,14 +1693,14 @@ Checking test 035 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.838758
-  0: The maximum resident set size (KB)                   = 1404160
+  0: The total amount of wall time                        = 168.942884
+  0: The maximum resident set size (KB)                   = 1404084
 
 Test 035 control_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_restart_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_restart_p8_intel
 Checking test 036 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1739,14 +1739,14 @@ Checking test 036 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.651385
-  0: The maximum resident set size (KB)                   = 564544
+  0: The total amount of wall time                        = 88.748846
+  0: The maximum resident set size (KB)                   = 564588
 
 Test 036 control_restart_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_qr_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_qr_p8_intel
 Checking test 037 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1793,14 +1793,14 @@ Checking test 037 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 169.869675
-  0: The maximum resident set size (KB)                   = 1407944
+  0: The total amount of wall time                        = 169.922886
+  0: The maximum resident set size (KB)                   = 1407924
 
 Test 037 control_qr_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_restart_qr_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_restart_qr_p8_intel
 Checking test 038 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1839,14 +1839,14 @@ Checking test 038 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 91.031228
-  0: The maximum resident set size (KB)                   = 579280
+  0: The total amount of wall time                        = 90.574726
+  0: The maximum resident set size (KB)                   = 579292
 
 Test 038 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_decomp_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_decomp_p8_intel
 Checking test 039 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1889,14 +1889,14 @@ Checking test 039 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 177.495497
-  0: The maximum resident set size (KB)                   = 1397692
+  0: The total amount of wall time                        = 175.415903
+  0: The maximum resident set size (KB)                   = 1397792
 
 Test 039 control_decomp_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_2threads_p8_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_2threads_p8_intel
 Checking test 040 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1939,14 +1939,14 @@ Checking test 040 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.536483
-  0: The maximum resident set size (KB)                   = 1486400
+  0: The total amount of wall time                        = 159.949195
+  0: The maximum resident set size (KB)                   = 1485068
 
 Test 040 control_2threads_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_lndp_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_p8_lndp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_p8_lndp_intel
 Checking test 041 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1965,14 +1965,14 @@ Checking test 041 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 322.578180
-  0: The maximum resident set size (KB)                   = 1405044
+  0: The total amount of wall time                        = 320.618158
+  0: The maximum resident set size (KB)                   = 1405088
 
 Test 041 control_p8_lndp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_rrtmgp_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_p8_rrtmgp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_p8_rrtmgp_intel
 Checking test 042 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2019,14 +2019,14 @@ Checking test 042 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.798763
-  0: The maximum resident set size (KB)                   = 1457972
+  0: The total amount of wall time                        = 231.099425
+  0: The maximum resident set size (KB)                   = 1458000
 
 Test 042 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_mynn_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_p8_mynn_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_p8_mynn_intel
 Checking test 043 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2073,14 +2073,14 @@ Checking test 043 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 173.571627
-  0: The maximum resident set size (KB)                   = 1409168
+  0: The total amount of wall time                        = 173.399656
+  0: The maximum resident set size (KB)                   = 1409164
 
 Test 043 control_p8_mynn_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/merra2_thompson_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/merra2_thompson_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/merra2_thompson_intel
 Checking test 044 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2127,14 +2127,14 @@ Checking test 044 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.659589
-  0: The maximum resident set size (KB)                   = 1407968
+  0: The total amount of wall time                        = 193.775580
+  0: The maximum resident set size (KB)                   = 1407892
 
 Test 044 merra2_thompson_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_control_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_control_intel
 Checking test 045 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2145,28 +2145,28 @@ Checking test 045 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 316.154277
-  0: The maximum resident set size (KB)                   = 574576
+  0: The total amount of wall time                        = 316.533998
+  0: The maximum resident set size (KB)                   = 574536
 
 Test 045 regional_control_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_restart_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_restart_intel
 Checking test 046 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 163.920105
-  0: The maximum resident set size (KB)                   = 576084
+  0: The total amount of wall time                        = 163.803143
+  0: The maximum resident set size (KB)                   = 576096
 
 Test 046 regional_restart_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_control_qr_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_control_qr_intel
 Checking test 047 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2177,28 +2177,28 @@ Checking test 047 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 315.538580
-  0: The maximum resident set size (KB)                   = 574528
+  0: The total amount of wall time                        = 315.674445
+  0: The maximum resident set size (KB)                   = 574496
 
 Test 047 regional_control_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_restart_qr_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_restart_qr_intel
 Checking test 048 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 164.060230
-  0: The maximum resident set size (KB)                   = 576120
+  0: The total amount of wall time                        = 164.004556
+  0: The maximum resident set size (KB)                   = 576116
 
 Test 048 regional_restart_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_decomp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_decomp_intel
 Checking test 049 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2209,14 +2209,14 @@ Checking test 049 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 334.759147
-  0: The maximum resident set size (KB)                   = 575696
+  0: The total amount of wall time                        = 333.669215
+  0: The maximum resident set size (KB)                   = 575712
 
 Test 049 regional_decomp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_2threads_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_2threads_intel
 Checking test 050 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2227,14 +2227,14 @@ Checking test 050 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 180.755886
-  0: The maximum resident set size (KB)                   = 583112
+  0: The total amount of wall time                        = 181.911853
+  0: The maximum resident set size (KB)                   = 583352
 
 Test 050 regional_2threads_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_noquilt_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_noquilt_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_noquilt_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_noquilt_intel
 Checking test 051 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2242,28 +2242,28 @@ Checking test 051 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 320.538766
-  0: The maximum resident set size (KB)                   = 568204
+  0: The total amount of wall time                        = 315.582690
+  0: The maximum resident set size (KB)                   = 568232
 
 Test 051 regional_noquilt_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_netcdf_parallel_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_netcdf_parallel_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_netcdf_parallel_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_netcdf_parallel_intel
 Checking test 052 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 315.320431
-  0: The maximum resident set size (KB)                   = 574396
+  0: The total amount of wall time                        = 322.930016
+  0: The maximum resident set size (KB)                   = 574440
 
 Test 052 regional_netcdf_parallel_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_2dwrtdecomp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_2dwrtdecomp_intel
 Checking test 053 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2274,14 +2274,14 @@ Checking test 053 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 321.924996
-  0: The maximum resident set size (KB)                   = 576156
+  0: The total amount of wall time                        = 322.254486
+  0: The maximum resident set size (KB)                   = 576152
 
 Test 053 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/fv3_regional_wofs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_wofs_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/fv3_regional_wofs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_wofs_intel
 Checking test 054 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2292,14 +2292,14 @@ Checking test 054 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 403.620303
-  0: The maximum resident set size (KB)                   = 259328
+  0: The total amount of wall time                        = 403.930546
+  0: The maximum resident set size (KB)                   = 259244
 
 Test 054 regional_wofs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_control_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_control_intel
 Checking test 055 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2346,14 +2346,14 @@ Checking test 055 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 450.900732
-  0: The maximum resident set size (KB)                   = 804812
+  0: The total amount of wall time                        = 451.322173
+  0: The maximum resident set size (KB)                   = 804824
 
 Test 055 rap_control_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_spp_sppt_shum_skeb_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_spp_sppt_shum_skeb_intel
 Checking test 056 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2364,14 +2364,14 @@ Checking test 056 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 251.699912
-  0: The maximum resident set size (KB)                   = 897184
+  0: The total amount of wall time                        = 250.895312
+  0: The maximum resident set size (KB)                   = 897312
 
 Test 056 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_decomp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_decomp_intel
 Checking test 057 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2418,14 +2418,14 @@ Checking test 057 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.528718
-  0: The maximum resident set size (KB)                   = 805072
+  0: The total amount of wall time                        = 464.373715
+  0: The maximum resident set size (KB)                   = 804952
 
 Test 057 rap_decomp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_2threads_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_2threads_intel
 Checking test 058 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2472,14 +2472,14 @@ Checking test 058 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 425.690835
-  0: The maximum resident set size (KB)                   = 875848
+  0: The total amount of wall time                        = 425.287644
+  0: The maximum resident set size (KB)                   = 879220
 
 Test 058 rap_2threads_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_restart_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_restart_intel
 Checking test 059 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2518,14 +2518,14 @@ Checking test 059 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.393361
-  0: The maximum resident set size (KB)                   = 545064
+  0: The total amount of wall time                        = 228.553054
+  0: The maximum resident set size (KB)                   = 545156
 
 Test 059 rap_restart_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_sfcdiff_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_sfcdiff_intel
 Checking test 060 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2572,14 +2572,14 @@ Checking test 060 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 450.909810
-  0: The maximum resident set size (KB)                   = 804708
+  0: The total amount of wall time                        = 449.908469
+  0: The maximum resident set size (KB)                   = 804428
 
 Test 060 rap_sfcdiff_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_sfcdiff_decomp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_sfcdiff_decomp_intel
 Checking test 061 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2626,14 +2626,14 @@ Checking test 061 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.803289
-  0: The maximum resident set size (KB)                   = 804860
+  0: The total amount of wall time                        = 464.713175
+  0: The maximum resident set size (KB)                   = 805008
 
 Test 061 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_sfcdiff_restart_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_sfcdiff_restart_intel
 Checking test 062 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2672,14 +2672,14 @@ Checking test 062 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 335.022039
-  0: The maximum resident set size (KB)                   = 549796
+  0: The total amount of wall time                        = 337.223553
+  0: The maximum resident set size (KB)                   = 549784
 
 Test 062 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_intel
 Checking test 063 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2695,9 +2695,9 @@ Checking test 063 hrrr_control_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
@@ -2707,7 +2707,7 @@ Checking test 063 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
@@ -2726,14 +2726,14 @@ Checking test 063 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 431.978537
-  0: The maximum resident set size (KB)                   = 802708
+  0: The total amount of wall time                        = 431.463815
+  0: The maximum resident set size (KB)                   = 802668
 
 Test 063 hrrr_control_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_qr_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_qr_intel
 Checking test 064 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2749,8 +2749,8 @@ Checking test 064 hrrr_control_qr_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
@@ -2780,14 +2780,14 @@ Checking test 064 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 430.917348
-  0: The maximum resident set size (KB)                   = 813560
+  0: The total amount of wall time                        = 431.700328
+  0: The maximum resident set size (KB)                   = 813616
 
 Test 064 hrrr_control_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_decomp_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_decomp_intel
 Checking test 065 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2803,9 +2803,9 @@ Checking test 065 hrrr_control_decomp_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
@@ -2815,7 +2815,7 @@ Checking test 065 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
@@ -2834,14 +2834,14 @@ Checking test 065 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 444.518043
-  0: The maximum resident set size (KB)                   = 802012
+  0: The total amount of wall time                        = 445.385147
+  0: The maximum resident set size (KB)                   = 802188
 
 Test 065 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_2threads_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_2threads_intel
 Checking test 066 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2857,9 +2857,9 @@ Checking test 066 hrrr_control_2threads_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
@@ -2869,7 +2869,7 @@ Checking test 066 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
@@ -2888,42 +2888,42 @@ Checking test 066 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 397.998773
-  0: The maximum resident set size (KB)                   = 876240
+  0: The total amount of wall time                        = 398.043430
+  0: The maximum resident set size (KB)                   = 876376
 
 Test 066 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_restart_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_restart_intel
 Checking test 067 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 320.871075
-  0: The maximum resident set size (KB)                   = 544452
+  0: The total amount of wall time                        = 320.291316
+  0: The maximum resident set size (KB)                   = 544516
 
 Test 067 hrrr_control_restart_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_restart_qr_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_restart_qr_intel
 Checking test 068 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 323.494632
-  0: The maximum resident set size (KB)                   = 565580
+  0: The total amount of wall time                        = 323.200165
+  0: The maximum resident set size (KB)                   = 565592
 
 Test 068 hrrr_control_restart_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_v1beta_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_v1beta_intel
 Checking test 069 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2970,14 +2970,14 @@ Checking test 069 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 442.592039
-  0: The maximum resident set size (KB)                   = 801600
+  0: The total amount of wall time                        = 441.156429
+  0: The maximum resident set size (KB)                   = 801532
 
 Test 069 rrfs_v1beta_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_v1nssl_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_v1nssl_intel
 Checking test 070 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2992,14 +2992,14 @@ Checking test 070 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 545.142152
-  0: The maximum resident set size (KB)                   = 490856
+  0: The total amount of wall time                        = 546.508570
+  0: The maximum resident set size (KB)                   = 490788
 
 Test 070 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_v1nssl_nohailnoccn_intel
 Checking test 071 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3014,14 +3014,14 @@ Checking test 071 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 529.450881
+  0: The total amount of wall time                        = 530.719728
   0: The maximum resident set size (KB)                   = 485024
 
 Test 071 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 072 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3037,15 +3037,31 @@ Checking test 072 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 149.459097
-  0: The maximum resident set size (KB)                   = 647452
+  0: The total amount of wall time                        = 149.205408
+  0: The maximum resident set size (KB)                   = 647468
 
 Test 072 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_hrrr_warm_qr_intel
-Checking test 073 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+Checking test 073 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 92.030762
+  0: The maximum resident set size (KB)                   = 662552
+
+Test 073 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
+
+
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_conus13km_hrrr_warm_intel
+Checking test 074 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3060,15 +3076,15 @@ Checking test 073 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 149.943347
-  0: The maximum resident set size (KB)                   = 647376
+  0: The total amount of wall time                        = 132.674637
+  0: The maximum resident set size (KB)                   = 632460
 
-Test 073 rrfs_smoke_conus13km_hrrr_warm_qr_intel PASS
+Test 074 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
-Checking test 074 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_smoke_conus13km_radar_tten_warm_intel
+Checking test 075 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3076,78 +3092,27 @@ Checking test 074 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 92.258035
-  0: The maximum resident set size (KB)                   = 663032
+  0: The total amount of wall time                        = 149.992508
+  0: The maximum resident set size (KB)                   = 650268
 
-Test 074 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_conus13km_hrrr_warm_intel
-Checking test 075 rrfs_conus13km_hrrr_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-  0: The total amount of wall time                        = 132.865067
-  0: The maximum resident set size (KB)                   = 632480
-
-Test 075 rrfs_conus13km_hrrr_warm_intel PASS
+Test 075 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_radar_tten_warm_intel
-Checking test 076 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 150.052635
-  0: The maximum resident set size (KB)                   = 650200
-
-Test 076 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-Checking test 077 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+Checking test 076 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 83.075866
-  0: The maximum resident set size (KB)                   = 639688
+  0: The total amount of wall time                        = 83.172015
+  0: The maximum resident set size (KB)                   = 639696
 
-Test 077 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
-
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel
-Checking test 078 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 83.309539
-  0: The maximum resident set size (KB)                   = 639652
-
-Test 078 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel PASS
+Test 076 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_csawmgt_intel
-Checking test 079 control_csawmgt_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_csawmgt_intel
+Checking test 077 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3157,15 +3122,15 @@ Checking test 079 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 361.413930
-  0: The maximum resident set size (KB)                   = 501020
+  0: The total amount of wall time                        = 361.439642
+  0: The maximum resident set size (KB)                   = 501064
 
-Test 079 control_csawmgt_intel PASS
+Test 077 control_csawmgt_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_ras_intel
-Checking test 080 control_ras_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_ras_intel
+Checking test 078 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3175,27 +3140,27 @@ Checking test 080 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.127524
-  0: The maximum resident set size (KB)                   = 470604
+  0: The total amount of wall time                        = 192.757443
+  0: The maximum resident set size (KB)                   = 470264
 
-Test 080 control_ras_intel PASS
+Test 078 control_ras_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wam_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_wam_intel
-Checking test 081 control_wam_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_wam_intel
+Checking test 079 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 121.419746
-  0: The maximum resident set size (KB)                   = 186528
+  0: The total amount of wall time                        = 121.312682
+  0: The maximum resident set size (KB)                   = 186488
 
-Test 081 control_wam_intel PASS
+Test 079 control_wam_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_faster_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_p8_faster_intel
-Checking test 082 control_p8_faster_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_p8_faster_intel
+Checking test 080 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3241,15 +3206,15 @@ Checking test 082 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 160.438569
-  0: The maximum resident set size (KB)                   = 1403992
+  0: The total amount of wall time                        = 160.351224
+  0: The maximum resident set size (KB)                   = 1404064
 
-Test 082 control_p8_faster_intel PASS
+Test 080 control_p8_faster_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_faster_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_control_faster_intel
-Checking test 083 regional_control_faster_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_control_faster_intel
+Checking test 081 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3259,57 +3224,57 @@ Checking test 083 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 295.902916
-  0: The maximum resident set size (KB)                   = 574316
+  0: The total amount of wall time                        = 295.974504
+  0: The maximum resident set size (KB)                   = 574300
 
-Test 083 regional_control_faster_intel PASS
+Test 081 regional_control_faster_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-Checking test 084 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 874.261422
-  0: The maximum resident set size (KB)                   = 679244
+  0: The total amount of wall time                        = 873.388321
+  0: The maximum resident set size (KB)                   = 679320
 
-Test 084 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
+Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
-Checking test 085 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+Checking test 083 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 497.279565
-  0: The maximum resident set size (KB)                   = 695964
+  0: The total amount of wall time                        = 496.667184
+  0: The maximum resident set size (KB)                   = 695832
 
-Test 085 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
+Test 083 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_conus13km_hrrr_warm_debug_intel
-Checking test 086 rrfs_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_conus13km_hrrr_warm_debug_intel
+Checking test 084 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 777.742577
-  0: The maximum resident set size (KB)                   = 663600
+  0: The total amount of wall time                        = 780.207388
+  0: The maximum resident set size (KB)                   = 663592
 
-Test 086 rrfs_conus13km_hrrr_warm_debug_intel PASS
+Test 084 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_CubedSphereGrid_debug_intel
-Checking test 087 control_CubedSphereGrid_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_CubedSphereGrid_debug_intel
+Checking test 085 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3335,349 +3300,349 @@ Checking test 087 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.307768
-  0: The maximum resident set size (KB)                   = 599156
+  0: The total amount of wall time                        = 150.475323
+  0: The maximum resident set size (KB)                   = 599004
 
-Test 087 control_CubedSphereGrid_debug_intel PASS
+Test 085 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_wrtGauss_netcdf_parallel_debug_intel
-Checking test 088 control_wrtGauss_netcdf_parallel_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_wrtGauss_netcdf_parallel_debug_intel
+Checking test 086 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 163.081153
-  0: The maximum resident set size (KB)                   = 598592
+  0: The total amount of wall time                        = 158.568612
+  0: The maximum resident set size (KB)                   = 598588
 
-Test 088 control_wrtGauss_netcdf_parallel_debug_intel PASS
+Test 086 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_stochy_debug_intel
-Checking test 089 control_stochy_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_stochy_debug_intel
+Checking test 087 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.560268
-  0: The maximum resident set size (KB)                   = 603204
+  0: The total amount of wall time                        = 170.859417
+  0: The maximum resident set size (KB)                   = 603248
 
-Test 089 control_stochy_debug_intel PASS
+Test 087 control_stochy_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_lndp_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_lndp_debug_intel
-Checking test 090 control_lndp_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_lndp_debug_intel
+Checking test 088 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.857410
-  0: The maximum resident set size (KB)                   = 605460
+  0: The total amount of wall time                        = 152.874341
+  0: The maximum resident set size (KB)                   = 605332
 
-Test 090 control_lndp_debug_intel PASS
+Test 088 control_lndp_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmg_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_csawmg_debug_intel
-Checking test 091 control_csawmg_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_csawmg_debug_intel
+Checking test 089 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 243.562374
-  0: The maximum resident set size (KB)                   = 638984
+  0: The total amount of wall time                        = 243.622490
+  0: The maximum resident set size (KB)                   = 639160
 
-Test 091 control_csawmg_debug_intel PASS
+Test 089 control_csawmg_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_csawmgt_debug_intel
-Checking test 092 control_csawmgt_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_csawmgt_debug_intel
+Checking test 090 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 239.518724
-  0: The maximum resident set size (KB)                   = 639100
+  0: The total amount of wall time                        = 238.978178
+  0: The maximum resident set size (KB)                   = 639064
 
-Test 092 control_csawmgt_debug_intel PASS
+Test 090 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_ras_debug_intel
-Checking test 093 control_ras_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_ras_debug_intel
+Checking test 091 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.541882
-  0: The maximum resident set size (KB)                   = 612024
+  0: The total amount of wall time                        = 154.723812
+  0: The maximum resident set size (KB)                   = 612092
 
-Test 093 control_ras_debug_intel PASS
+Test 091 control_ras_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_diag_debug_intel
-Checking test 094 control_diag_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_diag_debug_intel
+Checking test 092 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.052875
-  0: The maximum resident set size (KB)                   = 656856
+  0: The total amount of wall time                        = 156.863251
+  0: The maximum resident set size (KB)                   = 656984
 
-Test 094 control_diag_debug_intel PASS
+Test 092 control_diag_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_debug_p8_intel
-Checking test 095 control_debug_p8_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_debug_p8_intel
+Checking test 093 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.109471
-  0: The maximum resident set size (KB)                   = 1421592
+  0: The total amount of wall time                        = 171.931095
+  0: The maximum resident set size (KB)                   = 1421628
 
-Test 095 control_debug_p8_intel PASS
+Test 093 control_debug_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_debug_intel
-Checking test 096 regional_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_debug_intel
+Checking test 094 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1035.292290
-  0: The maximum resident set size (KB)                   = 602404
+  0: The total amount of wall time                        = 1035.850605
+  0: The maximum resident set size (KB)                   = 602416
 
-Test 096 regional_debug_intel PASS
+Test 094 regional_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_control_debug_intel
-Checking test 097 rap_control_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_control_debug_intel
+Checking test 095 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.427449
-  0: The maximum resident set size (KB)                   = 969248
+  0: The total amount of wall time                        = 282.613523
+  0: The maximum resident set size (KB)                   = 968984
 
-Test 097 rap_control_debug_intel PASS
+Test 095 rap_control_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_debug_intel
-Checking test 098 hrrr_control_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_debug_intel
+Checking test 096 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.602817
-  0: The maximum resident set size (KB)                   = 966292
+  0: The total amount of wall time                        = 275.123960
+  0: The maximum resident set size (KB)                   = 966108
 
-Test 098 hrrr_control_debug_intel PASS
+Test 096 hrrr_control_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_unified_drag_suite_debug_intel
-Checking test 099 rap_unified_drag_suite_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_unified_drag_suite_debug_intel
+Checking test 097 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.801349
-  0: The maximum resident set size (KB)                   = 969232
+  0: The total amount of wall time                        = 281.527556
+  0: The maximum resident set size (KB)                   = 969396
 
-Test 099 rap_unified_drag_suite_debug_intel PASS
+Test 097 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_diag_debug_intel
-Checking test 100 rap_diag_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_diag_debug_intel
+Checking test 098 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 295.722291
-  0: The maximum resident set size (KB)                   = 1051280
+  0: The total amount of wall time                        = 295.664464
+  0: The maximum resident set size (KB)                   = 1051364
 
-Test 100 rap_diag_debug_intel PASS
+Test 098 rap_diag_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_cires_ugwp_debug_intel
-Checking test 101 rap_cires_ugwp_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_cires_ugwp_debug_intel
+Checking test 099 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.481923
-  0: The maximum resident set size (KB)                   = 969328
+  0: The total amount of wall time                        = 287.525361
+  0: The maximum resident set size (KB)                   = 969280
 
-Test 101 rap_cires_ugwp_debug_intel PASS
+Test 099 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_unified_ugwp_debug_intel
-Checking test 102 rap_unified_ugwp_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_unified_ugwp_debug_intel
+Checking test 100 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.032938
-  0: The maximum resident set size (KB)                   = 969904
+  0: The total amount of wall time                        = 287.289516
+  0: The maximum resident set size (KB)                   = 969792
 
-Test 102 rap_unified_ugwp_debug_intel PASS
+Test 100 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_lndp_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_lndp_debug_intel
-Checking test 103 rap_lndp_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_lndp_debug_intel
+Checking test 101 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.279631
-  0: The maximum resident set size (KB)                   = 970488
+  0: The total amount of wall time                        = 285.017861
+  0: The maximum resident set size (KB)                   = 970480
 
-Test 103 rap_lndp_debug_intel PASS
+Test 101 rap_lndp_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_progcld_thompson_debug_intel
-Checking test 104 rap_progcld_thompson_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_progcld_thompson_debug_intel
+Checking test 102 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.481560
-  0: The maximum resident set size (KB)                   = 969316
+  0: The total amount of wall time                        = 282.405339
+  0: The maximum resident set size (KB)                   = 969360
 
-Test 104 rap_progcld_thompson_debug_intel PASS
+Test 102 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_noah_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_noah_debug_intel
-Checking test 105 rap_noah_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_noah_debug_intel
+Checking test 103 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.210338
-  0: The maximum resident set size (KB)                   = 967260
+  0: The total amount of wall time                        = 277.042931
+  0: The maximum resident set size (KB)                   = 967320
 
-Test 105 rap_noah_debug_intel PASS
+Test 103 rap_noah_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_sfcdiff_debug_intel
-Checking test 106 rap_sfcdiff_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_sfcdiff_debug_intel
+Checking test 104 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.531726
-  0: The maximum resident set size (KB)                   = 968716
+  0: The total amount of wall time                        = 281.804361
+  0: The maximum resident set size (KB)                   = 968592
 
-Test 106 rap_sfcdiff_debug_intel PASS
+Test 104 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_noah_sfcdiff_cires_ugwp_debug_intel
-Checking test 107 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_noah_sfcdiff_cires_ugwp_debug_intel
+Checking test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 466.486229
-  0: The maximum resident set size (KB)                   = 967092
+  0: The total amount of wall time                        = 466.587326
+  0: The maximum resident set size (KB)                   = 967044
 
-Test 107 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
+Test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rrfs_v1beta_debug_intel
-Checking test 108 rrfs_v1beta_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rrfs_v1beta_debug_intel
+Checking test 106 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.565775
-  0: The maximum resident set size (KB)                   = 965104
+  0: The total amount of wall time                        = 277.555944
+  0: The maximum resident set size (KB)                   = 965152
 
-Test 108 rrfs_v1beta_debug_intel PASS
+Test 106 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_clm_lake_debug_intel
-Checking test 109 rap_clm_lake_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_clm_lake_debug_intel
+Checking test 107 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 349.568928
-  0: The maximum resident set size (KB)                   = 970820
+  0: The total amount of wall time                        = 349.790612
+  0: The maximum resident set size (KB)                   = 970492
 
-Test 109 rap_clm_lake_debug_intel PASS
+Test 107 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_flake_debug_intel
-Checking test 110 rap_flake_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_flake_debug_intel
+Checking test 108 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.817755
-  0: The maximum resident set size (KB)                   = 969420
+  0: The total amount of wall time                        = 281.706879
+  0: The maximum resident set size (KB)                   = 969592
 
-Test 110 rap_flake_debug_intel PASS
+Test 108 rap_flake_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_wam_debug_intel
-Checking test 111 control_wam_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_wam_debug_intel
+Checking test 109 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 286.094235
-  0: The maximum resident set size (KB)                   = 215776
+  0: The total amount of wall time                        = 288.253653
+  0: The maximum resident set size (KB)                   = 215856
 
-Test 111 control_wam_debug_intel PASS
+Test 109 control_wam_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 112 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3687,15 +3652,15 @@ Checking test 112 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 235.747120
-  0: The maximum resident set size (KB)                   = 807732
+  0: The total amount of wall time                        = 235.849582
+  0: The maximum resident set size (KB)                   = 807532
 
-Test 112 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+Test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_control_dyn32_phy32_intel
-Checking test 113 rap_control_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_control_dyn32_phy32_intel
+Checking test 111 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3741,15 +3706,15 @@ Checking test 113 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 371.818641
-  0: The maximum resident set size (KB)                   = 689716
+  0: The total amount of wall time                        = 371.427371
+  0: The maximum resident set size (KB)                   = 689500
 
-Test 113 rap_control_dyn32_phy32_intel PASS
+Test 111 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_dyn32_phy32_intel
-Checking test 114 hrrr_control_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_dyn32_phy32_intel
+Checking test 112 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3795,15 +3760,15 @@ Checking test 114 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.393051
-  0: The maximum resident set size (KB)                   = 688392
+  0: The total amount of wall time                        = 190.501354
+  0: The maximum resident set size (KB)                   = 688376
 
-Test 114 hrrr_control_dyn32_phy32_intel PASS
+Test 112 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_qr_dyn32_phy32_intel
-Checking test 115 hrrr_control_qr_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_qr_dyn32_phy32_intel
+Checking test 113 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3849,15 +3814,15 @@ Checking test 115 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.023147
-  0: The maximum resident set size (KB)                   = 694780
+  0: The total amount of wall time                        = 191.143860
+  0: The maximum resident set size (KB)                   = 694700
 
-Test 115 hrrr_control_qr_dyn32_phy32_intel PASS
+Test 113 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_2threads_dyn32_phy32_intel
-Checking test 116 rap_2threads_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_2threads_dyn32_phy32_intel
+Checking test 114 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3903,15 +3868,15 @@ Checking test 116 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 349.207585
-  0: The maximum resident set size (KB)                   = 739940
+  0: The total amount of wall time                        = 348.686483
+  0: The maximum resident set size (KB)                   = 739864
 
-Test 116 rap_2threads_dyn32_phy32_intel PASS
+Test 114 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 117 hrrr_control_2threads_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_2threads_dyn32_phy32_intel
+Checking test 115 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3957,15 +3922,15 @@ Checking test 117 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.513595
-  0: The maximum resident set size (KB)                   = 739532
+  0: The total amount of wall time                        = 175.707812
+  0: The maximum resident set size (KB)                   = 740728
 
-Test 117 hrrr_control_2threads_dyn32_phy32_intel PASS
+Test 115 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 118 hrrr_control_decomp_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_decomp_dyn32_phy32_intel
+Checking test 116 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4011,15 +3976,15 @@ Checking test 118 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 197.920586
-  0: The maximum resident set size (KB)                   = 687560
+  0: The total amount of wall time                        = 196.204223
+  0: The maximum resident set size (KB)                   = 687656
 
-Test 118 hrrr_control_decomp_dyn32_phy32_intel PASS
+Test 116 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_restart_dyn32_phy32_intel
-Checking test 119 rap_restart_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_restart_dyn32_phy32_intel
+Checking test 117 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -4057,43 +4022,43 @@ Checking test 119 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.572415
-  0: The maximum resident set size (KB)                   = 519324
+  0: The total amount of wall time                        = 275.490802
+  0: The maximum resident set size (KB)                   = 519312
 
-Test 119 rap_restart_dyn32_phy32_intel PASS
+Test 117 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_restart_dyn32_phy32_intel
-Checking test 120 hrrr_control_restart_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_restart_dyn32_phy32_intel
+Checking test 118 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 99.439790
-  0: The maximum resident set size (KB)                   = 513908
+  0: The total amount of wall time                        = 99.235025
+  0: The maximum resident set size (KB)                   = 513896
 
-Test 120 hrrr_control_restart_dyn32_phy32_intel PASS
+Test 118 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_restart_qr_dyn32_phy32_intel
-Checking test 121 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 119 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.811923
-  0: The maximum resident set size (KB)                   = 541072
+  0: The total amount of wall time                        = 101.478334
+  0: The maximum resident set size (KB)                   = 541024
 
-Test 121 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+Test 119 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_control_dyn64_phy32_intel
-Checking test 122 rap_control_dyn64_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_control_dyn64_phy32_intel
+Checking test 120 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4139,82 +4104,82 @@ Checking test 122 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 248.503428
-  0: The maximum resident set size (KB)                   = 707808
+  0: The total amount of wall time                        = 248.719740
+  0: The maximum resident set size (KB)                   = 707940
 
-Test 122 rap_control_dyn64_phy32_intel PASS
+Test 120 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_control_debug_dyn32_phy32_intel
-Checking test 123 rap_control_debug_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_control_debug_dyn32_phy32_intel
+Checking test 121 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.197472
-  0: The maximum resident set size (KB)                   = 852428
+  0: The total amount of wall time                        = 277.905115
+  0: The maximum resident set size (KB)                   = 852424
 
-Test 123 rap_control_debug_dyn32_phy32_intel PASS
+Test 121 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hrrr_control_debug_dyn32_phy32_intel
-Checking test 124 hrrr_control_debug_dyn32_phy32_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hrrr_control_debug_dyn32_phy32_intel
+Checking test 122 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.581173
-  0: The maximum resident set size (KB)                   = 851072
+  0: The total amount of wall time                        = 271.551219
+  0: The maximum resident set size (KB)                   = 851196
 
-Test 124 hrrr_control_debug_dyn32_phy32_intel PASS
+Test 122 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/rap_control_dyn64_phy32_debug_intel
-Checking test 125 rap_control_dyn64_phy32_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/rap_control_dyn64_phy32_debug_intel
+Checking test 123 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.231742
-  0: The maximum resident set size (KB)                   = 871060
+  0: The total amount of wall time                        = 282.546390
+  0: The maximum resident set size (KB)                   = 871012
 
-Test 125 rap_control_dyn64_phy32_debug_intel PASS
+Test 123 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_atm_intel
-Checking test 126 hafs_regional_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_atm_intel
+Checking test 124 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 238.877456
-  0: The maximum resident set size (KB)                   = 684732
+  0: The total amount of wall time                        = 239.512469
+  0: The maximum resident set size (KB)                   = 684064
 
-Test 126 hafs_regional_atm_intel PASS
+Test 124 hafs_regional_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_atm_thompson_gfdlsf_intel
-Checking test 127 hafs_regional_atm_thompson_gfdlsf_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_atm_thompson_gfdlsf_intel
+Checking test 125 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 275.494438
-  0: The maximum resident set size (KB)                   = 1039576
+  0: The total amount of wall time                        = 275.258508
+  0: The maximum resident set size (KB)                   = 1035760
 
-Test 127 hafs_regional_atm_thompson_gfdlsf_intel PASS
+Test 125 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_atm_ocn_intel
-Checking test 128 hafs_regional_atm_ocn_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_atm_ocn_intel
+Checking test 126 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4222,15 +4187,15 @@ Checking test 128 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 417.066186
-  0: The maximum resident set size (KB)                   = 715016
+  0: The total amount of wall time                        = 417.543210
+  0: The maximum resident set size (KB)                   = 715280
 
-Test 128 hafs_regional_atm_ocn_intel PASS
+Test 126 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_wav_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_atm_wav_intel
-Checking test 129 hafs_regional_atm_wav_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_atm_wav_intel
+Checking test 127 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4238,15 +4203,15 @@ Checking test 129 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 902.141883
-  0: The maximum resident set size (KB)                   = 745464
+  0: The total amount of wall time                        = 901.870533
+  0: The maximum resident set size (KB)                   = 745656
 
-Test 129 hafs_regional_atm_wav_intel PASS
+Test 127 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_wav_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_atm_ocn_wav_intel
-Checking test 130 hafs_regional_atm_ocn_wav_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_atm_ocn_wav_intel
+Checking test 128 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4256,15 +4221,15 @@ Checking test 130 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1015.151738
-  0: The maximum resident set size (KB)                   = 764392
+  0: The total amount of wall time                        = 1016.279771
+  0: The maximum resident set size (KB)                   = 764136
 
-Test 130 hafs_regional_atm_ocn_wav_intel PASS
+Test 128 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_1nest_atm_intel
-Checking test 131 hafs_regional_1nest_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_1nest_atm_intel
+Checking test 129 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4285,15 +4250,15 @@ Checking test 131 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 335.811009
-  0: The maximum resident set size (KB)                   = 276008
+  0: The total amount of wall time                        = 336.304096
+  0: The maximum resident set size (KB)                   = 275520
 
-Test 131 hafs_regional_1nest_atm_intel PASS
+Test 129 hafs_regional_1nest_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_1nest_atm_qr_intel
-Checking test 132 hafs_regional_1nest_atm_qr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_1nest_atm_qr_intel
+Checking test 130 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4314,15 +4279,15 @@ Checking test 132 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 370.037573
-  0: The maximum resident set size (KB)                   = 270912
+  0: The total amount of wall time                        = 399.981482
+  0: The maximum resident set size (KB)                   = 270120
 
-Test 132 hafs_regional_1nest_atm_qr_intel PASS
+Test 130 hafs_regional_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_telescopic_2nests_atm_intel
-Checking test 133 hafs_regional_telescopic_2nests_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_telescopic_2nests_atm_intel
+Checking test 131 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4330,15 +4295,15 @@ Checking test 133 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 386.179597
-  0: The maximum resident set size (KB)                   = 284720
+  0: The total amount of wall time                        = 381.376112
+  0: The maximum resident set size (KB)                   = 284900
 
-Test 133 hafs_regional_telescopic_2nests_atm_intel PASS
+Test 131 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_global_1nest_atm_intel
-Checking test 134 hafs_global_1nest_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_global_1nest_atm_intel
+Checking test 132 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4384,15 +4349,15 @@ Checking test 134 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 152.157656
-  0: The maximum resident set size (KB)                   = 181732
+  0: The total amount of wall time                        = 152.138592
+  0: The maximum resident set size (KB)                   = 181880
 
-Test 134 hafs_global_1nest_atm_intel PASS
+Test 132 hafs_global_1nest_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_global_1nest_atm_qr_intel
-Checking test 135 hafs_global_1nest_atm_qr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_global_1nest_atm_qr_intel
+Checking test 133 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4438,15 +4403,15 @@ Checking test 135 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 201.937885
-  0: The maximum resident set size (KB)                   = 189908
+  0: The total amount of wall time                        = 215.066225
+  0: The maximum resident set size (KB)                   = 189748
 
-Test 135 hafs_global_1nest_atm_qr_intel PASS
+Test 133 hafs_global_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_global_multiple_4nests_atm_intel
-Checking test 136 hafs_global_multiple_4nests_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_global_multiple_4nests_atm_intel
+Checking test 134 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4527,15 +4492,15 @@ Checking test 136 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 435.394679
-  0: The maximum resident set size (KB)                   = 212668
+  0: The total amount of wall time                        = 436.154514
+  0: The maximum resident set size (KB)                   = 212932
 
-Test 136 hafs_global_multiple_4nests_atm_intel PASS
+Test 134 hafs_global_multiple_4nests_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_global_multiple_4nests_atm_qr_intel
-Checking test 137 hafs_global_multiple_4nests_atm_qr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_global_multiple_4nests_atm_qr_intel
+Checking test 135 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4616,15 +4581,15 @@ Checking test 137 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 553.701031
-  0: The maximum resident set size (KB)                   = 255324
+  0: The total amount of wall time                        = 603.259896
+  0: The maximum resident set size (KB)                   = 240188
 
-Test 137 hafs_global_multiple_4nests_atm_qr_intel PASS
+Test 135 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_specified_moving_1nest_atm_intel
-Checking test 138 hafs_regional_specified_moving_1nest_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_specified_moving_1nest_atm_intel
+Checking test 136 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4632,15 +4597,15 @@ Checking test 138 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 216.128312
-  0: The maximum resident set size (KB)                   = 296284
+  0: The total amount of wall time                        = 215.389808
+  0: The maximum resident set size (KB)                   = 293148
 
-Test 138 hafs_regional_specified_moving_1nest_atm_intel PASS
+Test 136 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_storm_following_1nest_atm_intel
-Checking test 139 hafs_regional_storm_following_1nest_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_storm_following_1nest_atm_intel
+Checking test 137 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4661,15 +4626,15 @@ Checking test 139 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 202.090261
-  0: The maximum resident set size (KB)                   = 290544
+  0: The total amount of wall time                        = 199.788330
+  0: The maximum resident set size (KB)                   = 291160
 
-Test 139 hafs_regional_storm_following_1nest_atm_intel PASS
+Test 137 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_storm_following_1nest_atm_qr_intel
-Checking test 140 hafs_regional_storm_following_1nest_atm_qr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_storm_following_1nest_atm_qr_intel
+Checking test 138 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4690,15 +4655,15 @@ Checking test 140 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 230.720593
-  0: The maximum resident set size (KB)                   = 300308
+  0: The total amount of wall time                        = 273.077350
+  0: The maximum resident set size (KB)                   = 300312
 
-Test 140 hafs_regional_storm_following_1nest_atm_qr_intel PASS
+Test 138 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_storm_following_1nest_atm_ocn_intel
-Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_storm_following_1nest_atm_ocn_intel
+Checking test 139 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4706,43 +4671,43 @@ Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 248.332131
-  0: The maximum resident set size (KB)                   = 319200
+  0: The total amount of wall time                        = 248.311741
+  0: The maximum resident set size (KB)                   = 319004
 
-Test 141 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
+Test 139 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_storm_following_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_global_storm_following_1nest_atm_intel
-Checking test 142 hafs_global_storm_following_1nest_atm_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_storm_following_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_global_storm_following_1nest_atm_intel
+Checking test 140 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 59.527492
-  0: The maximum resident set size (KB)                   = 200556
+  0: The total amount of wall time                        = 59.628257
+  0: The maximum resident set size (KB)                   = 200396
 
-Test 142 hafs_global_storm_following_1nest_atm_intel PASS
+Test 140 hafs_global_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 757.650854
-  0: The maximum resident set size (KB)                   = 345348
+  0: The total amount of wall time                        = 760.310671
+  0: The maximum resident set size (KB)                   = 345248
 
-Test 143 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
+Test 141 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-Checking test 144 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4752,162 +4717,162 @@ Checking test 144 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 642.422496
-  0: The maximum resident set size (KB)                   = 367144
+  0: The total amount of wall time                        = 642.990395
+  0: The maximum resident set size (KB)                   = 367396
 
-Test 144 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
+Test 142 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_docn_intel
-Checking test 145 hafs_regional_docn_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_docn_intel
+Checking test 143 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 358.933329
-  0: The maximum resident set size (KB)                   = 722580
+  0: The total amount of wall time                        = 358.843028
+  0: The maximum resident set size (KB)                   = 722408
 
-Test 145 hafs_regional_docn_intel PASS
+Test 143 hafs_regional_docn_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_oisst_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_docn_oisst_intel
-Checking test 146 hafs_regional_docn_oisst_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_oisst_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_docn_oisst_intel
+Checking test 144 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 359.475954
-  0: The maximum resident set size (KB)                   = 712132
+  0: The total amount of wall time                        = 361.853126
+  0: The maximum resident set size (KB)                   = 712096
 
-Test 146 hafs_regional_docn_oisst_intel PASS
+Test 144 hafs_regional_docn_oisst_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_datm_cdeps_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/hafs_regional_datm_cdeps_intel
-Checking test 147 hafs_regional_datm_cdeps_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_datm_cdeps_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/hafs_regional_datm_cdeps_intel
+Checking test 145 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1185.535499
-  0: The maximum resident set size (KB)                   = 805256
+  0: The total amount of wall time                        = 1180.423448
+  0: The maximum resident set size (KB)                   = 805268
 
-Test 147 hafs_regional_datm_cdeps_intel PASS
+Test 145 hafs_regional_datm_cdeps_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_control_cfsr_intel
-Checking test 148 datm_cdeps_control_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_control_cfsr_intel
+Checking test 146 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.799572
- 0: The maximum resident set size (KB)                   = 716096
+ 0: The total amount of wall time                        = 162.246903
+ 0: The maximum resident set size (KB)                   = 716192
 
-Test 148 datm_cdeps_control_cfsr_intel PASS
+Test 146 datm_cdeps_control_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_restart_cfsr_intel
-Checking test 149 datm_cdeps_restart_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_restart_cfsr_intel
+Checking test 147 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 94.095607
- 0: The maximum resident set size (KB)                   = 711396
+ 0: The total amount of wall time                        = 94.241273
+ 0: The maximum resident set size (KB)                   = 703972
 
-Test 149 datm_cdeps_restart_cfsr_intel PASS
+Test 147 datm_cdeps_restart_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_gefs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_control_gefs_intel
-Checking test 150 datm_cdeps_control_gefs_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_gefs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_control_gefs_intel
+Checking test 148 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.456353
- 0: The maximum resident set size (KB)                   = 595912
+ 0: The total amount of wall time                        = 155.092576
+ 0: The maximum resident set size (KB)                   = 598084
 
-Test 150 datm_cdeps_control_gefs_intel PASS
+Test 148 datm_cdeps_control_gefs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_iau_gefs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_iau_gefs_intel
-Checking test 151 datm_cdeps_iau_gefs_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_iau_gefs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_iau_gefs_intel
+Checking test 149 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 157.413651
- 0: The maximum resident set size (KB)                   = 599904
+ 0: The total amount of wall time                        = 156.071153
+ 0: The maximum resident set size (KB)                   = 598040
 
-Test 151 datm_cdeps_iau_gefs_intel PASS
+Test 149 datm_cdeps_iau_gefs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_stochy_gefs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_stochy_gefs_intel
-Checking test 152 datm_cdeps_stochy_gefs_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_stochy_gefs_intel
+Checking test 150 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 157.461040
- 0: The maximum resident set size (KB)                   = 598976
+ 0: The total amount of wall time                        = 156.221599
+ 0: The maximum resident set size (KB)                   = 598036
 
-Test 152 datm_cdeps_stochy_gefs_intel PASS
+Test 150 datm_cdeps_stochy_gefs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_ciceC_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_ciceC_cfsr_intel
-Checking test 153 datm_cdeps_ciceC_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_ciceC_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_ciceC_cfsr_intel
+Checking test 151 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.056313
- 0: The maximum resident set size (KB)                   = 716168
+ 0: The total amount of wall time                        = 160.309716
+ 0: The maximum resident set size (KB)                   = 716140
 
-Test 153 datm_cdeps_ciceC_cfsr_intel PASS
+Test 151 datm_cdeps_ciceC_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_bulk_cfsr_intel
-Checking test 154 datm_cdeps_bulk_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_bulk_cfsr_intel
+Checking test 152 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.419473
- 0: The maximum resident set size (KB)                   = 704536
+ 0: The total amount of wall time                        = 159.930180
+ 0: The maximum resident set size (KB)                   = 716044
 
-Test 154 datm_cdeps_bulk_cfsr_intel PASS
+Test 152 datm_cdeps_bulk_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_gefs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_bulk_gefs_intel
-Checking test 155 datm_cdeps_bulk_gefs_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_gefs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_bulk_gefs_intel
+Checking test 153 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.027728
- 0: The maximum resident set size (KB)                   = 596052
+ 0: The total amount of wall time                        = 153.396797
+ 0: The maximum resident set size (KB)                   = 599860
 
-Test 155 datm_cdeps_bulk_gefs_intel PASS
+Test 153 datm_cdeps_bulk_gefs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_mx025_cfsr_intel
-Checking test 156 datm_cdeps_mx025_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_mx025_cfsr_intel
+Checking test 154 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4915,15 +4880,15 @@ Checking test 156 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 389.584386
-  0: The maximum resident set size (KB)                   = 493080
+  0: The total amount of wall time                        = 394.449919
+  0: The maximum resident set size (KB)                   = 495120
 
-Test 156 datm_cdeps_mx025_cfsr_intel PASS
+Test 154 datm_cdeps_mx025_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_gefs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_mx025_gefs_intel
-Checking test 157 datm_cdeps_mx025_gefs_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_gefs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_mx025_gefs_intel
+Checking test 155 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4931,78 +4896,78 @@ Checking test 157 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 389.158414
-  0: The maximum resident set size (KB)                   = 473748
+  0: The total amount of wall time                        = 389.382223
+  0: The maximum resident set size (KB)                   = 473376
 
-Test 157 datm_cdeps_mx025_gefs_intel PASS
+Test 155 datm_cdeps_mx025_gefs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_multiple_files_cfsr_intel
-Checking test 158 datm_cdeps_multiple_files_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_multiple_files_cfsr_intel
+Checking test 156 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.833446
- 0: The maximum resident set size (KB)                   = 716936
+ 0: The total amount of wall time                        = 162.757236
+ 0: The maximum resident set size (KB)                   = 704536
 
-Test 158 datm_cdeps_multiple_files_cfsr_intel PASS
+Test 156 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_3072x1536_cfsr_intel
-Checking test 159 datm_cdeps_3072x1536_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_3072x1536_cfsr_intel
+Checking test 157 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 249.852077
- 0: The maximum resident set size (KB)                   = 1950536
+ 0: The total amount of wall time                        = 246.386108
+ 0: The maximum resident set size (KB)                   = 1958792
 
-Test 159 datm_cdeps_3072x1536_cfsr_intel PASS
+Test 157 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_gfs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_gfs_intel
-Checking test 160 datm_cdeps_gfs_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_gfs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_gfs_intel
+Checking test 158 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 247.638429
- 0: The maximum resident set size (KB)                   = 1963044
+ 0: The total amount of wall time                        = 247.324999
+ 0: The maximum resident set size (KB)                   = 1958856
 
-Test 160 datm_cdeps_gfs_intel PASS
+Test 158 datm_cdeps_gfs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_debug_cfsr_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_debug_cfsr_intel
-Checking test 161 datm_cdeps_debug_cfsr_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_debug_cfsr_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_debug_cfsr_intel
+Checking test 159 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 368.901064
- 0: The maximum resident set size (KB)                   = 712672
+ 0: The total amount of wall time                        = 367.400374
+ 0: The maximum resident set size (KB)                   = 707052
 
-Test 161 datm_cdeps_debug_cfsr_intel PASS
+Test 159 datm_cdeps_debug_cfsr_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_faster_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_control_cfsr_faster_intel
-Checking test 162 datm_cdeps_control_cfsr_faster_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_control_cfsr_faster_intel
+Checking test 160 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 160.903018
- 0: The maximum resident set size (KB)                   = 716296
+ 0: The total amount of wall time                        = 159.692861
+ 0: The maximum resident set size (KB)                   = 716188
 
-Test 162 datm_cdeps_control_cfsr_faster_intel PASS
+Test 160 datm_cdeps_control_cfsr_faster_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_lnd_gswp3_intel
-Checking test 163 datm_cdeps_lnd_gswp3_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_lnd_gswp3_intel
+Checking test 161 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5010,15 +4975,15 @@ Checking test 163 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 7.088451
-  0: The maximum resident set size (KB)                   = 149256
+  0: The total amount of wall time                        = 7.022547
+  0: The maximum resident set size (KB)                   = 153380
 
-Test 163 datm_cdeps_lnd_gswp3_intel PASS
+Test 161 datm_cdeps_lnd_gswp3_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/datm_cdeps_lnd_gswp3_rst_intel
-Checking test 164 datm_cdeps_lnd_gswp3_rst_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/datm_cdeps_lnd_gswp3_rst_intel
+Checking test 162 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5026,15 +4991,15 @@ Checking test 164 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 13.141905
-  0: The maximum resident set size (KB)                   = 148332
+  0: The total amount of wall time                        = 13.529237
+  0: The maximum resident set size (KB)                   = 148260
 
-Test 164 datm_cdeps_lnd_gswp3_rst_intel PASS
+Test 162 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_atmlnd_sbs_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_p8_atmlnd_sbs_intel
-Checking test 165 control_p8_atmlnd_sbs_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_p8_atmlnd_sbs_intel
+Checking test 163 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -5118,15 +5083,15 @@ Checking test 165 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.079280
-  0: The maximum resident set size (KB)                   = 1436368
+  0: The total amount of wall time                        = 213.921095
+  0: The maximum resident set size (KB)                   = 1436364
 
-Test 165 control_p8_atmlnd_sbs_intel PASS
+Test 163 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmwav_control_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/atmwav_control_noaero_p8_intel
-Checking test 166 atmwav_control_noaero_p8_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmwav_control_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/atmwav_control_noaero_p8_intel
+Checking test 164 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5168,15 +5133,15 @@ Checking test 166 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 92.437389
-  0: The maximum resident set size (KB)                   = 1421720
+  0: The total amount of wall time                        = 92.273581
+  0: The maximum resident set size (KB)                   = 1421544
 
-Test 166 atmwav_control_noaero_p8_intel PASS
+Test 164 atmwav_control_noaero_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_atmwav_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/control_atmwav_intel
-Checking test 167 control_atmwav_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_atmwav_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/control_atmwav_intel
+Checking test 165 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5219,15 +5184,15 @@ Checking test 167 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 92.047305
-  0: The maximum resident set size (KB)                   = 452752
+  0: The total amount of wall time                        = 89.958382
+  0: The maximum resident set size (KB)                   = 452672
 
-Test 167 control_atmwav_intel PASS
+Test 165 control_atmwav_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/atmaero_control_p8_intel
-Checking test 168 atmaero_control_p8_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/atmaero_control_p8_intel
+Checking test 166 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5270,15 +5235,15 @@ Checking test 168 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 233.529659
-  0: The maximum resident set size (KB)                   = 1446744
+  0: The total amount of wall time                        = 233.771137
+  0: The maximum resident set size (KB)                   = 1446752
 
-Test 168 atmaero_control_p8_intel PASS
+Test 166 atmaero_control_p8_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/atmaero_control_p8_rad_intel
-Checking test 169 atmaero_control_p8_rad_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/atmaero_control_p8_rad_intel
+Checking test 167 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5321,15 +5286,15 @@ Checking test 169 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 287.503157
-  0: The maximum resident set size (KB)                   = 1497548
+  0: The total amount of wall time                        = 287.654652
+  0: The maximum resident set size (KB)                   = 1497812
 
-Test 169 atmaero_control_p8_rad_intel PASS
+Test 167 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_micro_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/atmaero_control_p8_rad_micro_intel
-Checking test 170 atmaero_control_p8_rad_micro_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/atmaero_control_p8_rad_micro_intel
+Checking test 168 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5372,15 +5337,15 @@ Checking test 170 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 294.882343
-  0: The maximum resident set size (KB)                   = 1502216
+  0: The total amount of wall time                        = 295.801429
+  0: The maximum resident set size (KB)                   = 1502184
 
-Test 170 atmaero_control_p8_rad_micro_intel PASS
+Test 168 atmaero_control_p8_rad_micro_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_atmaq_intel
-Checking test 171 regional_atmaq_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_atmaq_intel
+Checking test 169 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5395,15 +5360,15 @@ Checking test 171 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 630.116320
-  0: The maximum resident set size (KB)                   = 962960
+  0: The total amount of wall time                        = 632.798318
+  0: The maximum resident set size (KB)                   = 960036
 
-Test 171 regional_atmaq_intel PASS
+Test 169 regional_atmaq_intel PASS
 
 
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_faster_intel
-working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_46141/regional_atmaq_faster_intel
-Checking test 172 regional_atmaq_faster_intel results ....
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_faster_intel
+working dir  = /lustre/f2/scratch/Zachary.Shrader/FV3_RT/rt_48837/regional_atmaq_faster_intel
+Checking test 170 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5418,12 +5383,12 @@ Checking test 172 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 583.239999
-  0: The maximum resident set size (KB)                   = 965752
+  0: The total amount of wall time                        = 581.981506
+  0: The maximum resident set size (KB)                   = 967112
 
-Test 172 regional_atmaq_faster_intel PASS
+Test 170 regional_atmaq_faster_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri 16 Jun 2023 06:04:28 PM EDT
-Elapsed time: 01h:10m:36s. Have a nice day!
+Fri 23 Jun 2023 05:31:40 PM EDT
+Elapsed time: 01h:12m:15s. Have a nice day!

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,73 +1,73 @@
-Fri Jun 16 20:55:37 UTC 2023
+Fri Jun 23 12:43:07 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: cf35d10cc851f55af57a5d786ae2f025aa8a20f2
+Testing UFSWM Hash: 9e642b2e928cc1060dd3388a762989e9196c371f
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-1401-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
+ f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 678 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 677 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 635 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 249 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 237 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 591 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 580 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 709 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 928 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 220 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 011 elapsed time 618 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 552 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 545 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 503 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 618 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 241 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 183 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 595 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 206 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 653 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 569 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 180 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 110 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 001 elapsed time 683 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 683 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 633 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 244 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 220 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 597 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 595 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 721 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 918 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 222 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 011 elapsed time 598 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 553 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 544 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 505 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 591 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 246 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 177 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 516 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 519 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 181 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 182 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 583 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 213 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 655 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 624 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 186 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 028 elapsed time 118 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 Compile 029 elapsed time 193 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 56 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 557 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 558 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 600 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 537 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 514 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 182 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 037 elapsed time 547 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 038 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 039 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 040 elapsed time 355 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 041 elapsed time 104 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 042 elapsed time 212 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 043 elapsed time 440 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 044 elapsed time 363 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 045 elapsed time 363 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 046 elapsed time 281 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 047 elapsed time 250 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 048 elapsed time 164 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 049 elapsed time 254 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 050 elapsed time 135 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 051 elapsed time 119 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 57 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 562 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 568 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 560 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 533 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 517 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 181 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 037 elapsed time 557 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 038 elapsed time 207 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 039 elapsed time 216 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 040 elapsed time 372 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 041 elapsed time 114 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 042 elapsed time 208 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 043 elapsed time 441 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 044 elapsed time 371 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 045 elapsed time 377 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 046 elapsed time 283 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 047 elapsed time 247 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 048 elapsed time 200 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 049 elapsed time 262 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 050 elapsed time 149 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 051 elapsed time 123 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_mixedmode_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_p8_mixedmode_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -132,14 +132,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 313.257333
-  0: The maximum resident set size (KB)                   = 3125900
+  0: The total amount of wall time                        = 313.420747
+  0: The maximum resident set size (KB)                   = 3093588
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_gfsv17_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_gfsv17_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -203,14 +203,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 222.360567
-  0: The maximum resident set size (KB)                   = 1681028
+  0: The total amount of wall time                        = 218.696435
+  0: The maximum resident set size (KB)                   = 1679928
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -275,14 +275,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 348.058175
-  0: The maximum resident set size (KB)                   = 3125600
+  0: The total amount of wall time                        = 343.303932
+  0: The maximum resident set size (KB)                   = 3156756
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_restart_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -335,14 +335,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 195.674839
-  0: The maximum resident set size (KB)                   = 3037616
+  0: The total amount of wall time                        = 197.976447
+  0: The maximum resident set size (KB)                   = 3050224
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_qr_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -407,14 +407,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 343.570162
-  0: The maximum resident set size (KB)                   = 3158588
+  0: The total amount of wall time                        = 348.869693
+  0: The maximum resident set size (KB)                   = 3138284
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_restart_qr_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -467,14 +467,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 201.756653
-  0: The maximum resident set size (KB)                   = 3058568
+  0: The total amount of wall time                        = 203.738855
+  0: The maximum resident set size (KB)                   = 3046168
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_2threads_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -527,14 +527,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 351.571914
-  0: The maximum resident set size (KB)                   = 3507316
+  0: The total amount of wall time                        = 353.702195
+  0: The maximum resident set size (KB)                   = 3462500
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_decomp_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -587,14 +587,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 348.550376
-  0: The maximum resident set size (KB)                   = 3112656
+  0: The total amount of wall time                        = 342.875926
+  0: The maximum resident set size (KB)                   = 3151144
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_mpi_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -647,14 +647,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 284.111314
-  0: The maximum resident set size (KB)                   = 3009392
+  0: The total amount of wall time                        = 286.538714
+  0: The maximum resident set size (KB)                   = 3012128
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_ciceC_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_ciceC_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_ciceC_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -719,14 +719,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 348.348905
-  0: The maximum resident set size (KB)                   = 3161704
+  0: The total amount of wall time                        = 342.561375
+  0: The maximum resident set size (KB)                   = 3178556
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c192_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_c192_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c192_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_c192_p8_intel
 Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -779,14 +779,14 @@ Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 594.071178
-  0: The maximum resident set size (KB)                   = 3221256
+  0: The total amount of wall time                        = 603.056728
+  0: The maximum resident set size (KB)                   = 3241460
 
 Test 011 cpld_control_c192_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c192_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_restart_c192_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c192_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_restart_c192_p8_intel
 Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -839,14 +839,14 @@ Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 398.135949
-  0: The maximum resident set size (KB)                   = 3146992
+  0: The total amount of wall time                        = 402.241667
+  0: The maximum resident set size (KB)                   = 3137716
 
 Test 012 cpld_restart_c192_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_bmark_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_bmark_p8_intel
 Checking test 013 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -894,14 +894,14 @@ Checking test 013 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 737.040713
-   0: The maximum resident set size (KB)                   = 4016492
+   0: The total amount of wall time                        = 730.675177
+   0: The maximum resident set size (KB)                   = 4016168
 
 Test 013 cpld_bmark_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_restart_bmark_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_restart_bmark_p8_intel
 Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -949,14 +949,14 @@ Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 450.536303
-   0: The maximum resident set size (KB)                   = 3900160
+   0: The total amount of wall time                        = 458.626828
+   0: The maximum resident set size (KB)                   = 3898064
 
 Test 014 cpld_restart_bmark_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_noaero_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_noaero_p8_intel
 Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1020,14 +1020,14 @@ Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 266.593553
-  0: The maximum resident set size (KB)                   = 1706636
+  0: The total amount of wall time                        = 267.644224
+  0: The maximum resident set size (KB)                   = 1709620
 
 Test 015 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_nowave_noaero_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_nowave_noaero_p8_intel
 Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 263.510324
-  0: The maximum resident set size (KB)                   = 1727980
+  0: The total amount of wall time                        = 268.449612
+  0: The maximum resident set size (KB)                   = 1756696
 
 Test 016 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_debug_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_debug_p8_intel
 Checking test 017 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1149,14 +1149,14 @@ Checking test 017 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 529.792822
-  0: The maximum resident set size (KB)                   = 3234276
+  0: The total amount of wall time                        = 530.701930
+  0: The maximum resident set size (KB)                   = 3191824
 
 Test 017 cpld_debug_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_debug_noaero_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_debug_noaero_p8_intel
 Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1208,14 +1208,14 @@ Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 370.996653
-  0: The maximum resident set size (KB)                   = 1691140
+  0: The total amount of wall time                        = 360.999386
+  0: The maximum resident set size (KB)                   = 1692820
 
 Test 018 cpld_debug_noaero_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_agrid_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_noaero_p8_agrid_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_noaero_p8_agrid_intel
 Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1277,14 +1277,14 @@ Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 274.512921
-  0: The maximum resident set size (KB)                   = 1748252
+  0: The total amount of wall time                        = 269.694378
+  0: The maximum resident set size (KB)                   = 1767608
 
 Test 019 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_c48_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_c48_intel
 Checking test 020 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1334,14 +1334,14 @@ Checking test 020 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 572.765605
- 0: The maximum resident set size (KB)                   = 2807368
+ 0: The total amount of wall time                        = 574.624175
+ 0: The maximum resident set size (KB)                   = 2800164
 
 Test 020 cpld_control_c48_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_warmstart_c48_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_warmstart_c48_intel
 Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 157.071764
- 0: The maximum resident set size (KB)                   = 2778188
+ 0: The total amount of wall time                        = 155.915283
+ 0: The maximum resident set size (KB)                   = 2782624
 
 Test 021 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_restart_c48_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_restart_c48_intel
 Checking test 022 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1448,14 +1448,14 @@ Checking test 022 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 83.068646
- 0: The maximum resident set size (KB)                   = 2226644
+ 0: The total amount of wall time                        = 87.092666
+ 0: The maximum resident set size (KB)                   = 2215852
 
 Test 022 cpld_restart_c48_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_p8_faster_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_p8_faster_intel
 Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1520,14 +1520,14 @@ Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 330.119547
-  0: The maximum resident set size (KB)                   = 3153648
+  0: The total amount of wall time                        = 328.077457
+  0: The maximum resident set size (KB)                   = 3153556
 
 Test 023 cpld_control_p8_faster_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_pdlib_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_pdlib_p8_intel
 Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1591,14 +1591,14 @@ Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1192.330005
-  0: The maximum resident set size (KB)                   = 1723240
+  0: The total amount of wall time                        = 1190.032742
+  0: The maximum resident set size (KB)                   = 1724236
 
 Test 024 cpld_control_pdlib_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_restart_pdlib_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_restart_pdlib_p8_intel
 Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1650,14 +1650,14 @@ Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 562.780361
-  0: The maximum resident set size (KB)                   = 1027792
+  0: The total amount of wall time                        = 562.045117
+  0: The maximum resident set size (KB)                   = 1017592
 
 Test 025 cpld_restart_pdlib_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_mpi_pdlib_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_mpi_pdlib_p8_intel
 Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1721,14 +1721,14 @@ Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1073.582346
-  0: The maximum resident set size (KB)                   = 1642796
+  0: The total amount of wall time                        = 1086.903666
+  0: The maximum resident set size (KB)                   = 1640820
 
 Test 026 cpld_mpi_pdlib_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_debug_pdlib_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_debug_pdlib_p8_intel
 Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1780,14 +1780,14 @@ Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1380.212171
-  0: The maximum resident set size (KB)                   = 1688176
+  0: The total amount of wall time                        = 1413.935354
+  0: The maximum resident set size (KB)                   = 1679440
 
 Test 027 cpld_debug_pdlib_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_flake_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_flake_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_flake_intel
 Checking test 028 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1798,14 +1798,14 @@ Checking test 028 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 186.948376
-  0: The maximum resident set size (KB)                   = 676632
+  0: The total amount of wall time                        = 189.800715
+  0: The maximum resident set size (KB)                   = 672136
 
 Test 028 control_flake_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_CubedSphereGrid_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_CubedSphereGrid_intel
 Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1832,28 +1832,28 @@ Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 130.396578
-  0: The maximum resident set size (KB)                   = 623264
+  0: The total amount of wall time                        = 131.882766
+  0: The maximum resident set size (KB)                   = 625124
 
 Test 029 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_CubedSphereGrid_parallel_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_CubedSphereGrid_parallel_intel
 Checking test 030 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 130.171513
-  0: The maximum resident set size (KB)                   = 615988
+  0: The total amount of wall time                        = 128.388593
+  0: The maximum resident set size (KB)                   = 625508
 
 Test 030 control_CubedSphereGrid_parallel_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_latlon_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_latlon_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_latlon_intel
 Checking test 031 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1864,14 +1864,14 @@ Checking test 031 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.774001
-  0: The maximum resident set size (KB)                   = 624640
+  0: The total amount of wall time                        = 135.841226
+  0: The maximum resident set size (KB)                   = 624092
 
 Test 031 control_latlon_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_wrtGauss_netcdf_parallel_intel
 Checking test 032 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1882,14 +1882,14 @@ Checking test 032 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 138.335397
-  0: The maximum resident set size (KB)                   = 624216
+  0: The total amount of wall time                        = 137.309184
+  0: The maximum resident set size (KB)                   = 620376
 
 Test 032 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_c48_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_c48_intel
 Checking test 033 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1928,14 +1928,14 @@ Checking test 033 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 367.673974
-0: The maximum resident set size (KB)                   = 810728
+0: The total amount of wall time                        = 369.770034
+0: The maximum resident set size (KB)                   = 816936
 
 Test 033 control_c48_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c192_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_c192_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_c192_intel
 Checking test 034 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1946,14 +1946,14 @@ Checking test 034 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 532.449454
-  0: The maximum resident set size (KB)                   = 762476
+  0: The total amount of wall time                        = 532.871499
+  0: The maximum resident set size (KB)                   = 762880
 
 Test 034 control_c192_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c384_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_c384_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_c384_intel
 Checking test 035 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1964,14 +1964,14 @@ Checking test 035 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 530.760852
-  0: The maximum resident set size (KB)                   = 1263608
+  0: The total amount of wall time                        = 531.526170
+  0: The maximum resident set size (KB)                   = 1246300
 
 Test 035 control_c384_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c384gdas_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_c384gdas_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_c384gdas_intel
 Checking test 036 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2014,14 +2014,14 @@ Checking test 036 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 462.060282
-  0: The maximum resident set size (KB)                   = 1371228
+  0: The total amount of wall time                        = 469.853046
+  0: The maximum resident set size (KB)                   = 1363048
 
 Test 036 control_c384gdas_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_stochy_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_stochy_intel
 Checking test 037 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2032,28 +2032,28 @@ Checking test 037 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 90.170238
-  0: The maximum resident set size (KB)                   = 626256
+  0: The total amount of wall time                        = 87.637053
+  0: The maximum resident set size (KB)                   = 625260
 
 Test 037 control_stochy_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_stochy_restart_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_stochy_restart_intel
 Checking test 038 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 50.972895
-  0: The maximum resident set size (KB)                   = 486380
+  0: The total amount of wall time                        = 48.463341
+  0: The maximum resident set size (KB)                   = 483728
 
 Test 038 control_stochy_restart_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_lndp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_lndp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_lndp_intel
 Checking test 039 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2064,14 +2064,14 @@ Checking test 039 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.639892
-  0: The maximum resident set size (KB)                   = 613056
+  0: The total amount of wall time                        = 82.340516
+  0: The maximum resident set size (KB)                   = 634708
 
 Test 039 control_lndp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_iovr4_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_iovr4_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_iovr4_intel
 Checking test 040 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2086,14 +2086,14 @@ Checking test 040 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.528043
-  0: The maximum resident set size (KB)                   = 626604
+  0: The total amount of wall time                        = 137.330559
+  0: The maximum resident set size (KB)                   = 612712
 
 Test 040 control_iovr4_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_iovr5_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_iovr5_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_iovr5_intel
 Checking test 041 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2108,14 +2108,14 @@ Checking test 041 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.434044
-  0: The maximum resident set size (KB)                   = 621932
+  0: The total amount of wall time                        = 136.623419
+  0: The maximum resident set size (KB)                   = 627128
 
 Test 041 control_iovr5_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_p8_intel
 Checking test 042 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2162,14 +2162,14 @@ Checking test 042 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.043756
-  0: The maximum resident set size (KB)                   = 1594916
+  0: The total amount of wall time                        = 171.462339
+  0: The maximum resident set size (KB)                   = 1589152
 
 Test 042 control_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_restart_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_restart_p8_intel
 Checking test 043 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2208,14 +2208,14 @@ Checking test 043 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.316030
-  0: The maximum resident set size (KB)                   = 870912
+  0: The total amount of wall time                        = 90.472233
+  0: The maximum resident set size (KB)                   = 848636
 
 Test 043 control_restart_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_qr_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_qr_p8_intel
 Checking test 044 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2262,14 +2262,14 @@ Checking test 044 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 169.377041
-  0: The maximum resident set size (KB)                   = 1604244
+  0: The total amount of wall time                        = 169.988348
+  0: The maximum resident set size (KB)                   = 1584232
 
 Test 044 control_qr_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_restart_qr_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_restart_qr_p8_intel
 Checking test 045 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2308,14 +2308,14 @@ Checking test 045 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 90.750330
-  0: The maximum resident set size (KB)                   = 859568
+  0: The total amount of wall time                        = 91.860235
+  0: The maximum resident set size (KB)                   = 857512
 
 Test 045 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_decomp_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_decomp_p8_intel
 Checking test 046 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2358,14 +2358,14 @@ Checking test 046 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.060506
-  0: The maximum resident set size (KB)                   = 1569816
+  0: The total amount of wall time                        = 177.748432
+  0: The maximum resident set size (KB)                   = 1581856
 
 Test 046 control_decomp_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_2threads_p8_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_2threads_p8_intel
 Checking test 047 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2408,14 +2408,14 @@ Checking test 047 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.871914
-  0: The maximum resident set size (KB)                   = 1675956
+  0: The total amount of wall time                        = 157.956910
+  0: The maximum resident set size (KB)                   = 1663028
 
 Test 047 control_2threads_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_lndp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_p8_lndp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_p8_lndp_intel
 Checking test 048 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2434,14 +2434,14 @@ Checking test 048 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 314.583527
-  0: The maximum resident set size (KB)                   = 1598168
+  0: The total amount of wall time                        = 315.486885
+  0: The maximum resident set size (KB)                   = 1595480
 
 Test 048 control_p8_lndp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_rrtmgp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_p8_rrtmgp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_p8_rrtmgp_intel
 Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2488,14 +2488,14 @@ Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 234.668473
-  0: The maximum resident set size (KB)                   = 1653872
+  0: The total amount of wall time                        = 226.549622
+  0: The maximum resident set size (KB)                   = 1657948
 
 Test 049 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_mynn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_p8_mynn_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_p8_mynn_intel
 Checking test 050 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2542,14 +2542,14 @@ Checking test 050 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.620143
-  0: The maximum resident set size (KB)                   = 1579060
+  0: The total amount of wall time                        = 173.994170
+  0: The maximum resident set size (KB)                   = 1569532
 
 Test 050 control_p8_mynn_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/merra2_thompson_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/merra2_thompson_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/merra2_thompson_intel
 Checking test 051 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2596,14 +2596,14 @@ Checking test 051 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.169586
-  0: The maximum resident set size (KB)                   = 1590368
+  0: The total amount of wall time                        = 193.946126
+  0: The maximum resident set size (KB)                   = 1588848
 
 Test 051 merra2_thompson_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_control_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_control_intel
 Checking test 052 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2614,28 +2614,28 @@ Checking test 052 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 294.542169
-  0: The maximum resident set size (KB)                   = 865416
+  0: The total amount of wall time                        = 296.145475
+  0: The maximum resident set size (KB)                   = 862232
 
 Test 052 regional_control_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_restart_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_restart_intel
 Checking test 053 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 149.272734
-  0: The maximum resident set size (KB)                   = 859976
+  0: The total amount of wall time                        = 157.818209
+  0: The maximum resident set size (KB)                   = 832276
 
 Test 053 regional_restart_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_control_qr_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_control_qr_intel
 Checking test 054 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2646,28 +2646,28 @@ Checking test 054 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 294.824086
-  0: The maximum resident set size (KB)                   = 862536
+  0: The total amount of wall time                        = 295.456569
+  0: The maximum resident set size (KB)                   = 866436
 
 Test 054 regional_control_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_restart_qr_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_restart_qr_intel
 Checking test 055 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 149.510684
-  0: The maximum resident set size (KB)                   = 835140
+  0: The total amount of wall time                        = 149.794468
+  0: The maximum resident set size (KB)                   = 856008
 
 Test 055 regional_restart_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_decomp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_decomp_intel
 Checking test 056 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2678,14 +2678,14 @@ Checking test 056 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 312.927872
-  0: The maximum resident set size (KB)                   = 856484
+  0: The total amount of wall time                        = 310.325532
+  0: The maximum resident set size (KB)                   = 851520
 
 Test 056 regional_decomp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_2threads_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_2threads_intel
 Checking test 057 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2696,14 +2696,14 @@ Checking test 057 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 176.170212
-  0: The maximum resident set size (KB)                   = 842840
+  0: The total amount of wall time                        = 181.215624
+  0: The maximum resident set size (KB)                   = 840396
 
 Test 057 regional_2threads_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_noquilt_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_noquilt_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_noquilt_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_noquilt_intel
 Checking test 058 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2711,28 +2711,28 @@ Checking test 058 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 293.063281
-  0: The maximum resident set size (KB)                   = 852660
+  0: The total amount of wall time                        = 294.949670
+  0: The maximum resident set size (KB)                   = 831912
 
 Test 058 regional_noquilt_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_netcdf_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_netcdf_parallel_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_netcdf_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_netcdf_parallel_intel
 Checking test 059 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 293.354889
-  0: The maximum resident set size (KB)                   = 860452
+  0: The total amount of wall time                        = 290.836973
+  0: The maximum resident set size (KB)                   = 856400
 
 Test 059 regional_netcdf_parallel_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_2dwrtdecomp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_2dwrtdecomp_intel
 Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2743,14 +2743,14 @@ Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 294.141050
-  0: The maximum resident set size (KB)                   = 862076
+  0: The total amount of wall time                        = 295.440022
+  0: The maximum resident set size (KB)                   = 863076
 
 Test 060 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/fv3_regional_wofs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_wofs_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/fv3_regional_wofs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_wofs_intel
 Checking test 061 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2761,14 +2761,14 @@ Checking test 061 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 373.457700
-  0: The maximum resident set size (KB)                   = 628512
+  0: The total amount of wall time                        = 375.377625
+  0: The maximum resident set size (KB)                   = 591552
 
 Test 061 regional_wofs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_intel
 Checking test 062 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2815,14 +2815,14 @@ Checking test 062 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 448.415452
-  0: The maximum resident set size (KB)                   = 1055884
+  0: The total amount of wall time                        = 449.291155
+  0: The maximum resident set size (KB)                   = 1041708
 
 Test 062 rap_control_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_spp_sppt_shum_skeb_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_spp_sppt_shum_skeb_intel
 Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2833,14 +2833,14 @@ Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 232.685577
-  0: The maximum resident set size (KB)                   = 1179776
+  0: The total amount of wall time                        = 232.157605
+  0: The maximum resident set size (KB)                   = 1180984
 
 Test 063 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_decomp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_decomp_intel
 Checking test 064 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2887,14 +2887,14 @@ Checking test 064 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.513623
-  0: The maximum resident set size (KB)                   = 998788
+  0: The total amount of wall time                        = 464.810963
+  0: The maximum resident set size (KB)                   = 994648
 
 Test 064 rap_decomp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_2threads_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_2threads_intel
 Checking test 065 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2941,14 +2941,14 @@ Checking test 065 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 417.397500
-  0: The maximum resident set size (KB)                   = 1135716
+  0: The total amount of wall time                        = 419.478604
+  0: The maximum resident set size (KB)                   = 1129736
 
 Test 065 rap_2threads_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_restart_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_restart_intel
 Checking test 066 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2987,14 +2987,14 @@ Checking test 066 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 227.804278
-  0: The maximum resident set size (KB)                   = 931612
+  0: The total amount of wall time                        = 225.691802
+  0: The maximum resident set size (KB)                   = 953224
 
 Test 066 rap_restart_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_sfcdiff_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_sfcdiff_intel
 Checking test 067 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3041,14 +3041,14 @@ Checking test 067 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 454.477794
-  0: The maximum resident set size (KB)                   = 1055704
+  0: The total amount of wall time                        = 447.401708
+  0: The maximum resident set size (KB)                   = 1038424
 
 Test 067 rap_sfcdiff_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_sfcdiff_decomp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_sfcdiff_decomp_intel
 Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3095,14 +3095,14 @@ Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 470.646570
-  0: The maximum resident set size (KB)                   = 997416
+  0: The total amount of wall time                        = 471.083168
+  0: The maximum resident set size (KB)                   = 991336
 
 Test 068 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_sfcdiff_restart_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_sfcdiff_restart_intel
 Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3141,69 +3141,15 @@ Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.774736
-  0: The maximum resident set size (KB)                   = 981412
+  0: The total amount of wall time                        = 335.570964
+  0: The maximum resident set size (KB)                   = 982300
 
 Test 069 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_intel
 Checking test 070 hrrr_control_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 434.233941
-  0: The maximum resident set size (KB)                   = 1047676
-
-Test 070 hrrr_control_intel PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_qr_intel
-Checking test 071 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3249,14 +3195,68 @@ Checking test 071 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 427.047126
-  0: The maximum resident set size (KB)                   = 1057036
+  0: The total amount of wall time                        = 433.422251
+  0: The maximum resident set size (KB)                   = 1036712
+
+Test 070 hrrr_control_intel PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_qr_intel
+Checking test 071 hrrr_control_qr_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 428.397940
+  0: The maximum resident set size (KB)                   = 1047872
 
 Test 071 hrrr_control_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_decomp_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_decomp_intel
 Checking test 072 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3272,45 +3272,45 @@ Checking test 072 hrrr_control_decomp_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 452.873544
-  0: The maximum resident set size (KB)                   = 994024
+  0: The total amount of wall time                        = 451.602722
+  0: The maximum resident set size (KB)                   = 987708
 
 Test 072 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_2threads_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_2threads_intel
 Checking test 073 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3326,73 +3326,73 @@ Checking test 073 hrrr_control_2threads_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 402.720667
-  0: The maximum resident set size (KB)                   = 1071268
+  0: The total amount of wall time                        = 400.077430
+  0: The maximum resident set size (KB)                   = 1070652
 
 Test 073 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_intel
 Checking test 074 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 320.161964
-  0: The maximum resident set size (KB)                   = 945768
+  0: The total amount of wall time                        = 321.714543
+  0: The maximum resident set size (KB)                   = 973840
 
 Test 074 hrrr_control_restart_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_qr_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_qr_intel
 Checking test 075 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 322.012029
-  0: The maximum resident set size (KB)                   = 986160
+  0: The total amount of wall time                        = 324.574185
+  0: The maximum resident set size (KB)                   = 983820
 
 Test 075 hrrr_control_restart_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_v1beta_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_v1beta_intel
 Checking test 076 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3439,14 +3439,14 @@ Checking test 076 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 442.821858
-  0: The maximum resident set size (KB)                   = 1054080
+  0: The total amount of wall time                        = 445.921957
+  0: The maximum resident set size (KB)                   = 1017096
 
 Test 076 rrfs_v1beta_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_v1nssl_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_v1nssl_intel
 Checking test 077 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3461,14 +3461,14 @@ Checking test 077 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 525.675316
-  0: The maximum resident set size (KB)                   = 681548
+  0: The total amount of wall time                        = 522.848247
+  0: The maximum resident set size (KB)                   = 684980
 
 Test 077 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_v1nssl_nohailnoccn_intel
 Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3483,14 +3483,14 @@ Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 511.051727
-  0: The maximum resident set size (KB)                   = 753556
+  0: The total amount of wall time                        = 507.403791
+  0: The maximum resident set size (KB)                   = 753076
 
 Test 078 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3506,15 +3506,31 @@ Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 149.641939
-  0: The maximum resident set size (KB)                   = 1025188
+  0: The total amount of wall time                        = 150.468741
+  0: The maximum resident set size (KB)                   = 1026548
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_qr_intel
-Checking test 080 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+Checking test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 95.663001
+  0: The maximum resident set size (KB)                   = 937772
+
+Test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_conus13km_hrrr_warm_intel
+Checking test 081 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3529,15 +3545,15 @@ Checking test 080 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 149.612610
-  0: The maximum resident set size (KB)                   = 1029612
+  0: The total amount of wall time                        = 134.725072
+  0: The maximum resident set size (KB)                   = 973608
 
-Test 080 rrfs_smoke_conus13km_hrrr_warm_qr_intel PASS
+Test 081 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
-Checking test 081 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_radar_tten_warm_intel
+Checking test 082 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3545,78 +3561,27 @@ Checking test 081 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 93.135613
-  0: The maximum resident set size (KB)                   = 938548
+  0: The total amount of wall time                        = 151.263430
+  0: The maximum resident set size (KB)                   = 1030924
 
-Test 081 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_conus13km_hrrr_warm_intel
-Checking test 082 rrfs_conus13km_hrrr_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-  0: The total amount of wall time                        = 133.722765
-  0: The maximum resident set size (KB)                   = 983120
-
-Test 082 rrfs_conus13km_hrrr_warm_intel PASS
+Test 082 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_radar_tten_warm_intel
-Checking test 083 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 153.521705
-  0: The maximum resident set size (KB)                   = 1018544
-
-Test 083 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-Checking test 084 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+Checking test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 84.291088
-  0: The maximum resident set size (KB)                   = 1020412
+  0: The total amount of wall time                        = 88.402729
+  0: The maximum resident set size (KB)                   = 1015772
 
-Test 084 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel
-Checking test 085 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 83.734901
-  0: The maximum resident set size (KB)                   = 1023256
-
-Test 085 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel PASS
+Test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmg_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_csawmg_intel
-Checking test 086 control_csawmg_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmg_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_csawmg_intel
+Checking test 084 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3626,15 +3591,15 @@ Checking test 086 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 343.051639
-  0: The maximum resident set size (KB)                   = 721520
+  0: The total amount of wall time                        = 337.999732
+  0: The maximum resident set size (KB)                   = 722756
 
-Test 086 control_csawmg_intel PASS
+Test 084 control_csawmg_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_csawmgt_intel
-Checking test 087 control_csawmgt_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_csawmgt_intel
+Checking test 085 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3644,15 +3609,15 @@ Checking test 087 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 333.110336
-  0: The maximum resident set size (KB)                   = 716140
+  0: The total amount of wall time                        = 333.616989
+  0: The maximum resident set size (KB)                   = 719800
 
-Test 087 control_csawmgt_intel PASS
+Test 085 control_csawmgt_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_ras_intel
-Checking test 088 control_ras_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_ras_intel
+Checking test 086 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3662,27 +3627,27 @@ Checking test 088 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 183.452553
-  0: The maximum resident set size (KB)                   = 721288
+  0: The total amount of wall time                        = 182.745456
+  0: The maximum resident set size (KB)                   = 707060
 
-Test 088 control_ras_intel PASS
+Test 086 control_ras_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wam_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_wam_intel
-Checking test 089 control_wam_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_wam_intel
+Checking test 087 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 115.746593
-  0: The maximum resident set size (KB)                   = 639532
+  0: The total amount of wall time                        = 113.167480
+  0: The maximum resident set size (KB)                   = 633228
 
-Test 089 control_wam_intel PASS
+Test 087 control_wam_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_p8_faster_intel
-Checking test 090 control_p8_faster_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_p8_faster_intel
+Checking test 088 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3728,15 +3693,15 @@ Checking test 090 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.673845
-  0: The maximum resident set size (KB)                   = 1604364
+  0: The total amount of wall time                        = 155.584861
+  0: The maximum resident set size (KB)                   = 1597048
 
-Test 090 control_p8_faster_intel PASS
+Test 088 control_p8_faster_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_control_faster_intel
-Checking test 091 regional_control_faster_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_control_faster_intel
+Checking test 089 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3746,57 +3711,57 @@ Checking test 091 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 269.681093
-  0: The maximum resident set size (KB)                   = 868576
+  0: The total amount of wall time                        = 266.904790
+  0: The maximum resident set size (KB)                   = 845068
 
-Test 091 regional_control_faster_intel PASS
+Test 089 regional_control_faster_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-Checking test 092 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+Checking test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 842.953494
-  0: The maximum resident set size (KB)                   = 1053536
+  0: The total amount of wall time                        = 847.048172
+  0: The maximum resident set size (KB)                   = 1060636
 
-Test 092 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
+Test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
-Checking test 093 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+Checking test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 474.896467
-  0: The maximum resident set size (KB)                   = 971316
+  0: The total amount of wall time                        = 466.434281
+  0: The maximum resident set size (KB)                   = 970080
 
-Test 093 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
+Test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_conus13km_hrrr_warm_debug_intel
-Checking test 094 rrfs_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_conus13km_hrrr_warm_debug_intel
+Checking test 092 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 743.879118
-  0: The maximum resident set size (KB)                   = 1011324
+  0: The total amount of wall time                        = 747.621899
+  0: The maximum resident set size (KB)                   = 996236
 
-Test 094 rrfs_conus13km_hrrr_warm_debug_intel PASS
+Test 092 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_CubedSphereGrid_debug_intel
-Checking test 095 control_CubedSphereGrid_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_CubedSphereGrid_debug_intel
+Checking test 093 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3822,349 +3787,349 @@ Checking test 095 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.967566
-  0: The maximum resident set size (KB)                   = 787568
+  0: The total amount of wall time                        = 148.517677
+  0: The maximum resident set size (KB)                   = 786892
 
-Test 095 control_CubedSphereGrid_debug_intel PASS
+Test 093 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_wrtGauss_netcdf_parallel_debug_intel
-Checking test 096 control_wrtGauss_netcdf_parallel_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_wrtGauss_netcdf_parallel_debug_intel
+Checking test 094 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.082952
-  0: The maximum resident set size (KB)                   = 786952
+  0: The total amount of wall time                        = 149.686412
+  0: The maximum resident set size (KB)                   = 789440
 
-Test 096 control_wrtGauss_netcdf_parallel_debug_intel PASS
+Test 094 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_stochy_debug_intel
-Checking test 097 control_stochy_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_stochy_debug_intel
+Checking test 095 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.781934
-  0: The maximum resident set size (KB)                   = 795852
+  0: The total amount of wall time                        = 165.194639
+  0: The maximum resident set size (KB)                   = 793816
 
-Test 097 control_stochy_debug_intel PASS
+Test 095 control_stochy_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_lndp_debug_intel
-Checking test 098 control_lndp_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_lndp_debug_intel
+Checking test 096 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.375267
-  0: The maximum resident set size (KB)                   = 790832
+  0: The total amount of wall time                        = 150.328466
+  0: The maximum resident set size (KB)                   = 787824
 
-Test 098 control_lndp_debug_intel PASS
+Test 096 control_lndp_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmg_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_csawmg_debug_intel
-Checking test 099 control_csawmg_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_csawmg_debug_intel
+Checking test 097 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.666382
-  0: The maximum resident set size (KB)                   = 837244
+  0: The total amount of wall time                        = 230.258067
+  0: The maximum resident set size (KB)                   = 837952
 
-Test 099 control_csawmg_debug_intel PASS
+Test 097 control_csawmg_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_csawmgt_debug_intel
-Checking test 100 control_csawmgt_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_csawmgt_debug_intel
+Checking test 098 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 222.546021
-  0: The maximum resident set size (KB)                   = 836864
+  0: The total amount of wall time                        = 226.342755
+  0: The maximum resident set size (KB)                   = 810644
 
-Test 100 control_csawmgt_debug_intel PASS
+Test 098 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_ras_debug_intel
-Checking test 101 control_ras_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_ras_debug_intel
+Checking test 099 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.507659
-  0: The maximum resident set size (KB)                   = 804544
+  0: The total amount of wall time                        = 149.456271
+  0: The maximum resident set size (KB)                   = 800516
 
-Test 101 control_ras_debug_intel PASS
+Test 099 control_ras_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_diag_debug_intel
-Checking test 102 control_diag_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_diag_debug_intel
+Checking test 100 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.615453
-  0: The maximum resident set size (KB)                   = 849864
+  0: The total amount of wall time                        = 151.931749
+  0: The maximum resident set size (KB)                   = 853324
 
-Test 102 control_diag_debug_intel PASS
+Test 100 control_diag_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_debug_p8_intel
-Checking test 103 control_debug_p8_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_debug_p8_intel
+Checking test 101 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.374881
-  0: The maximum resident set size (KB)                   = 1611840
+  0: The total amount of wall time                        = 166.781097
+  0: The maximum resident set size (KB)                   = 1600016
 
-Test 103 control_debug_p8_intel PASS
+Test 101 control_debug_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_debug_intel
-Checking test 104 regional_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_debug_intel
+Checking test 102 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 972.418067
-  0: The maximum resident set size (KB)                   = 883648
+  0: The total amount of wall time                        = 998.613449
+  0: The maximum resident set size (KB)                   = 874004
 
-Test 104 regional_debug_intel PASS
+Test 102 regional_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_debug_intel
-Checking test 105 rap_control_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_debug_intel
+Checking test 103 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.555773
-  0: The maximum resident set size (KB)                   = 1145380
+  0: The total amount of wall time                        = 271.787721
+  0: The maximum resident set size (KB)                   = 1165996
 
-Test 105 rap_control_debug_intel PASS
+Test 103 rap_control_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_debug_intel
-Checking test 106 hrrr_control_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_debug_intel
+Checking test 104 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.895268
-  0: The maximum resident set size (KB)                   = 1165736
+  0: The total amount of wall time                        = 270.206389
+  0: The maximum resident set size (KB)                   = 1163848
 
-Test 106 hrrr_control_debug_intel PASS
+Test 104 hrrr_control_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_unified_drag_suite_debug_intel
-Checking test 107 rap_unified_drag_suite_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_unified_drag_suite_debug_intel
+Checking test 105 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.204715
-  0: The maximum resident set size (KB)                   = 1165472
+  0: The total amount of wall time                        = 271.345757
+  0: The maximum resident set size (KB)                   = 1164632
 
-Test 107 rap_unified_drag_suite_debug_intel PASS
+Test 105 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_diag_debug_intel
-Checking test 108 rap_diag_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_diag_debug_intel
+Checking test 106 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.999102
-  0: The maximum resident set size (KB)                   = 1252676
+  0: The total amount of wall time                        = 287.256498
+  0: The maximum resident set size (KB)                   = 1248080
 
-Test 108 rap_diag_debug_intel PASS
+Test 106 rap_diag_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_cires_ugwp_debug_intel
-Checking test 109 rap_cires_ugwp_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_cires_ugwp_debug_intel
+Checking test 107 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.889568
-  0: The maximum resident set size (KB)                   = 1171092
+  0: The total amount of wall time                        = 279.112624
+  0: The maximum resident set size (KB)                   = 1145436
 
-Test 109 rap_cires_ugwp_debug_intel PASS
+Test 107 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_unified_ugwp_debug_intel
-Checking test 110 rap_unified_ugwp_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_unified_ugwp_debug_intel
+Checking test 108 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.636074
-  0: The maximum resident set size (KB)                   = 1169672
+  0: The total amount of wall time                        = 275.347472
+  0: The maximum resident set size (KB)                   = 1164204
 
-Test 110 rap_unified_ugwp_debug_intel PASS
+Test 108 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_lndp_debug_intel
-Checking test 111 rap_lndp_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_lndp_debug_intel
+Checking test 109 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.393594
-  0: The maximum resident set size (KB)                   = 1165188
+  0: The total amount of wall time                        = 274.650884
+  0: The maximum resident set size (KB)                   = 1176432
 
-Test 111 rap_lndp_debug_intel PASS
+Test 109 rap_lndp_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_progcld_thompson_debug_intel
-Checking test 112 rap_progcld_thompson_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_progcld_thompson_debug_intel
+Checking test 110 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.606207
-  0: The maximum resident set size (KB)                   = 1167688
+  0: The total amount of wall time                        = 270.530313
+  0: The maximum resident set size (KB)                   = 1142632
 
-Test 112 rap_progcld_thompson_debug_intel PASS
+Test 110 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_noah_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_noah_debug_intel
-Checking test 113 rap_noah_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_noah_debug_intel
+Checking test 111 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.935314
-  0: The maximum resident set size (KB)                   = 1165080
+  0: The total amount of wall time                        = 267.955535
+  0: The maximum resident set size (KB)                   = 1165360
 
-Test 113 rap_noah_debug_intel PASS
+Test 111 rap_noah_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_sfcdiff_debug_intel
-Checking test 114 rap_sfcdiff_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_sfcdiff_debug_intel
+Checking test 112 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.512001
-  0: The maximum resident set size (KB)                   = 1166368
+  0: The total amount of wall time                        = 271.540647
+  0: The maximum resident set size (KB)                   = 1171736
 
-Test 114 rap_sfcdiff_debug_intel PASS
+Test 112 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_noah_sfcdiff_cires_ugwp_debug_intel
-Checking test 115 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_noah_sfcdiff_cires_ugwp_debug_intel
+Checking test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 447.046202
-  0: The maximum resident set size (KB)                   = 1169508
+  0: The total amount of wall time                        = 450.388998
+  0: The maximum resident set size (KB)                   = 1166256
 
-Test 115 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
+Test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_v1beta_debug_intel
-Checking test 116 rrfs_v1beta_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_v1beta_debug_intel
+Checking test 114 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 267.432769
-  0: The maximum resident set size (KB)                   = 1136632
+  0: The total amount of wall time                        = 273.329362
+  0: The maximum resident set size (KB)                   = 1168172
 
-Test 116 rrfs_v1beta_debug_intel PASS
+Test 114 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_clm_lake_debug_intel
-Checking test 117 rap_clm_lake_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_clm_lake_debug_intel
+Checking test 115 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 328.646649
-  0: The maximum resident set size (KB)                   = 1159064
+  0: The total amount of wall time                        = 330.981522
+  0: The maximum resident set size (KB)                   = 1165868
 
-Test 117 rap_clm_lake_debug_intel PASS
+Test 115 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_flake_debug_intel
-Checking test 118 rap_flake_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_flake_debug_intel
+Checking test 116 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.915723
-  0: The maximum resident set size (KB)                   = 1167432
+  0: The total amount of wall time                        = 274.429448
+  0: The maximum resident set size (KB)                   = 1166552
 
-Test 118 rap_flake_debug_intel PASS
+Test 116 rap_flake_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_wam_debug_intel
-Checking test 119 control_wam_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_wam_debug_intel
+Checking test 117 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 279.690514
-  0: The maximum resident set size (KB)                   = 519228
+  0: The total amount of wall time                        = 273.956791
+  0: The maximum resident set size (KB)                   = 523732
 
-Test 119 control_wam_debug_intel PASS
+Test 117 control_wam_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 120 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+Checking test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4174,15 +4139,15 @@ Checking test 120 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 217.044462
-  0: The maximum resident set size (KB)                   = 1069200
+  0: The total amount of wall time                        = 213.915631
+  0: The maximum resident set size (KB)                   = 1070620
 
-Test 120 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+Test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_dyn32_phy32_intel
-Checking test 121 rap_control_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_dyn32_phy32_intel
+Checking test 119 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4228,15 +4193,15 @@ Checking test 121 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 368.683816
-  0: The maximum resident set size (KB)                   = 1000208
+  0: The total amount of wall time                        = 372.234458
+  0: The maximum resident set size (KB)                   = 991720
 
-Test 121 rap_control_dyn32_phy32_intel PASS
+Test 119 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_dyn32_phy32_intel
-Checking test 122 hrrr_control_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_dyn32_phy32_intel
+Checking test 120 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4282,15 +4247,15 @@ Checking test 122 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.902285
-  0: The maximum resident set size (KB)                   = 925696
+  0: The total amount of wall time                        = 189.858524
+  0: The maximum resident set size (KB)                   = 945924
 
-Test 122 hrrr_control_dyn32_phy32_intel PASS
+Test 120 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_qr_dyn32_phy32_intel
-Checking test 123 hrrr_control_qr_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_qr_dyn32_phy32_intel
+Checking test 121 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4336,15 +4301,15 @@ Checking test 123 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.526432
-  0: The maximum resident set size (KB)                   = 967640
+  0: The total amount of wall time                        = 191.238913
+  0: The maximum resident set size (KB)                   = 962244
 
-Test 123 hrrr_control_qr_dyn32_phy32_intel PASS
+Test 121 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_2threads_dyn32_phy32_intel
-Checking test 124 rap_2threads_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_2threads_dyn32_phy32_intel
+Checking test 122 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4390,15 +4355,15 @@ Checking test 124 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 352.813415
-  0: The maximum resident set size (KB)                   = 1007936
+  0: The total amount of wall time                        = 349.547863
+  0: The maximum resident set size (KB)                   = 1008548
 
-Test 124 rap_2threads_dyn32_phy32_intel PASS
+Test 122 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 125 hrrr_control_2threads_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_2threads_dyn32_phy32_intel
+Checking test 123 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4444,15 +4409,15 @@ Checking test 125 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.878321
-  0: The maximum resident set size (KB)                   = 938764
+  0: The total amount of wall time                        = 177.162758
+  0: The maximum resident set size (KB)                   = 918932
 
-Test 125 hrrr_control_2threads_dyn32_phy32_intel PASS
+Test 123 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 126 hrrr_control_decomp_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_decomp_dyn32_phy32_intel
+Checking test 124 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4498,15 +4463,15 @@ Checking test 126 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.034535
-  0: The maximum resident set size (KB)                   = 893156
+  0: The total amount of wall time                        = 203.373104
+  0: The maximum resident set size (KB)                   = 872496
 
-Test 126 hrrr_control_decomp_dyn32_phy32_intel PASS
+Test 124 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_restart_dyn32_phy32_intel
-Checking test 127 rap_restart_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_restart_dyn32_phy32_intel
+Checking test 125 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -4544,43 +4509,43 @@ Checking test 127 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.371853
-  0: The maximum resident set size (KB)                   = 937048
+  0: The total amount of wall time                        = 275.500941
+  0: The maximum resident set size (KB)                   = 928260
 
-Test 127 rap_restart_dyn32_phy32_intel PASS
+Test 125 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_dyn32_phy32_intel
-Checking test 128 hrrr_control_restart_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_dyn32_phy32_intel
+Checking test 126 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 99.078936
-  0: The maximum resident set size (KB)                   = 857100
+  0: The total amount of wall time                        = 101.288580
+  0: The maximum resident set size (KB)                   = 858976
 
-Test 128 hrrr_control_restart_dyn32_phy32_intel PASS
+Test 126 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_qr_dyn32_phy32_intel
-Checking test 129 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 127 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.950429
-  0: The maximum resident set size (KB)                   = 876796
+  0: The total amount of wall time                        = 103.324400
+  0: The maximum resident set size (KB)                   = 874000
 
-Test 129 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+Test 127 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_dyn64_phy32_intel
-Checking test 130 rap_control_dyn64_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_dyn64_phy32_intel
+Checking test 128 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4626,82 +4591,82 @@ Checking test 130 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 239.966746
-  0: The maximum resident set size (KB)                   = 933180
+  0: The total amount of wall time                        = 241.075748
+  0: The maximum resident set size (KB)                   = 944736
 
-Test 130 rap_control_dyn64_phy32_intel PASS
+Test 128 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_debug_dyn32_phy32_intel
-Checking test 131 rap_control_debug_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_debug_dyn32_phy32_intel
+Checking test 129 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.164325
-  0: The maximum resident set size (KB)                   = 1051088
+  0: The total amount of wall time                        = 271.166751
+  0: The maximum resident set size (KB)                   = 1049124
 
-Test 131 rap_control_debug_dyn32_phy32_intel PASS
+Test 129 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_debug_dyn32_phy32_intel
-Checking test 132 hrrr_control_debug_dyn32_phy32_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_debug_dyn32_phy32_intel
+Checking test 130 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.156865
-  0: The maximum resident set size (KB)                   = 1027076
+  0: The total amount of wall time                        = 269.403542
+  0: The maximum resident set size (KB)                   = 1037380
 
-Test 132 hrrr_control_debug_dyn32_phy32_intel PASS
+Test 130 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_dyn64_phy32_debug_intel
-Checking test 133 rap_control_dyn64_phy32_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_dyn64_phy32_debug_intel
+Checking test 131 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.935129
-  0: The maximum resident set size (KB)                   = 1093824
+  0: The total amount of wall time                        = 278.956473
+  0: The maximum resident set size (KB)                   = 1084084
 
-Test 133 rap_control_dyn64_phy32_debug_intel PASS
+Test 131 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_atm_intel
-Checking test 134 hafs_regional_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_atm_intel
+Checking test 132 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 226.048826
-  0: The maximum resident set size (KB)                   = 1046796
+  0: The total amount of wall time                        = 228.353104
+  0: The maximum resident set size (KB)                   = 1040408
 
-Test 134 hafs_regional_atm_intel PASS
+Test 132 hafs_regional_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_atm_thompson_gfdlsf_intel
-Checking test 135 hafs_regional_atm_thompson_gfdlsf_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_atm_thompson_gfdlsf_intel
+Checking test 133 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 336.903448
-  0: The maximum resident set size (KB)                   = 1401072
+  0: The total amount of wall time                        = 322.045899
+  0: The maximum resident set size (KB)                   = 1419520
 
-Test 135 hafs_regional_atm_thompson_gfdlsf_intel PASS
+Test 133 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_atm_ocn_intel
-Checking test 136 hafs_regional_atm_ocn_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_atm_ocn_intel
+Checking test 134 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4709,15 +4674,15 @@ Checking test 136 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 379.944733
-  0: The maximum resident set size (KB)                   = 1218544
+  0: The total amount of wall time                        = 384.243856
+  0: The maximum resident set size (KB)                   = 1199456
 
-Test 136 hafs_regional_atm_ocn_intel PASS
+Test 134 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_atm_wav_intel
-Checking test 137 hafs_regional_atm_wav_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_atm_wav_intel
+Checking test 135 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4725,15 +4690,15 @@ Checking test 137 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 742.436377
-  0: The maximum resident set size (KB)                   = 1246256
+  0: The total amount of wall time                        = 748.475318
+  0: The maximum resident set size (KB)                   = 1225860
 
-Test 137 hafs_regional_atm_wav_intel PASS
+Test 135 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_atm_ocn_wav_intel
-Checking test 138 hafs_regional_atm_ocn_wav_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_atm_ocn_wav_intel
+Checking test 136 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4743,15 +4708,15 @@ Checking test 138 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 843.100559
-  0: The maximum resident set size (KB)                   = 1245844
+  0: The total amount of wall time                        = 853.483201
+  0: The maximum resident set size (KB)                   = 1261420
 
-Test 138 hafs_regional_atm_ocn_wav_intel PASS
+Test 136 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_1nest_atm_intel
-Checking test 139 hafs_regional_1nest_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_1nest_atm_intel
+Checking test 137 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4772,15 +4737,15 @@ Checking test 139 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 295.907834
-  0: The maximum resident set size (KB)                   = 471648
+  0: The total amount of wall time                        = 304.469457
+  0: The maximum resident set size (KB)                   = 499836
 
-Test 139 hafs_regional_1nest_atm_intel PASS
+Test 137 hafs_regional_1nest_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_1nest_atm_qr_intel
-Checking test 140 hafs_regional_1nest_atm_qr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_1nest_atm_qr_intel
+Checking test 138 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4801,15 +4766,15 @@ Checking test 140 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 312.882021
-  0: The maximum resident set size (KB)                   = 468016
+  0: The total amount of wall time                        = 316.451201
+  0: The maximum resident set size (KB)                   = 474248
 
-Test 140 hafs_regional_1nest_atm_qr_intel PASS
+Test 138 hafs_regional_1nest_atm_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_telescopic_2nests_atm_intel
-Checking test 141 hafs_regional_telescopic_2nests_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_telescopic_2nests_atm_intel
+Checking test 139 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4817,15 +4782,15 @@ Checking test 141 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 340.918538
-  0: The maximum resident set size (KB)                   = 507740
+  0: The total amount of wall time                        = 341.447268
+  0: The maximum resident set size (KB)                   = 510992
 
-Test 141 hafs_regional_telescopic_2nests_atm_intel PASS
+Test 139 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_global_1nest_atm_intel
-Checking test 142 hafs_global_1nest_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_global_1nest_atm_intel
+Checking test 140 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4871,15 +4836,15 @@ Checking test 142 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 139.578064
-  0: The maximum resident set size (KB)                   = 347580
+  0: The total amount of wall time                        = 139.383747
+  0: The maximum resident set size (KB)                   = 351900
 
-Test 142 hafs_global_1nest_atm_intel PASS
+Test 140 hafs_global_1nest_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_global_1nest_atm_qr_intel
-Checking test 143 hafs_global_1nest_atm_qr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_global_1nest_atm_qr_intel
+Checking test 141 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4925,15 +4890,15 @@ Checking test 143 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 143.478338
-  0: The maximum resident set size (KB)                   = 346884
+  0: The total amount of wall time                        = 147.089019
+  0: The maximum resident set size (KB)                   = 351080
 
-Test 143 hafs_global_1nest_atm_qr_intel PASS
+Test 141 hafs_global_1nest_atm_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_global_multiple_4nests_atm_intel
-Checking test 144 hafs_global_multiple_4nests_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_global_multiple_4nests_atm_intel
+Checking test 142 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5014,15 +4979,15 @@ Checking test 144 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 393.004267
-  0: The maximum resident set size (KB)                   = 427252
+  0: The total amount of wall time                        = 404.202141
+  0: The maximum resident set size (KB)                   = 451700
 
-Test 144 hafs_global_multiple_4nests_atm_intel PASS
+Test 142 hafs_global_multiple_4nests_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_global_multiple_4nests_atm_qr_intel
-Checking test 145 hafs_global_multiple_4nests_atm_qr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_global_multiple_4nests_atm_qr_intel
+Checking test 143 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5103,15 +5068,15 @@ Checking test 145 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 426.956600
-  0: The maximum resident set size (KB)                   = 441068
+  0: The total amount of wall time                        = 423.768421
+  0: The maximum resident set size (KB)                   = 444608
 
-Test 145 hafs_global_multiple_4nests_atm_qr_intel PASS
+Test 143 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_specified_moving_1nest_atm_intel
-Checking test 146 hafs_regional_specified_moving_1nest_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_specified_moving_1nest_atm_intel
+Checking test 144 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5119,15 +5084,15 @@ Checking test 146 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 194.800377
-  0: The maximum resident set size (KB)                   = 516096
+  0: The total amount of wall time                        = 193.264241
+  0: The maximum resident set size (KB)                   = 516244
 
-Test 146 hafs_regional_specified_moving_1nest_atm_intel PASS
+Test 144 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_storm_following_1nest_atm_intel
-Checking test 147 hafs_regional_storm_following_1nest_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_storm_following_1nest_atm_intel
+Checking test 145 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5148,15 +5113,15 @@ Checking test 147 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 181.781239
-  0: The maximum resident set size (KB)                   = 513024
+  0: The total amount of wall time                        = 183.288131
+  0: The maximum resident set size (KB)                   = 516980
 
-Test 147 hafs_regional_storm_following_1nest_atm_intel PASS
+Test 145 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_storm_following_1nest_atm_qr_intel
-Checking test 148 hafs_regional_storm_following_1nest_atm_qr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_storm_following_1nest_atm_qr_intel
+Checking test 146 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5177,15 +5142,15 @@ Checking test 148 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 200.632059
-  0: The maximum resident set size (KB)                   = 503056
+  0: The total amount of wall time                        = 199.494375
+  0: The maximum resident set size (KB)                   = 500516
 
-Test 148 hafs_regional_storm_following_1nest_atm_qr_intel PASS
+Test 146 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_storm_following_1nest_atm_ocn_intel
-Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_storm_following_1nest_atm_ocn_intel
+Checking test 147 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5193,43 +5158,43 @@ Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 220.157324
-  0: The maximum resident set size (KB)                   = 564288
+  0: The total amount of wall time                        = 220.943321
+  0: The maximum resident set size (KB)                   = 564816
 
-Test 149 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
+Test 147 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_global_storm_following_1nest_atm_intel
-Checking test 150 hafs_global_storm_following_1nest_atm_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_storm_following_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_global_storm_following_1nest_atm_intel
+Checking test 148 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 56.025285
-  0: The maximum resident set size (KB)                   = 363912
+  0: The total amount of wall time                        = 58.455741
+  0: The maximum resident set size (KB)                   = 371968
 
-Test 150 hafs_global_storm_following_1nest_atm_intel PASS
+Test 148 hafs_global_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-Checking test 151 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 729.678318
-  0: The maximum resident set size (KB)                   = 583896
+  0: The total amount of wall time                        = 715.464111
+  0: The maximum resident set size (KB)                   = 582548
 
-Test 151 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
+Test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-Checking test 152 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+Checking test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5239,162 +5204,162 @@ Checking test 152 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 485.869594
-  0: The maximum resident set size (KB)                   = 613876
+  0: The total amount of wall time                        = 485.166530
+  0: The maximum resident set size (KB)                   = 614812
 
-Test 152 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
+Test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_docn_intel
-Checking test 153 hafs_regional_docn_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_docn_intel
+Checking test 151 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 342.609626
-  0: The maximum resident set size (KB)                   = 1225376
+  0: The total amount of wall time                        = 343.282138
+  0: The maximum resident set size (KB)                   = 1218336
 
-Test 153 hafs_regional_docn_intel PASS
+Test 151 hafs_regional_docn_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_oisst_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_docn_oisst_intel
-Checking test 154 hafs_regional_docn_oisst_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_oisst_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_docn_oisst_intel
+Checking test 152 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 345.634874
-  0: The maximum resident set size (KB)                   = 1214340
+  0: The total amount of wall time                        = 347.266999
+  0: The maximum resident set size (KB)                   = 1197988
 
-Test 154 hafs_regional_docn_oisst_intel PASS
+Test 152 hafs_regional_docn_oisst_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_datm_cdeps_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hafs_regional_datm_cdeps_intel
-Checking test 155 hafs_regional_datm_cdeps_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_datm_cdeps_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hafs_regional_datm_cdeps_intel
+Checking test 153 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 960.021123
-  0: The maximum resident set size (KB)                   = 1023280
+  0: The total amount of wall time                        = 957.555215
+  0: The maximum resident set size (KB)                   = 1036264
 
-Test 155 hafs_regional_datm_cdeps_intel PASS
+Test 153 hafs_regional_datm_cdeps_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_control_cfsr_intel
-Checking test 156 datm_cdeps_control_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_control_cfsr_intel
+Checking test 154 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.027425
- 0: The maximum resident set size (KB)                   = 1056232
+ 0: The total amount of wall time                        = 149.285473
+ 0: The maximum resident set size (KB)                   = 1066928
 
-Test 156 datm_cdeps_control_cfsr_intel PASS
+Test 154 datm_cdeps_control_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_restart_cfsr_intel
-Checking test 157 datm_cdeps_restart_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_restart_cfsr_intel
+Checking test 155 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 91.464998
- 0: The maximum resident set size (KB)                   = 1006948
+ 0: The total amount of wall time                        = 89.103133
+ 0: The maximum resident set size (KB)                   = 1012552
 
-Test 157 datm_cdeps_restart_cfsr_intel PASS
+Test 155 datm_cdeps_restart_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_control_gefs_intel
-Checking test 158 datm_cdeps_control_gefs_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_control_gefs_intel
+Checking test 156 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 151.418494
- 0: The maximum resident set size (KB)                   = 966984
+ 0: The total amount of wall time                        = 150.421879
+ 0: The maximum resident set size (KB)                   = 950852
 
-Test 158 datm_cdeps_control_gefs_intel PASS
+Test 156 datm_cdeps_control_gefs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_iau_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_iau_gefs_intel
-Checking test 159 datm_cdeps_iau_gefs_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_iau_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_iau_gefs_intel
+Checking test 157 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.257264
- 0: The maximum resident set size (KB)                   = 956760
+ 0: The total amount of wall time                        = 154.265237
+ 0: The maximum resident set size (KB)                   = 955080
 
-Test 159 datm_cdeps_iau_gefs_intel PASS
+Test 157 datm_cdeps_iau_gefs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_stochy_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_stochy_gefs_intel
-Checking test 160 datm_cdeps_stochy_gefs_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_stochy_gefs_intel
+Checking test 158 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.759463
- 0: The maximum resident set size (KB)                   = 963868
+ 0: The total amount of wall time                        = 148.556045
+ 0: The maximum resident set size (KB)                   = 964808
 
-Test 160 datm_cdeps_stochy_gefs_intel PASS
+Test 158 datm_cdeps_stochy_gefs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_ciceC_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_ciceC_cfsr_intel
-Checking test 161 datm_cdeps_ciceC_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_ciceC_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_ciceC_cfsr_intel
+Checking test 159 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.570658
- 0: The maximum resident set size (KB)                   = 1066964
+ 0: The total amount of wall time                        = 151.713636
+ 0: The maximum resident set size (KB)                   = 1064488
 
-Test 161 datm_cdeps_ciceC_cfsr_intel PASS
+Test 159 datm_cdeps_ciceC_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_bulk_cfsr_intel
-Checking test 162 datm_cdeps_bulk_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_bulk_cfsr_intel
+Checking test 160 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 157.357836
- 0: The maximum resident set size (KB)                   = 1042388
+ 0: The total amount of wall time                        = 150.553707
+ 0: The maximum resident set size (KB)                   = 1051904
 
-Test 162 datm_cdeps_bulk_cfsr_intel PASS
+Test 160 datm_cdeps_bulk_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_bulk_gefs_intel
-Checking test 163 datm_cdeps_bulk_gefs_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_bulk_gefs_intel
+Checking test 161 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.050664
- 0: The maximum resident set size (KB)                   = 960804
+ 0: The total amount of wall time                        = 143.192675
+ 0: The maximum resident set size (KB)                   = 967816
 
-Test 163 datm_cdeps_bulk_gefs_intel PASS
+Test 161 datm_cdeps_bulk_gefs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_mx025_cfsr_intel
-Checking test 164 datm_cdeps_mx025_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_mx025_cfsr_intel
+Checking test 162 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -5402,15 +5367,15 @@ Checking test 164 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 428.492949
-  0: The maximum resident set size (KB)                   = 879836
+  0: The total amount of wall time                        = 452.332478
+  0: The maximum resident set size (KB)                   = 877868
 
-Test 164 datm_cdeps_mx025_cfsr_intel PASS
+Test 162 datm_cdeps_mx025_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_mx025_gefs_intel
-Checking test 165 datm_cdeps_mx025_gefs_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_mx025_gefs_intel
+Checking test 163 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -5418,78 +5383,78 @@ Checking test 165 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 429.421763
-  0: The maximum resident set size (KB)                   = 927324
+  0: The total amount of wall time                        = 416.682503
+  0: The maximum resident set size (KB)                   = 925508
 
-Test 165 datm_cdeps_mx025_gefs_intel PASS
+Test 163 datm_cdeps_mx025_gefs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_multiple_files_cfsr_intel
-Checking test 166 datm_cdeps_multiple_files_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_multiple_files_cfsr_intel
+Checking test 164 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.963107
- 0: The maximum resident set size (KB)                   = 1068228
+ 0: The total amount of wall time                        = 151.740828
+ 0: The maximum resident set size (KB)                   = 1049720
 
-Test 166 datm_cdeps_multiple_files_cfsr_intel PASS
+Test 164 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_3072x1536_cfsr_intel
-Checking test 167 datm_cdeps_3072x1536_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_3072x1536_cfsr_intel
+Checking test 165 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 221.509176
- 0: The maximum resident set size (KB)                   = 2302180
+ 0: The total amount of wall time                        = 213.894018
+ 0: The maximum resident set size (KB)                   = 2349908
 
-Test 167 datm_cdeps_3072x1536_cfsr_intel PASS
+Test 165 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_gfs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_gfs_intel
-Checking test 168 datm_cdeps_gfs_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_gfs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_gfs_intel
+Checking test 166 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 221.026239
- 0: The maximum resident set size (KB)                   = 2306624
+ 0: The total amount of wall time                        = 213.398898
+ 0: The maximum resident set size (KB)                   = 2293464
 
-Test 168 datm_cdeps_gfs_intel PASS
+Test 166 datm_cdeps_gfs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_debug_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_debug_cfsr_intel
-Checking test 169 datm_cdeps_debug_cfsr_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_debug_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_debug_cfsr_intel
+Checking test 167 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 365.275045
- 0: The maximum resident set size (KB)                   = 981576
+ 0: The total amount of wall time                        = 352.214981
+ 0: The maximum resident set size (KB)                   = 968736
 
-Test 169 datm_cdeps_debug_cfsr_intel PASS
+Test 167 datm_cdeps_debug_cfsr_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_control_cfsr_faster_intel
-Checking test 170 datm_cdeps_control_cfsr_faster_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_control_cfsr_faster_intel
+Checking test 168 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.931351
- 0: The maximum resident set size (KB)                   = 1056824
+ 0: The total amount of wall time                        = 152.711409
+ 0: The maximum resident set size (KB)                   = 1054344
 
-Test 170 datm_cdeps_control_cfsr_faster_intel PASS
+Test 168 datm_cdeps_control_cfsr_faster_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_lnd_gswp3_intel
-Checking test 171 datm_cdeps_lnd_gswp3_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_lnd_gswp3_intel
+Checking test 169 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5497,15 +5462,15 @@ Checking test 171 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 7.285680
-  0: The maximum resident set size (KB)                   = 261216
+  0: The total amount of wall time                        = 7.774779
+  0: The maximum resident set size (KB)                   = 259444
 
-Test 171 datm_cdeps_lnd_gswp3_intel PASS
+Test 169 datm_cdeps_lnd_gswp3_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_lnd_gswp3_rst_intel
-Checking test 172 datm_cdeps_lnd_gswp3_rst_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_lnd_gswp3_rst_intel
+Checking test 170 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5513,15 +5478,15 @@ Checking test 172 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.830740
-  0: The maximum resident set size (KB)                   = 261712
+  0: The total amount of wall time                        = 12.991508
+  0: The maximum resident set size (KB)                   = 241368
 
-Test 172 datm_cdeps_lnd_gswp3_rst_intel PASS
+Test 170 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_atmlnd_sbs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_p8_atmlnd_sbs_intel
-Checking test 173 control_p8_atmlnd_sbs_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_p8_atmlnd_sbs_intel
+Checking test 171 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -5605,15 +5570,15 @@ Checking test 173 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 205.462206
-  0: The maximum resident set size (KB)                   = 1602424
+  0: The total amount of wall time                        = 205.634987
+  0: The maximum resident set size (KB)                   = 1608684
 
-Test 173 control_p8_atmlnd_sbs_intel PASS
+Test 171 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmwav_control_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/atmwav_control_noaero_p8_intel
-Checking test 174 atmwav_control_noaero_p8_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmwav_control_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/atmwav_control_noaero_p8_intel
+Checking test 172 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5655,15 +5620,15 @@ Checking test 174 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 93.368936
-  0: The maximum resident set size (KB)                   = 1631124
+  0: The total amount of wall time                        = 95.224070
+  0: The maximum resident set size (KB)                   = 1630492
 
-Test 174 atmwav_control_noaero_p8_intel PASS
+Test 172 atmwav_control_noaero_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_atmwav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_atmwav_intel
-Checking test 175 control_atmwav_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_atmwav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_atmwav_intel
+Checking test 173 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5706,15 +5671,15 @@ Checking test 175 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 88.646220
-  0: The maximum resident set size (KB)                   = 626892
+  0: The total amount of wall time                        = 87.754156
+  0: The maximum resident set size (KB)                   = 656584
 
-Test 175 control_atmwav_intel PASS
+Test 173 control_atmwav_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/atmaero_control_p8_intel
-Checking test 176 atmaero_control_p8_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/atmaero_control_p8_intel
+Checking test 174 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5757,15 +5722,15 @@ Checking test 176 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 236.522061
-  0: The maximum resident set size (KB)                   = 2962844
+  0: The total amount of wall time                        = 237.175504
+  0: The maximum resident set size (KB)                   = 2924828
 
-Test 176 atmaero_control_p8_intel PASS
+Test 174 atmaero_control_p8_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/atmaero_control_p8_rad_intel
-Checking test 177 atmaero_control_p8_rad_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/atmaero_control_p8_rad_intel
+Checking test 175 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5808,15 +5773,15 @@ Checking test 177 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 280.538455
-  0: The maximum resident set size (KB)                   = 3033248
+  0: The total amount of wall time                        = 286.382395
+  0: The maximum resident set size (KB)                   = 3036012
 
-Test 177 atmaero_control_p8_rad_intel PASS
+Test 175 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_micro_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/atmaero_control_p8_rad_micro_intel
-Checking test 178 atmaero_control_p8_rad_micro_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/atmaero_control_p8_rad_micro_intel
+Checking test 176 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5859,15 +5824,15 @@ Checking test 178 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 287.565398
-  0: The maximum resident set size (KB)                   = 3051124
+  0: The total amount of wall time                        = 286.794674
+  0: The maximum resident set size (KB)                   = 3053216
 
-Test 178 atmaero_control_p8_rad_micro_intel PASS
+Test 176 atmaero_control_p8_rad_micro_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_atmaq_intel
-Checking test 179 regional_atmaq_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_atmaq_intel
+Checking test 177 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5882,15 +5847,15 @@ Checking test 179 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 638.320770
-  0: The maximum resident set size (KB)                   = 1356292
+  0: The total amount of wall time                        = 663.526759
+  0: The maximum resident set size (KB)                   = 1316552
 
-Test 179 regional_atmaq_intel PASS
+Test 177 regional_atmaq_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_atmaq_debug_intel
-Checking test 180 regional_atmaq_debug_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_atmaq_debug_intel
+Checking test 178 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5903,15 +5868,15 @@ Checking test 180 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1190.339616
-  0: The maximum resident set size (KB)                   = 1386036
+  0: The total amount of wall time                        = 1212.292056
+  0: The maximum resident set size (KB)                   = 1356064
 
-Test 180 regional_atmaq_debug_intel PASS
+Test 178 regional_atmaq_debug_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_atmaq_faster_intel
-Checking test 181 regional_atmaq_faster_intel results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_atmaq_faster_intel
+Checking test 179 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5926,15 +5891,15 @@ Checking test 181 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 561.688868
-  0: The maximum resident set size (KB)                   = 1317928
+  0: The total amount of wall time                        = 588.070770
+  0: The maximum resident set size (KB)                   = 1349380
 
-Test 181 regional_atmaq_faster_intel PASS
+Test 179 regional_atmaq_faster_intel PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c48_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_c48_gnu
-Checking test 182 control_c48_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c48_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_c48_gnu
+Checking test 180 control_c48_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5972,15 +5937,15 @@ Checking test 182 control_c48_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 683.297805
-0: The maximum resident set size (KB)                   = 705892
+0: The total amount of wall time                        = 688.569102
+0: The maximum resident set size (KB)                   = 699328
 
-Test 182 control_c48_gnu PASS
+Test 180 control_c48_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_stochy_gnu
-Checking test 183 control_stochy_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_stochy_gnu
+Checking test 181 control_stochy_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5990,15 +5955,15 @@ Checking test 183 control_stochy_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 653.212571
-  0: The maximum resident set size (KB)                   = 477648
+  0: The total amount of wall time                        = 647.726542
+  0: The maximum resident set size (KB)                   = 479128
 
-Test 183 control_stochy_gnu PASS
+Test 181 control_stochy_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_ras_gnu
-Checking test 184 control_ras_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_ras_gnu
+Checking test 182 control_ras_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -6008,87 +5973,15 @@ Checking test 184 control_ras_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 838.932645
-  0: The maximum resident set size (KB)                   = 483568
+  0: The total amount of wall time                        = 829.760604
+  0: The maximum resident set size (KB)                   = 483788
 
-Test 184 control_ras_gnu PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_p8_gnu
-Checking test 185 control_p8_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf021.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf021.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF21 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF21 .........OK
- Comparing GFSPRS.GrbF24 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 896.314952
-  0: The maximum resident set size (KB)                   = 1233116
-
-Test 185 control_p8_gnu PASS
+Test 182 control_ras_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_flake_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_flake_gnu
-Checking test 186 control_flake_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF24 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF24 .........OK
-
-  0: The total amount of wall time                        = 1586.129291
-  0: The maximum resident set size (KB)                   = 523012
-
-Test 186 control_flake_gnu PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_gnu
-Checking test 187 rap_control_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_p8_gnu
+Checking test 183 control_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -6134,15 +6027,33 @@ Checking test 187 rap_control_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1441.095753
-  0: The maximum resident set size (KB)                   = 823724
+  0: The total amount of wall time                        = 884.794816
+  0: The maximum resident set size (KB)                   = 1233964
 
-Test 187 rap_control_gnu PASS
+Test 183 control_p8_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_decomp_gnu
-Checking test 188 rap_decomp_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_flake_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_flake_gnu
+Checking test 184 control_flake_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+
+  0: The total amount of wall time                        = 1557.095925
+  0: The maximum resident set size (KB)                   = 522532
+
+Test 184 control_flake_gnu PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_gnu
+Checking test 185 rap_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -6188,15 +6099,15 @@ Checking test 188 rap_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1439.087407
-  0: The maximum resident set size (KB)                   = 826632
+  0: The total amount of wall time                        = 1464.709004
+  0: The maximum resident set size (KB)                   = 828496
 
-Test 188 rap_decomp_gnu PASS
+Test 185 rap_control_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_2threads_gnu
-Checking test 189 rap_2threads_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_decomp_gnu
+Checking test 186 rap_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -6242,15 +6153,69 @@ Checking test 189 rap_2threads_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1328.027021
-  0: The maximum resident set size (KB)                   = 893048
+  0: The total amount of wall time                        = 1455.882483
+  0: The maximum resident set size (KB)                   = 828988
 
-Test 189 rap_2threads_gnu PASS
+Test 186 rap_decomp_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_restart_gnu
-Checking test 190 rap_restart_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_2threads_gnu
+Checking test 187 rap_2threads_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF21 .........OK
+ Comparing GFSFLX.GrbF24 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF21 .........OK
+ Comparing GFSPRS.GrbF24 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 1343.587143
+  0: The maximum resident set size (KB)                   = 894968
+
+Test 187 rap_2threads_gnu PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_restart_gnu
+Checking test 188 rap_restart_gnu results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -6288,15 +6253,15 @@ Checking test 190 rap_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 723.923184
-  0: The maximum resident set size (KB)                   = 546972
+  0: The total amount of wall time                        = 730.302527
+  0: The maximum resident set size (KB)                   = 545912
 
-Test 190 rap_restart_gnu PASS
+Test 188 rap_restart_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_sfcdiff_gnu
-Checking test 191 rap_sfcdiff_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_sfcdiff_gnu
+Checking test 189 rap_sfcdiff_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6342,15 +6307,15 @@ Checking test 191 rap_sfcdiff_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1459.677949
-  0: The maximum resident set size (KB)                   = 825720
+  0: The total amount of wall time                        = 1488.730888
+  0: The maximum resident set size (KB)                   = 828088
 
-Test 191 rap_sfcdiff_gnu PASS
+Test 189 rap_sfcdiff_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_sfcdiff_decomp_gnu
-Checking test 192 rap_sfcdiff_decomp_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_sfcdiff_decomp_gnu
+Checking test 190 rap_sfcdiff_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6396,15 +6361,15 @@ Checking test 192 rap_sfcdiff_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1445.620453
-  0: The maximum resident set size (KB)                   = 824272
+  0: The total amount of wall time                        = 1459.014546
+  0: The maximum resident set size (KB)                   = 828836
 
-Test 192 rap_sfcdiff_decomp_gnu PASS
+Test 190 rap_sfcdiff_decomp_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_sfcdiff_restart_gnu
-Checking test 193 rap_sfcdiff_restart_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_sfcdiff_restart_gnu
+Checking test 191 rap_sfcdiff_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -6442,15 +6407,15 @@ Checking test 193 rap_sfcdiff_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1067.418443
-  0: The maximum resident set size (KB)                   = 547908
+  0: The total amount of wall time                        = 1073.174858
+  0: The maximum resident set size (KB)                   = 553692
 
-Test 193 rap_sfcdiff_restart_gnu PASS
+Test 191 rap_sfcdiff_restart_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_gnu
-Checking test 194 hrrr_control_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_gnu
+Checking test 192 hrrr_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6496,15 +6461,15 @@ Checking test 194 hrrr_control_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1429.669644
-  0: The maximum resident set size (KB)                   = 825336
+  0: The total amount of wall time                        = 1467.260296
+  0: The maximum resident set size (KB)                   = 822792
 
-Test 194 hrrr_control_gnu PASS
+Test 192 hrrr_control_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_qr_gnu
-Checking test 195 hrrr_control_qr_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_qr_gnu
+Checking test 193 hrrr_control_qr_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6550,15 +6515,15 @@ Checking test 195 hrrr_control_qr_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1461.404500
-  0: The maximum resident set size (KB)                   = 836728
+  0: The total amount of wall time                        = 1448.266809
+  0: The maximum resident set size (KB)                   = 832052
 
-Test 195 hrrr_control_qr_gnu PASS
+Test 193 hrrr_control_qr_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_2threads_gnu
-Checking test 196 hrrr_control_2threads_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_2threads_gnu
+Checking test 194 hrrr_control_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6604,15 +6569,15 @@ Checking test 196 hrrr_control_2threads_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1547.520628
-  0: The maximum resident set size (KB)                   = 891204
+  0: The total amount of wall time                        = 1472.453709
+  0: The maximum resident set size (KB)                   = 887724
 
-Test 196 hrrr_control_2threads_gnu PASS
+Test 194 hrrr_control_2threads_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_decomp_gnu
-Checking test 197 hrrr_control_decomp_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_decomp_gnu
+Checking test 195 hrrr_control_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6658,43 +6623,43 @@ Checking test 197 hrrr_control_decomp_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1412.641116
-  0: The maximum resident set size (KB)                   = 820492
+  0: The total amount of wall time                        = 1427.972047
+  0: The maximum resident set size (KB)                   = 821688
 
-Test 197 hrrr_control_decomp_gnu PASS
+Test 195 hrrr_control_decomp_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_gnu
-Checking test 198 hrrr_control_restart_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_gnu
+Checking test 196 hrrr_control_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1048.979641
-  0: The maximum resident set size (KB)                   = 544372
+  0: The total amount of wall time                        = 1080.004561
+  0: The maximum resident set size (KB)                   = 544268
 
-Test 198 hrrr_control_restart_gnu PASS
+Test 196 hrrr_control_restart_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_qr_gnu
-Checking test 199 hrrr_control_restart_qr_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_qr_gnu
+Checking test 197 hrrr_control_restart_qr_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1051.069863
-  0: The maximum resident set size (KB)                   = 559180
+  0: The total amount of wall time                        = 1086.073489
+  0: The maximum resident set size (KB)                   = 561964
 
-Test 199 hrrr_control_restart_qr_gnu PASS
+Test 197 hrrr_control_restart_qr_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_v1beta_gnu
-Checking test 200 rrfs_v1beta_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_v1beta_gnu
+Checking test 198 rrfs_v1beta_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6740,15 +6705,15 @@ Checking test 200 rrfs_v1beta_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1445.803528
-  0: The maximum resident set size (KB)                   = 822512
+  0: The total amount of wall time                        = 1430.549686
+  0: The maximum resident set size (KB)                   = 821740
 
-Test 200 rrfs_v1beta_gnu PASS
+Test 198 rrfs_v1beta_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_gnu
-Checking test 201 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_gnu
+Checking test 199 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -6763,15 +6728,47 @@ Checking test 201 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 788.120698
-  0: The maximum resident set size (KB)                   = 662388
+  0: The total amount of wall time                        = 776.521003
+  0: The maximum resident set size (KB)                   = 663116
 
-Test 201 rrfs_smoke_conus13km_hrrr_warm_gnu PASS
+Test 199 rrfs_smoke_conus13km_hrrr_warm_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_qr_gnu
-Checking test 202 rrfs_smoke_conus13km_hrrr_warm_qr_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
+Checking test 200 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 1018.616033
+  0: The maximum resident set size (KB)                   = 661136
+
+Test 200 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_radar_tten_warm_gnu
+Checking test 201 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 803.700707
+  0: The maximum resident set size (KB)                   = 666232
+
+Test 201 rrfs_smoke_conus13km_radar_tten_warm_gnu PASS
+
+
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_conus13km_hrrr_warm_gnu
+Checking test 202 rrfs_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -6786,330 +6783,263 @@ Checking test 202 rrfs_smoke_conus13km_hrrr_warm_qr_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 776.412503
-  0: The maximum resident set size (KB)                   = 665464
+  0: The total amount of wall time                        = 777.208322
+  0: The maximum resident set size (KB)                   = 641576
 
-Test 202 rrfs_smoke_conus13km_hrrr_warm_qr_gnu PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
-Checking test 203 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 1050.595625
-  0: The maximum resident set size (KB)                   = 661084
-
-Test 203 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu PASS
+Test 202 rrfs_conus13km_hrrr_warm_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_radar_tten_warm_gnu
-Checking test 204 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 797.067550
-  0: The maximum resident set size (KB)                   = 667568
-
-Test 204 rrfs_smoke_conus13km_radar_tten_warm_gnu PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_conus13km_hrrr_warm_gnu
-Checking test 205 rrfs_conus13km_hrrr_warm_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-  0: The total amount of wall time                        = 768.523704
-  0: The maximum resident set size (KB)                   = 642812
-
-Test 205 rrfs_conus13km_hrrr_warm_gnu PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-Checking test 206 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
+Checking test 203 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 419.588600
-  0: The maximum resident set size (KB)                   = 652580
+  0: The total amount of wall time                        = 414.850005
+  0: The maximum resident set size (KB)                   = 653960
 
-Test 206 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu PASS
-
-
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_gnu
-Checking test 207 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_gnu results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 414.013876
-  0: The maximum resident set size (KB)                   = 654588
-
-Test 207 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_gnu PASS
+Test 203 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_diag_debug_gnu
-Checking test 208 control_diag_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_diag_debug_gnu
+Checking test 204 control_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 124.605211
-  0: The maximum resident set size (KB)                   = 529100
+  0: The total amount of wall time                        = 125.382970
+  0: The maximum resident set size (KB)                   = 527256
 
-Test 208 control_diag_debug_gnu PASS
+Test 204 control_diag_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/regional_debug_gnu
-Checking test 209 regional_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/regional_debug_gnu
+Checking test 205 regional_debug_gnu results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 664.681421
-  0: The maximum resident set size (KB)                   = 593560
+  0: The total amount of wall time                        = 613.837345
+  0: The maximum resident set size (KB)                   = 592684
 
-Test 209 regional_debug_gnu PASS
+Test 205 regional_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_debug_gnu
-Checking test 210 rap_control_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_debug_gnu
+Checking test 206 rap_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.663537
-  0: The maximum resident set size (KB)                   = 841056
+  0: The total amount of wall time                        = 172.998954
+  0: The maximum resident set size (KB)                   = 836012
 
-Test 210 rap_control_debug_gnu PASS
+Test 206 rap_control_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_debug_gnu
-Checking test 211 hrrr_control_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_debug_gnu
+Checking test 207 hrrr_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.022664
-  0: The maximum resident set size (KB)                   = 832964
+  0: The total amount of wall time                        = 169.404015
+  0: The maximum resident set size (KB)                   = 837424
 
-Test 211 hrrr_control_debug_gnu PASS
+Test 207 hrrr_control_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_diag_debug_gnu
-Checking test 212 rap_diag_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_diag_debug_gnu
+Checking test 208 rap_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 208.698615
-  0: The maximum resident set size (KB)                   = 928452
+  0: The total amount of wall time                        = 210.844574
+  0: The maximum resident set size (KB)                   = 925352
 
-Test 212 rap_diag_debug_gnu PASS
+Test 208 rap_diag_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_noah_sfcdiff_cires_ugwp_debug_gnu
-Checking test 213 rap_noah_sfcdiff_cires_ugwp_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_noah_sfcdiff_cires_ugwp_debug_gnu
+Checking test 209 rap_noah_sfcdiff_cires_ugwp_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.917180
-  0: The maximum resident set size (KB)                   = 832880
+  0: The total amount of wall time                        = 273.966185
+  0: The maximum resident set size (KB)                   = 837204
 
-Test 213 rap_noah_sfcdiff_cires_ugwp_debug_gnu PASS
+Test 209 rap_noah_sfcdiff_cires_ugwp_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_progcld_thompson_debug_gnu
-Checking test 214 rap_progcld_thompson_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_progcld_thompson_debug_gnu
+Checking test 210 rap_progcld_thompson_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.903206
-  0: The maximum resident set size (KB)                   = 837036
+  0: The total amount of wall time                        = 177.619905
+  0: The maximum resident set size (KB)                   = 837296
 
-Test 214 rap_progcld_thompson_debug_gnu PASS
+Test 210 rap_progcld_thompson_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_v1beta_debug_gnu
-Checking test 215 rrfs_v1beta_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_v1beta_debug_gnu
+Checking test 211 rrfs_v1beta_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 177.577362
-  0: The maximum resident set size (KB)                   = 834048
+  0: The total amount of wall time                        = 172.628056
+  0: The maximum resident set size (KB)                   = 837220
 
-Test 215 rrfs_v1beta_debug_gnu PASS
+Test 211 rrfs_v1beta_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_ras_debug_gnu
-Checking test 216 control_ras_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_ras_debug_gnu
+Checking test 212 control_ras_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.502840
-  0: The maximum resident set size (KB)                   = 481560
+  0: The total amount of wall time                        = 104.576034
+  0: The maximum resident set size (KB)                   = 483544
 
-Test 216 control_ras_debug_gnu PASS
+Test 212 control_ras_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_stochy_debug_gnu
-Checking test 217 control_stochy_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_stochy_debug_gnu
+Checking test 213 control_stochy_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 122.071767
-  0: The maximum resident set size (KB)                   = 474804
+  0: The total amount of wall time                        = 116.420415
+  0: The maximum resident set size (KB)                   = 473924
 
-Test 217 control_stochy_debug_gnu PASS
+Test 213 control_stochy_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_debug_p8_gnu
-Checking test 218 control_debug_p8_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_debug_p8_gnu
+Checking test 214 control_debug_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 121.920140
-  0: The maximum resident set size (KB)                   = 1226004
+  0: The total amount of wall time                        = 121.442524
+  0: The maximum resident set size (KB)                   = 1225612
 
-Test 218 control_debug_p8_gnu PASS
+Test 214 control_debug_p8_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-Checking test 219 rrfs_smoke_conus13km_hrrr_warm_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+Checking test 215 rrfs_smoke_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 648.814610
-  0: The maximum resident set size (KB)                   = 679944
+  0: The total amount of wall time                        = 643.798671
+  0: The maximum resident set size (KB)                   = 680652
 
-Test 219 rrfs_smoke_conus13km_hrrr_warm_debug_gnu PASS
+Test 215 rrfs_smoke_conus13km_hrrr_warm_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
-Checking test 220 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
+Checking test 216 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 759.330590
-  0: The maximum resident set size (KB)                   = 678144
+  0: The total amount of wall time                        = 754.730193
+  0: The maximum resident set size (KB)                   = 678844
 
-Test 220 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu PASS
+Test 216 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rrfs_conus13km_hrrr_warm_debug_gnu
-Checking test 221 rrfs_conus13km_hrrr_warm_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rrfs_conus13km_hrrr_warm_debug_gnu
+Checking test 217 rrfs_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 594.787238
-  0: The maximum resident set size (KB)                   = 653912
+  0: The total amount of wall time                        = 599.770974
+  0: The maximum resident set size (KB)                   = 656016
 
-Test 221 rrfs_conus13km_hrrr_warm_debug_gnu PASS
+Test 217 rrfs_conus13km_hrrr_warm_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_flake_debug_gnu
-Checking test 222 rap_flake_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_flake_debug_gnu
+Checking test 218 rap_flake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 179.181474
-  0: The maximum resident set size (KB)                   = 836768
+  0: The total amount of wall time                        = 173.682277
+  0: The maximum resident set size (KB)                   = 837272
 
-Test 222 rap_flake_debug_gnu PASS
+Test 218 rap_flake_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_clm_lake_debug_gnu
-Checking test 223 rap_clm_lake_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_clm_lake_debug_gnu
+Checking test 219 rap_clm_lake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.404129
-  0: The maximum resident set size (KB)                   = 840092
+  0: The total amount of wall time                        = 191.786130
+  0: The maximum resident set size (KB)                   = 842748
 
-Test 223 rap_clm_lake_debug_gnu PASS
+Test 219 rap_clm_lake_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/control_wam_debug_gnu
-Checking test 224 control_wam_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/control_wam_debug_gnu
+Checking test 220 control_wam_debug_gnu results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 186.590958
-  0: The maximum resident set size (KB)                   = 193388
+  0: The total amount of wall time                        = 183.099301
+  0: The maximum resident set size (KB)                   = 189328
 
-Test 224 control_wam_debug_gnu PASS
+Test 220 control_wam_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_dyn32_phy32_gnu
-Checking test 225 rap_control_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_dyn32_phy32_gnu
+Checking test 221 rap_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7155,15 +7085,15 @@ Checking test 225 rap_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1462.463702
-  0: The maximum resident set size (KB)                   = 677732
+  0: The total amount of wall time                        = 1474.820199
+  0: The maximum resident set size (KB)                   = 683172
 
-Test 225 rap_control_dyn32_phy32_gnu PASS
+Test 221 rap_control_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_dyn32_phy32_gnu
-Checking test 226 hrrr_control_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_dyn32_phy32_gnu
+Checking test 222 hrrr_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7209,15 +7139,15 @@ Checking test 226 hrrr_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 737.344941
-  0: The maximum resident set size (KB)                   = 682100
+  0: The total amount of wall time                        = 737.538343
+  0: The maximum resident set size (KB)                   = 681832
 
-Test 226 hrrr_control_dyn32_phy32_gnu PASS
+Test 222 hrrr_control_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_qr_dyn32_phy32_gnu
-Checking test 227 hrrr_control_qr_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_qr_dyn32_phy32_gnu
+Checking test 223 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7263,15 +7193,15 @@ Checking test 227 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 742.768190
-  0: The maximum resident set size (KB)                   = 687720
+  0: The total amount of wall time                        = 754.525752
+  0: The maximum resident set size (KB)                   = 686528
 
-Test 227 hrrr_control_qr_dyn32_phy32_gnu PASS
+Test 223 hrrr_control_qr_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_2threads_dyn32_phy32_gnu
-Checking test 228 rap_2threads_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_2threads_dyn32_phy32_gnu
+Checking test 224 rap_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7317,15 +7247,15 @@ Checking test 228 rap_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1351.277225
-  0: The maximum resident set size (KB)                   = 731804
+  0: The total amount of wall time                        = 1358.606837
+  0: The maximum resident set size (KB)                   = 731160
 
-Test 228 rap_2threads_dyn32_phy32_gnu PASS
+Test 224 rap_2threads_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_2threads_dyn32_phy32_gnu
-Checking test 229 hrrr_control_2threads_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_2threads_dyn32_phy32_gnu
+Checking test 225 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7371,15 +7301,15 @@ Checking test 229 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 785.579456
-  0: The maximum resident set size (KB)                   = 726212
+  0: The total amount of wall time                        = 764.577924
+  0: The maximum resident set size (KB)                   = 726296
 
-Test 229 hrrr_control_2threads_dyn32_phy32_gnu PASS
+Test 225 hrrr_control_2threads_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_decomp_dyn32_phy32_gnu
-Checking test 230 hrrr_control_decomp_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_decomp_dyn32_phy32_gnu
+Checking test 226 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7425,15 +7355,15 @@ Checking test 230 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 710.492499
-  0: The maximum resident set size (KB)                   = 677960
+  0: The total amount of wall time                        = 726.596323
+  0: The maximum resident set size (KB)                   = 679916
 
-Test 230 hrrr_control_decomp_dyn32_phy32_gnu PASS
+Test 226 hrrr_control_decomp_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_restart_dyn32_phy32_gnu
-Checking test 231 rap_restart_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_restart_dyn32_phy32_gnu
+Checking test 227 rap_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -7471,43 +7401,43 @@ Checking test 231 rap_restart_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1067.794939
-  0: The maximum resident set size (KB)                   = 502908
+  0: The total amount of wall time                        = 1071.027518
+  0: The maximum resident set size (KB)                   = 508684
 
-Test 231 rap_restart_dyn32_phy32_gnu PASS
+Test 227 rap_restart_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_dyn32_phy32_gnu
-Checking test 232 hrrr_control_restart_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_dyn32_phy32_gnu
+Checking test 228 hrrr_control_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 366.178217
-  0: The maximum resident set size (KB)                   = 504496
+  0: The total amount of wall time                        = 371.832659
+  0: The maximum resident set size (KB)                   = 503608
 
-Test 232 hrrr_control_restart_dyn32_phy32_gnu PASS
+Test 228 hrrr_control_restart_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_restart_qr_dyn32_phy32_gnu
-Checking test 233 hrrr_control_restart_qr_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_restart_qr_dyn32_phy32_gnu
+Checking test 229 hrrr_control_restart_qr_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 374.448064
-  0: The maximum resident set size (KB)                   = 522552
+  0: The total amount of wall time                        = 370.597757
+  0: The maximum resident set size (KB)                   = 525500
 
-Test 233 hrrr_control_restart_qr_dyn32_phy32_gnu PASS
+Test 229 hrrr_control_restart_qr_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_dyn64_phy32_gnu
-Checking test 234 rap_control_dyn64_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_dyn64_phy32_gnu
+Checking test 230 rap_control_dyn64_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -7553,57 +7483,57 @@ Checking test 234 rap_control_dyn64_phy32_gnu results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1079.158420
-  0: The maximum resident set size (KB)                   = 702908
+  0: The total amount of wall time                        = 1071.861307
+  0: The maximum resident set size (KB)                   = 707304
 
-Test 234 rap_control_dyn64_phy32_gnu PASS
+Test 230 rap_control_dyn64_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_debug_dyn32_phy32_gnu
-Checking test 235 rap_control_debug_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_debug_dyn32_phy32_gnu
+Checking test 231 rap_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 172.079122
-  0: The maximum resident set size (KB)                   = 705696
+  0: The total amount of wall time                        = 172.249010
+  0: The maximum resident set size (KB)                   = 694680
 
-Test 235 rap_control_debug_dyn32_phy32_gnu PASS
+Test 231 rap_control_debug_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/hrrr_control_debug_dyn32_phy32_gnu
-Checking test 236 hrrr_control_debug_dyn32_phy32_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/hrrr_control_debug_dyn32_phy32_gnu
+Checking test 232 hrrr_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.569599
-  0: The maximum resident set size (KB)                   = 695992
+  0: The total amount of wall time                        = 169.562931
+  0: The maximum resident set size (KB)                   = 696016
 
-Test 236 hrrr_control_debug_dyn32_phy32_gnu PASS
+Test 232 hrrr_control_debug_dyn32_phy32_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/rap_control_dyn64_phy32_debug_gnu
-Checking test 237 rap_control_dyn64_phy32_debug_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/rap_control_dyn64_phy32_debug_gnu
+Checking test 233 rap_control_dyn64_phy32_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 204.727166
-  0: The maximum resident set size (KB)                   = 719756
+  0: The total amount of wall time                        = 206.249665
+  0: The maximum resident set size (KB)                   = 713196
 
-Test 237 rap_control_dyn64_phy32_debug_gnu PASS
+Test 233 rap_control_dyn64_phy32_debug_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_p8_gnu
-Checking test 238 cpld_control_p8_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_p8_gnu
+Checking test 234 cpld_control_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -7667,15 +7597,15 @@ Checking test 238 cpld_control_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1716.256073
-  0: The maximum resident set size (KB)                   = 1414200
+  0: The total amount of wall time                        = 1723.146697
+  0: The maximum resident set size (KB)                   = 1427572
 
-Test 238 cpld_control_p8_gnu PASS
+Test 234 cpld_control_p8_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_nowave_noaero_p8_gnu
-Checking test 239 cpld_control_nowave_noaero_p8_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_nowave_noaero_p8_gnu
+Checking test 235 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -7736,15 +7666,15 @@ Checking test 239 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1247.048013
-  0: The maximum resident set size (KB)                   = 1332564
+  0: The total amount of wall time                        = 1238.099942
+  0: The maximum resident set size (KB)                   = 1329628
 
-Test 239 cpld_control_nowave_noaero_p8_gnu PASS
+Test 235 cpld_control_nowave_noaero_p8_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_debug_p8_gnu
-Checking test 240 cpld_debug_p8_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_debug_p8_gnu
+Checking test 236 cpld_debug_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
  Comparing sfcf003.tile3.nc .........OK
@@ -7796,15 +7726,15 @@ Checking test 240 cpld_debug_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 828.447664
-  0: The maximum resident set size (KB)                   = 1437060
+  0: The total amount of wall time                        = 1557.183849
+  0: The maximum resident set size (KB)                   = 1433696
 
-Test 240 cpld_debug_p8_gnu PASS
+Test 236 cpld_debug_p8_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_control_pdlib_p8_gnu
-Checking test 241 cpld_control_pdlib_p8_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_control_pdlib_p8_gnu
+Checking test 237 cpld_control_pdlib_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
  Comparing sfcf021.tile3.nc .........OK
@@ -7867,15 +7797,15 @@ Checking test 241 cpld_control_pdlib_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1717.012552
-  0: The maximum resident set size (KB)                   = 1296120
+  0: The total amount of wall time                        = 1727.261823
+  0: The maximum resident set size (KB)                   = 1291308
 
-Test 241 cpld_control_pdlib_p8_gnu PASS
+Test 237 cpld_control_pdlib_p8_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_pdlib_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/cpld_debug_pdlib_p8_gnu
-Checking test 242 cpld_debug_pdlib_p8_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_pdlib_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/cpld_debug_pdlib_p8_gnu
+Checking test 238 cpld_debug_pdlib_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
  Comparing sfcf003.tile3.nc .........OK
@@ -7926,25 +7856,25 @@ Checking test 242 cpld_debug_pdlib_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 904.852458
-  0: The maximum resident set size (KB)                   = 1294220
+  0: The total amount of wall time                        = 909.778549
+  0: The maximum resident set size (KB)                   = 1295816
 
-Test 242 cpld_debug_pdlib_p8_gnu PASS
+Test 238 cpld_debug_pdlib_p8_gnu PASS
 
 
-baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_126038/datm_cdeps_control_cfsr_gnu
-Checking test 243 datm_cdeps_control_cfsr_gnu results ....
+baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_283198/datm_cdeps_control_cfsr_gnu
+Checking test 239 datm_cdeps_control_cfsr_gnu results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 173.702208
- 0: The maximum resident set size (KB)                   = 667356
+ 0: The total amount of wall time                        = 177.049033
+ 0: The maximum resident set size (KB)                   = 654860
 
-Test 243 datm_cdeps_control_cfsr_gnu PASS
+Test 239 datm_cdeps_control_cfsr_gnu PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 16 23:28:34 UTC 2023
-Elapsed time: 02h:32m:58s. Have a nice day!
+Fri Jun 23 15:48:04 UTC 2023
+Elapsed time: 03h:04m:59s. Have a nice day!

--- a/tests/logs/RegressionTests_jet.log
+++ b/tests/logs/RegressionTests_jet.log
@@ -1,74 +1,52 @@
-Sat Jun 17 20:55:37 UTC 2023
+Thu Jun 22 18:21:54 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: cf35d10cc851f55af57a5d786ae2f025aa8a20f2
+Testing UFSWM Hash: 2d5a7ba68ca795af5ce01c7619099940d309bfde
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-1401-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
+ f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 678 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 677 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 635 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 249 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 237 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 591 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 580 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 709 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 928 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 220 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 011 elapsed time 618 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 552 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 545 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 503 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 618 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 241 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 183 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 518 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 595 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 206 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 653 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 569 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 180 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 110 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 193 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 56 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 557 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 558 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 600 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 537 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 514 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 182 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 037 elapsed time 547 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 038 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 039 elapsed time 201 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 040 elapsed time 355 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 041 elapsed time 104 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 042 elapsed time 212 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 043 elapsed time 440 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 044 elapsed time 363 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 045 elapsed time 363 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 046 elapsed time 281 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 047 elapsed time 250 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 048 elapsed time 164 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 049 elapsed time 254 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 050 elapsed time 135 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 051 elapsed time 119 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 2243 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 2295 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 2140 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 004 elapsed time 323 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 294 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1707 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 007 elapsed time 1963 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 008 elapsed time 3346 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 011 elapsed time 2083 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 013 elapsed time 2007 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 1957 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 015 elapsed time 1823 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 016 elapsed time 2028 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 017 elapsed time 329 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 1808 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 020 elapsed time 1862 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 021 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 254 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 1941 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 026 elapsed time 1915 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 027 elapsed time 286 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 028 elapsed time 139 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 277 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 030 elapsed time 79 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 031 elapsed time 2074 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 032 elapsed time 2265 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 033 elapsed time 2387 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 034 elapsed time 2462 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_mixedmode_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_p8_mixedmode_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -133,14 +111,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 415.577558
-  0: The maximum resident set size (KB)                   = 1724408
+  0: The total amount of wall time                        = 404.521990
+  0: The maximum resident set size (KB)                   = 1752236
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_gfsv17_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_gfsv17_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -204,14 +182,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 292.779346
-  0: The maximum resident set size (KB)                   = 1605840
+  0: The total amount of wall time                        = 289.793269
+  0: The maximum resident set size (KB)                   = 1602620
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -276,86 +254,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 461.443905
-  0: The maximum resident set size (KB)                   = 1782376
+  0: The total amount of wall time                        = 452.855283
+  0: The maximum resident set size (KB)                   = 1798380
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_p8_intel
-Checking test 003 cpld_control_p8_intel results ....
- Comparing sfcf021.tile1.nc .........OK
- Comparing sfcf021.tile2.nc .........OK
- Comparing sfcf021.tile3.nc .........OK
- Comparing sfcf021.tile4.nc .........OK
- Comparing sfcf021.tile5.nc .........OK
- Comparing sfcf021.tile6.nc .........OK
- Comparing atmf021.tile1.nc .........OK
- Comparing atmf021.tile2.nc .........OK
- Comparing atmf021.tile3.nc .........OK
- Comparing atmf021.tile4.nc .........OK
- Comparing atmf021.tile5.nc .........OK
- Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 461.443905
-  0: The maximum resident set size (KB)                   = 1782376
-
-Test 003 cpld_control_p8_intel PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_restart_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -408,14 +314,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 268.416865
-  0: The maximum resident set size (KB)                   = 1506344
+  0: The total amount of wall time                        = 256.852757
+  0: The maximum resident set size (KB)                   = 1492628
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -480,14 +386,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 458.741029
-  0: The maximum resident set size (KB)                   = 1803988
+  0: The total amount of wall time                        = 455.369562
+  0: The maximum resident set size (KB)                   = 1782372
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_restart_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -540,14 +446,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 266.815363
-  0: The maximum resident set size (KB)                   = 1516672
+  0: The total amount of wall time                        = 275.571952
+  0: The maximum resident set size (KB)                   = 1520672
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_2threads_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -600,14 +506,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 477.669406
-  0: The maximum resident set size (KB)                   = 2000492
+  0: The total amount of wall time                        = 472.756578
+  0: The maximum resident set size (KB)                   = 1995180
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_decomp_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -660,14 +566,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 461.345604
-  0: The maximum resident set size (KB)                   = 1801420
+  0: The total amount of wall time                        = 453.272737
+  0: The maximum resident set size (KB)                   = 1793492
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_mpi_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -720,14 +626,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 392.733209
-  0: The maximum resident set size (KB)                   = 1724544
+  0: The total amount of wall time                        = 380.798531
+  0: The maximum resident set size (KB)                   = 1740468
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_ciceC_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_ciceC_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_ciceC_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -792,14 +698,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 453.106756
-  0: The maximum resident set size (KB)                   = 1792792
+  0: The total amount of wall time                        = 452.073692
+  0: The maximum resident set size (KB)                   = 1804392
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_noaero_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_noaero_p8_intel
 Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -863,14 +769,14 @@ Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 361.648868
-  0: The maximum resident set size (KB)                   = 1630020
+  0: The total amount of wall time                        = 347.141566
+  0: The maximum resident set size (KB)                   = 1637908
 
 Test 011 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_nowave_noaero_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_nowave_noaero_p8_intel
 Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -932,14 +838,14 @@ Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 358.903190
-  0: The maximum resident set size (KB)                   = 1679772
+  0: The total amount of wall time                        = 348.135190
+  0: The maximum resident set size (KB)                   = 1685072
 
 Test 012 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_debug_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_debug_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_debug_p8_intel
 Checking test 013 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -992,14 +898,14 @@ Checking test 013 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 690.020422
-  0: The maximum resident set size (KB)                   = 1836936
+  0: The total amount of wall time                        = 673.085737
+  0: The maximum resident set size (KB)                   = 1828720
 
 Test 013 cpld_debug_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_debug_noaero_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_debug_noaero_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_debug_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_debug_noaero_p8_intel
 Checking test 014 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1051,14 +957,14 @@ Checking test 014 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 480.701873
-  0: The maximum resident set size (KB)                   = 1641080
+  0: The total amount of wall time                        = 470.917918
+  0: The maximum resident set size (KB)                   = 1639480
 
 Test 014 cpld_debug_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_agrid_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_noaero_p8_agrid_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_noaero_p8_agrid_intel
 Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1120,14 +1026,14 @@ Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 376.682577
-  0: The maximum resident set size (KB)                   = 1689148
+  0: The total amount of wall time                        = 371.564685
+  0: The maximum resident set size (KB)                   = 1671388
 
 Test 015 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_c48_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_c48_intel
 Checking test 016 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1177,14 +1083,14 @@ Checking test 016 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 789.702439
- 0: The maximum resident set size (KB)                   = 2771928
+ 0: The total amount of wall time                        = 798.915669
+ 0: The maximum resident set size (KB)                   = 2774940
 
 Test 016 cpld_control_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_warmstart_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_warmstart_c48_intel
 Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1234,14 +1140,14 @@ Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 208.562863
- 0: The maximum resident set size (KB)                   = 2764600
+ 0: The total amount of wall time                        = 214.868226
+ 0: The maximum resident set size (KB)                   = 2760456
 
 Test 017 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_restart_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_restart_c48_intel
 Checking test 018 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1291,14 +1197,14 @@ Checking test 018 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 110.461408
- 0: The maximum resident set size (KB)                   = 2201032
+ 0: The total amount of wall time                        = 113.045065
+ 0: The maximum resident set size (KB)                   = 2198348
 
 Test 018 cpld_restart_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_faster_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/cpld_control_p8_faster_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_p8_faster_intel
 Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1363,14 +1269,14 @@ Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 435.800533
-  0: The maximum resident set size (KB)                   = 1776340
+  0: The total amount of wall time                        = 426.611293
+  0: The maximum resident set size (KB)                   = 1797888
 
 Test 019 cpld_control_p8_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_flake_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_flake_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_flake_intel
 Checking test 020 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1381,14 +1287,14 @@ Checking test 020 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 261.596821
-  0: The maximum resident set size (KB)                   = 624872
+  0: The total amount of wall time                        = 258.976066
+  0: The maximum resident set size (KB)                   = 623888
 
 Test 020 control_flake_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_CubedSphereGrid_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_CubedSphereGrid_intel
 Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1415,28 +1321,28 @@ Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 188.748745
-  0: The maximum resident set size (KB)                   = 574060
+  0: The total amount of wall time                        = 182.880788
+  0: The maximum resident set size (KB)                   = 572908
 
 Test 021 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_parallel_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_CubedSphereGrid_parallel_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_parallel_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_CubedSphereGrid_parallel_intel
 Checking test 022 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 179.731657
-  0: The maximum resident set size (KB)                   = 574412
+  0: The total amount of wall time                        = 182.557617
+  0: The maximum resident set size (KB)                   = 573492
 
 Test 022 control_CubedSphereGrid_parallel_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_latlon_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_latlon_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_latlon_intel
 Checking test 023 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1447,14 +1353,14 @@ Checking test 023 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 180.654641
-  0: The maximum resident set size (KB)                   = 574804
+  0: The total amount of wall time                        = 186.602682
+  0: The maximum resident set size (KB)                   = 574000
 
 Test 023 control_latlon_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wrtGauss_netcdf_parallel_intel
 Checking test 024 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1465,14 +1371,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 189.175782
-  0: The maximum resident set size (KB)                   = 578144
+  0: The total amount of wall time                        = 190.250073
+  0: The maximum resident set size (KB)                   = 576272
 
 Test 024 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_c48_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c48_intel
 Checking test 025 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1511,14 +1417,14 @@ Checking test 025 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 593.799978
-0: The maximum resident set size (KB)                   = 802272
+0: The total amount of wall time                        = 598.251116
+0: The maximum resident set size (KB)                   = 805312
 
 Test 025 control_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_c192_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_c192_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c192_intel
 Checking test 026 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1529,14 +1435,14 @@ Checking test 026 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 731.565690
-  0: The maximum resident set size (KB)                   = 692612
+  0: The total amount of wall time                        = 729.831404
+  0: The maximum resident set size (KB)                   = 697044
 
 Test 026 control_c192_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_c384_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_c384_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c384_intel
 Checking test 027 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1547,14 +1453,14 @@ Checking test 027 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 933.181113
-  0: The maximum resident set size (KB)                   = 1062712
+  0: The total amount of wall time                        = 933.223671
+  0: The maximum resident set size (KB)                   = 1051624
 
 Test 027 control_c384_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_c384gdas_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_c384gdas_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c384gdas_intel
 Checking test 028 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1597,14 +1503,14 @@ Checking test 028 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 815.899826
-  0: The maximum resident set size (KB)                   = 1192580
+  0: The total amount of wall time                        = 792.014395
+  0: The maximum resident set size (KB)                   = 1202684
 
 Test 028 control_c384gdas_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_stochy_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_stochy_intel
 Checking test 029 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1615,28 +1521,28 @@ Checking test 029 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 122.366306
-  0: The maximum resident set size (KB)                   = 581140
+  0: The total amount of wall time                        = 124.034575
+  0: The maximum resident set size (KB)                   = 579176
 
 Test 029 control_stochy_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_stochy_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_stochy_restart_intel
 Checking test 030 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 68.419353
-  0: The maximum resident set size (KB)                   = 395328
+  0: The total amount of wall time                        = 65.777939
+  0: The maximum resident set size (KB)                   = 393632
 
 Test 030 control_stochy_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_lndp_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_lndp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_lndp_intel
 Checking test 031 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1647,14 +1553,14 @@ Checking test 031 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 114.405277
-  0: The maximum resident set size (KB)                   = 579364
+  0: The total amount of wall time                        = 113.410401
+  0: The maximum resident set size (KB)                   = 581108
 
 Test 031 control_lndp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_iovr4_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_iovr4_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_iovr4_intel
 Checking test 032 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1669,14 +1575,14 @@ Checking test 032 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 185.997957
-  0: The maximum resident set size (KB)                   = 573692
+  0: The total amount of wall time                        = 192.652888
+  0: The maximum resident set size (KB)                   = 577104
 
 Test 032 control_iovr4_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_iovr5_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_iovr5_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_iovr5_intel
 Checking test 033 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1691,14 +1597,14 @@ Checking test 033 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 187.692272
-  0: The maximum resident set size (KB)                   = 572196
+  0: The total amount of wall time                        = 188.933123
+  0: The maximum resident set size (KB)                   = 579000
 
 Test 033 control_iovr5_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_intel
 Checking test 034 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1745,14 +1651,14 @@ Checking test 034 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 227.075494
-  0: The maximum resident set size (KB)                   = 1549896
+  0: The total amount of wall time                        = 229.967041
+  0: The maximum resident set size (KB)                   = 1552672
 
 Test 034 control_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_restart_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_restart_p8_intel
 Checking test 035 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1791,14 +1697,14 @@ Checking test 035 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 122.343327
-  0: The maximum resident set size (KB)                   = 769940
+  0: The total amount of wall time                        = 117.089592
+  0: The maximum resident set size (KB)                   = 784032
 
 Test 035 control_restart_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_qr_p8_intel
 Checking test 036 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1845,14 +1751,14 @@ Checking test 036 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 220.650006
-  0: The maximum resident set size (KB)                   = 1550952
+  0: The total amount of wall time                        = 223.396538
+  0: The maximum resident set size (KB)                   = 1560332
 
 Test 036 control_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_restart_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_restart_qr_p8_intel
 Checking test 037 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1891,14 +1797,14 @@ Checking test 037 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 120.359851
-  0: The maximum resident set size (KB)                   = 797156
+  0: The total amount of wall time                        = 118.715301
+  0: The maximum resident set size (KB)                   = 788924
 
 Test 037 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_decomp_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_decomp_p8_intel
 Checking test 038 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1941,14 +1847,14 @@ Checking test 038 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 237.232060
-  0: The maximum resident set size (KB)                   = 1539552
+  0: The total amount of wall time                        = 233.410155
+  0: The maximum resident set size (KB)                   = 1537328
 
 Test 038 control_decomp_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_2threads_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_2threads_p8_intel
 Checking test 039 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1991,14 +1897,14 @@ Checking test 039 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 214.337883
-  0: The maximum resident set size (KB)                   = 1630136
+  0: The total amount of wall time                        = 210.822738
+  0: The maximum resident set size (KB)                   = 1630172
 
 Test 039 control_2threads_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_lndp_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_p8_lndp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_lndp_intel
 Checking test 040 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2017,14 +1923,14 @@ Checking test 040 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 431.237948
-  0: The maximum resident set size (KB)                   = 1549936
+  0: The total amount of wall time                        = 424.381662
+  0: The maximum resident set size (KB)                   = 1550760
 
 Test 040 control_p8_lndp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_rrtmgp_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_p8_rrtmgp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_rrtmgp_intel
 Checking test 041 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2071,14 +1977,14 @@ Checking test 041 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 311.851838
-  0: The maximum resident set size (KB)                   = 1614808
+  0: The total amount of wall time                        = 298.523686
+  0: The maximum resident set size (KB)                   = 1622872
 
 Test 041 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_mynn_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_p8_mynn_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_mynn_intel
 Checking test 042 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2125,14 +2031,14 @@ Checking test 042 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 239.034151
-  0: The maximum resident set size (KB)                   = 1549388
+  0: The total amount of wall time                        = 232.262045
+  0: The maximum resident set size (KB)                   = 1541752
 
 Test 042 control_p8_mynn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/merra2_thompson_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/merra2_thompson_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/merra2_thompson_intel
 Checking test 043 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2179,14 +2085,14 @@ Checking test 043 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 264.592198
-  0: The maximum resident set size (KB)                   = 1559976
+  0: The total amount of wall time                        = 258.405741
+  0: The maximum resident set size (KB)                   = 1556928
 
 Test 043 merra2_thompson_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_control_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_control_intel
 Checking test 044 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2197,28 +2103,28 @@ Checking test 044 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 402.443992
-  0: The maximum resident set size (KB)                   = 785784
+  0: The total amount of wall time                        = 397.091595
+  0: The maximum resident set size (KB)                   = 785260
 
 Test 044 regional_control_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_restart_intel
 Checking test 045 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 204.549670
-  0: The maximum resident set size (KB)                   = 783780
+  0: The total amount of wall time                        = 208.008915
+  0: The maximum resident set size (KB)                   = 784904
 
 Test 045 regional_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_control_qr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_control_qr_intel
 Checking test 046 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2229,28 +2135,28 @@ Checking test 046 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 398.179731
-  0: The maximum resident set size (KB)                   = 786548
+  0: The total amount of wall time                        = 398.499874
+  0: The maximum resident set size (KB)                   = 791344
 
 Test 046 regional_control_qr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_restart_qr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_restart_qr_intel
 Checking test 047 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 202.923139
-  0: The maximum resident set size (KB)                   = 780508
+  0: The total amount of wall time                        = 202.398131
+  0: The maximum resident set size (KB)                   = 783992
 
 Test 047 regional_restart_qr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_decomp_intel
 Checking test 048 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2261,14 +2167,14 @@ Checking test 048 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 415.864614
-  0: The maximum resident set size (KB)                   = 779916
+  0: The total amount of wall time                        = 412.951581
+  0: The maximum resident set size (KB)                   = 778868
 
 Test 048 regional_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_2threads_intel
 Checking test 049 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2279,28 +2185,28 @@ Checking test 049 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 242.843605
-  0: The maximum resident set size (KB)                   = 764992
+  0: The total amount of wall time                        = 235.473845
+  0: The maximum resident set size (KB)                   = 774148
 
 Test 049 regional_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_netcdf_parallel_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_netcdf_parallel_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_netcdf_parallel_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_netcdf_parallel_intel
 Checking test 050 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 391.473867
-  0: The maximum resident set size (KB)                   = 784408
+  0: The total amount of wall time                        = 386.590903
+  0: The maximum resident set size (KB)                   = 784216
 
 Test 050 regional_netcdf_parallel_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_2dwrtdecomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_2dwrtdecomp_intel
 Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2311,14 +2217,14 @@ Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 400.066404
-  0: The maximum resident set size (KB)                   = 783788
+  0: The total amount of wall time                        = 395.695645
+  0: The maximum resident set size (KB)                   = 793740
 
 Test 051 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_control_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_intel
 Checking test 052 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2365,14 +2271,14 @@ Checking test 052 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 600.877705
-  0: The maximum resident set size (KB)                   = 957084
+  0: The total amount of wall time                        = 589.656341
+  0: The maximum resident set size (KB)                   = 959172
 
 Test 052 rap_control_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_spp_sppt_shum_skeb_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_spp_sppt_shum_skeb_intel
 Checking test 053 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2383,14 +2289,14 @@ Checking test 053 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 318.677996
-  0: The maximum resident set size (KB)                   = 1091860
+  0: The total amount of wall time                        = 309.647291
+  0: The maximum resident set size (KB)                   = 1093704
 
 Test 053 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_decomp_intel
 Checking test 054 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2437,14 +2343,14 @@ Checking test 054 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 616.762413
-  0: The maximum resident set size (KB)                   = 953288
+  0: The total amount of wall time                        = 612.664842
+  0: The maximum resident set size (KB)                   = 945120
 
 Test 054 rap_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_2threads_intel
 Checking test 055 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2491,14 +2397,14 @@ Checking test 055 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 559.343607
-  0: The maximum resident set size (KB)                   = 1031080
+  0: The total amount of wall time                        = 555.136745
+  0: The maximum resident set size (KB)                   = 1035080
 
 Test 055 rap_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_restart_intel
 Checking test 056 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2537,14 +2443,14 @@ Checking test 056 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 299.746914
-  0: The maximum resident set size (KB)                   = 822780
+  0: The total amount of wall time                        = 311.906231
+  0: The maximum resident set size (KB)                   = 827956
 
 Test 056 rap_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_sfcdiff_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_intel
 Checking test 057 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2591,14 +2497,14 @@ Checking test 057 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 597.769526
-  0: The maximum resident set size (KB)                   = 940168
+  0: The total amount of wall time                        = 595.859763
+  0: The maximum resident set size (KB)                   = 948740
 
 Test 057 rap_sfcdiff_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_sfcdiff_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_decomp_intel
 Checking test 058 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2645,14 +2551,14 @@ Checking test 058 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 634.397333
-  0: The maximum resident set size (KB)                   = 946360
+  0: The total amount of wall time                        = 631.288318
+  0: The maximum resident set size (KB)                   = 938860
 
 Test 058 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_sfcdiff_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_restart_intel
 Checking test 059 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2691,14 +2597,14 @@ Checking test 059 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 434.139635
-  0: The maximum resident set size (KB)                   = 840444
+  0: The total amount of wall time                        = 435.538603
+  0: The maximum resident set size (KB)                   = 831612
 
 Test 059 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_intel
 Checking test 060 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2718,41 +2624,41 @@ Checking test 060 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 577.745549
-  0: The maximum resident set size (KB)                   = 950760
+  0: The total amount of wall time                        = 568.425398
+  0: The maximum resident set size (KB)                   = 951272
 
-Test 060 hrrr_control_intel FAIL
+Test 060 hrrr_control_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_qr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_qr_intel
 Checking test 061 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2790,23 +2696,23 @@ Checking test 061 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 557.975980
-  0: The maximum resident set size (KB)                   = 960876
+  0: The total amount of wall time                        = 563.135433
+  0: The maximum resident set size (KB)                   = 960656
 
-Test 061 hrrr_control_qr_intel FAIL
+Test 061 hrrr_control_qr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_decomp_intel
 Checking test 062 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2826,41 +2732,41 @@ Checking test 062 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 596.631125
-  0: The maximum resident set size (KB)                   = 943652
+  0: The total amount of wall time                        = 596.633945
+  0: The maximum resident set size (KB)                   = 951376
 
-Test 062 hrrr_control_decomp_intel FAIL
+Test 062 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_2threads_intel
 Checking test 063 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2880,41 +2786,123 @@ Checking test 063 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
  Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 524.984856
-  0: The maximum resident set size (KB)                   = 1003372
+  0: The total amount of wall time                        = 526.762507
+  0: The maximum resident set size (KB)                   = 1014792
 
-Test 063 hrrr_control_2threads_intel FAIL
+Test 063 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_v1nssl_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_intel
+Checking test 064 hrrr_control_restart_intel results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 418.021823
+  0: The maximum resident set size (KB)                   = 838692
+
+Test 064 hrrr_control_restart_intel PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_qr_intel
+Checking test 065 hrrr_control_restart_qr_intel results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 421.280277
+  0: The maximum resident set size (KB)                   = 854648
+
+Test 065 hrrr_control_restart_qr_intel PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1beta_intel
+Checking test 066 rrfs_v1beta_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+
+  0: The total amount of wall time                        = 601.597541
+  0: The maximum resident set size (KB)                   = 954080
+
+Test 066 rrfs_v1beta_intel PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1nssl_intel
 Checking test 067 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2929,14 +2917,14 @@ Checking test 067 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 706.125896
-  0: The maximum resident set size (KB)                   = 632316
+  0: The total amount of wall time                        = 711.713546
+  0: The maximum resident set size (KB)                   = 628800
 
 Test 067 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1nssl_nohailnoccn_intel
 Checking test 068 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2951,14 +2939,14 @@ Checking test 068 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 693.133154
-  0: The maximum resident set size (KB)                   = 634556
+  0: The total amount of wall time                        = 707.982244
+  0: The maximum resident set size (KB)                   = 635536
 
 Test 068 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 069 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2974,15 +2962,31 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 202.693457
-  0: The maximum resident set size (KB)                   = 908836
+  0: The total amount of wall time                        = 197.603339
+  0: The maximum resident set size (KB)                   = 902156
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_hrrr_warm_qr_intel
-Checking test 070 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 128.248768
+  0: The maximum resident set size (KB)                   = 872272
+
+Test 070 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
+
+
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_conus13km_hrrr_warm_intel
+Checking test 071 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2997,15 +3001,15 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 207.488866
-  0: The maximum resident set size (KB)                   = 893496
+  0: The total amount of wall time                        = 176.516553
+  0: The maximum resident set size (KB)                   = 874612
 
-Test 070 rrfs_smoke_conus13km_hrrr_warm_qr_intel PASS
+Test 071 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
-Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_radar_tten_warm_intel
+Checking test 072 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3013,78 +3017,27 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 130.732276
-  0: The maximum resident set size (KB)                   = 870676
+  0: The total amount of wall time                        = 199.338798
+  0: The maximum resident set size (KB)                   = 910760
 
-Test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_conus13km_hrrr_warm_intel
-Checking test 072 rrfs_conus13km_hrrr_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-  0: The total amount of wall time                        = 181.565948
-  0: The maximum resident set size (KB)                   = 876716
-
-Test 072 rrfs_conus13km_hrrr_warm_intel PASS
+Test 072 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_radar_tten_warm_intel
-Checking test 073 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 203.899682
-  0: The maximum resident set size (KB)                   = 909172
-
-Test 073 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-Checking test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+Checking test 073 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 118.942340
-  0: The maximum resident set size (KB)                   = 898176
+  0: The total amount of wall time                        = 116.078382
+  0: The maximum resident set size (KB)                   = 891524
 
-Test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel
-Checking test 075 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 117.309635
-  0: The maximum resident set size (KB)                   = 889196
-
-Test 075 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel PASS
+Test 073 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_csawmg_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_csawmg_intel
-Checking test 076 control_csawmg_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmg_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmg_intel
+Checking test 074 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3094,15 +3047,15 @@ Checking test 076 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 454.832807
-  0: The maximum resident set size (KB)                   = 673408
+  0: The total amount of wall time                        = 468.067220
+  0: The maximum resident set size (KB)                   = 672956
 
-Test 076 control_csawmg_intel PASS
+Test 074 control_csawmg_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_csawmgt_intel
-Checking test 077 control_csawmgt_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmgt_intel
+Checking test 075 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3112,15 +3065,15 @@ Checking test 077 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 448.068869
-  0: The maximum resident set size (KB)                   = 662884
+  0: The total amount of wall time                        = 460.199912
+  0: The maximum resident set size (KB)                   = 667108
 
-Test 077 control_csawmgt_intel PASS
+Test 075 control_csawmgt_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_ras_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_ras_intel
-Checking test 078 control_ras_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_ras_intel
+Checking test 076 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3130,27 +3083,27 @@ Checking test 078 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 250.084145
-  0: The maximum resident set size (KB)                   = 634932
+  0: The total amount of wall time                        = 248.462259
+  0: The maximum resident set size (KB)                   = 635344
 
-Test 078 control_ras_intel PASS
+Test 076 control_ras_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_wam_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_wam_intel
-Checking test 079 control_wam_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wam_intel
+Checking test 077 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 161.638111
-  0: The maximum resident set size (KB)                   = 483476
+  0: The total amount of wall time                        = 150.974707
+  0: The maximum resident set size (KB)                   = 485320
 
-Test 079 control_wam_intel PASS
+Test 077 control_wam_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_faster_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_p8_faster_intel
-Checking test 080 control_p8_faster_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_faster_intel
+Checking test 078 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3196,15 +3149,15 @@ Checking test 080 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 217.899480
-  0: The maximum resident set size (KB)                   = 1537544
+  0: The total amount of wall time                        = 211.305588
+  0: The maximum resident set size (KB)                   = 1552500
 
-Test 080 control_p8_faster_intel PASS
+Test 078 control_p8_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_control_faster_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_control_faster_intel
-Checking test 081 regional_control_faster_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_control_faster_intel
+Checking test 079 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3214,57 +3167,57 @@ Checking test 081 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 378.118702
-  0: The maximum resident set size (KB)                   = 785864
+  0: The total amount of wall time                        = 368.467879
+  0: The maximum resident set size (KB)                   = 793248
 
-Test 081 regional_control_faster_intel PASS
+Test 079 regional_control_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 1082.104763
-  0: The maximum resident set size (KB)                   = 932708
+  0: The total amount of wall time                        = 1076.754596
+  0: The maximum resident set size (KB)                   = 932448
 
-Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
+Test 080 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
-Checking test 083 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 617.928134
-  0: The maximum resident set size (KB)                   = 897800
+  0: The total amount of wall time                        = 632.349554
+  0: The maximum resident set size (KB)                   = 897852
 
-Test 083 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
+Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_conus13km_hrrr_warm_debug_intel
-Checking test 084 rrfs_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_conus13km_hrrr_warm_debug_intel
+Checking test 082 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 968.235113
-  0: The maximum resident set size (KB)                   = 850832
+  0: The total amount of wall time                        = 963.277850
+  0: The maximum resident set size (KB)                   = 903872
 
-Test 084 rrfs_conus13km_hrrr_warm_debug_intel PASS
+Test 082 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_CubedSphereGrid_debug_intel
-Checking test 085 control_CubedSphereGrid_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_CubedSphereGrid_debug_intel
+Checking test 083 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3290,349 +3243,349 @@ Checking test 085 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.099888
-  0: The maximum resident set size (KB)                   = 729544
+  0: The total amount of wall time                        = 184.993414
+  0: The maximum resident set size (KB)                   = 730392
 
-Test 085 control_CubedSphereGrid_debug_intel PASS
+Test 083 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_wrtGauss_netcdf_parallel_debug_intel
-Checking test 086 control_wrtGauss_netcdf_parallel_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wrtGauss_netcdf_parallel_debug_intel
+Checking test 084 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 187.795384
-  0: The maximum resident set size (KB)                   = 734748
+  0: The total amount of wall time                        = 186.806760
+  0: The maximum resident set size (KB)                   = 738512
 
-Test 086 control_wrtGauss_netcdf_parallel_debug_intel PASS
+Test 084 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_stochy_debug_intel
-Checking test 087 control_stochy_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_stochy_debug_intel
+Checking test 085 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 213.911266
-  0: The maximum resident set size (KB)                   = 736352
+  0: The total amount of wall time                        = 211.507235
+  0: The maximum resident set size (KB)                   = 741452
 
-Test 087 control_stochy_debug_intel PASS
+Test 085 control_stochy_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_lndp_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_lndp_debug_intel
-Checking test 088 control_lndp_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_lndp_debug_intel
+Checking test 086 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.736131
-  0: The maximum resident set size (KB)                   = 734924
+  0: The total amount of wall time                        = 195.295067
+  0: The maximum resident set size (KB)                   = 736460
 
-Test 088 control_lndp_debug_intel PASS
+Test 086 control_lndp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_csawmg_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_csawmg_debug_intel
-Checking test 089 control_csawmg_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmg_debug_intel
+Checking test 087 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 302.196714
-  0: The maximum resident set size (KB)                   = 785076
+  0: The total amount of wall time                        = 298.929669
+  0: The maximum resident set size (KB)                   = 780924
 
-Test 089 control_csawmg_debug_intel PASS
+Test 087 control_csawmg_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_csawmgt_debug_intel
-Checking test 090 control_csawmgt_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmgt_debug_intel
+Checking test 088 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 294.433586
-  0: The maximum resident set size (KB)                   = 780348
+  0: The total amount of wall time                        = 293.662722
+  0: The maximum resident set size (KB)                   = 783184
 
-Test 090 control_csawmgt_debug_intel PASS
+Test 088 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_ras_debug_intel
-Checking test 091 control_ras_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_ras_debug_intel
+Checking test 089 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 192.837515
-  0: The maximum resident set size (KB)                   = 745676
+  0: The total amount of wall time                        = 191.791935
+  0: The maximum resident set size (KB)                   = 746692
 
-Test 091 control_ras_debug_intel PASS
+Test 089 control_ras_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_diag_debug_intel
-Checking test 092 control_diag_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_diag_debug_intel
+Checking test 090 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 196.787923
-  0: The maximum resident set size (KB)                   = 789780
+  0: The total amount of wall time                        = 194.626234
+  0: The maximum resident set size (KB)                   = 785568
 
-Test 092 control_diag_debug_intel PASS
+Test 090 control_diag_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_debug_p8_intel
-Checking test 093 control_debug_p8_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_debug_p8_intel
+Checking test 091 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 218.642320
-  0: The maximum resident set size (KB)                   = 1567068
+  0: The total amount of wall time                        = 212.386800
+  0: The maximum resident set size (KB)                   = 1566024
 
-Test 093 control_debug_p8_intel PASS
+Test 091 control_debug_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_debug_intel
-Checking test 094 regional_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_debug_intel
+Checking test 092 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1280.407916
-  0: The maximum resident set size (KB)                   = 801904
+  0: The total amount of wall time                        = 1268.478785
+  0: The maximum resident set size (KB)                   = 802564
 
-Test 094 regional_debug_intel PASS
+Test 092 regional_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_control_debug_intel
-Checking test 095 rap_control_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_debug_intel
+Checking test 093 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 359.478675
-  0: The maximum resident set size (KB)                   = 1113460
+  0: The total amount of wall time                        = 348.628326
+  0: The maximum resident set size (KB)                   = 1106156
 
-Test 095 rap_control_debug_intel PASS
+Test 093 rap_control_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_debug_intel
-Checking test 096 hrrr_control_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_debug_intel
+Checking test 094 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.801488
-  0: The maximum resident set size (KB)                   = 1112212
+  0: The total amount of wall time                        = 336.773772
+  0: The maximum resident set size (KB)                   = 1112308
 
-Test 096 hrrr_control_debug_intel PASS
+Test 094 hrrr_control_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_unified_drag_suite_debug_intel
-Checking test 097 rap_unified_drag_suite_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_unified_drag_suite_debug_intel
+Checking test 095 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.017108
-  0: The maximum resident set size (KB)                   = 1116188
+  0: The total amount of wall time                        = 347.695101
+  0: The maximum resident set size (KB)                   = 1111588
 
-Test 097 rap_unified_drag_suite_debug_intel PASS
+Test 095 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_diag_debug_intel
-Checking test 098 rap_diag_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_diag_debug_intel
+Checking test 096 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 368.187002
-  0: The maximum resident set size (KB)                   = 1184892
+  0: The total amount of wall time                        = 364.708746
+  0: The maximum resident set size (KB)                   = 1195580
 
-Test 098 rap_diag_debug_intel PASS
+Test 096 rap_diag_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_cires_ugwp_debug_intel
-Checking test 099 rap_cires_ugwp_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_cires_ugwp_debug_intel
+Checking test 097 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 359.379117
-  0: The maximum resident set size (KB)                   = 1105572
+  0: The total amount of wall time                        = 354.323338
+  0: The maximum resident set size (KB)                   = 1113252
 
-Test 099 rap_cires_ugwp_debug_intel PASS
+Test 097 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_unified_ugwp_debug_intel
-Checking test 100 rap_unified_ugwp_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_unified_ugwp_debug_intel
+Checking test 098 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 355.155050
-  0: The maximum resident set size (KB)                   = 1117888
+  0: The total amount of wall time                        = 356.864633
+  0: The maximum resident set size (KB)                   = 1117036
 
-Test 100 rap_unified_ugwp_debug_intel PASS
+Test 098 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_lndp_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_lndp_debug_intel
-Checking test 101 rap_lndp_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_lndp_debug_intel
+Checking test 099 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 352.384159
-  0: The maximum resident set size (KB)                   = 1115720
+  0: The total amount of wall time                        = 347.999813
+  0: The maximum resident set size (KB)                   = 1112176
 
-Test 101 rap_lndp_debug_intel PASS
+Test 099 rap_lndp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_progcld_thompson_debug_intel
-Checking test 102 rap_progcld_thompson_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_progcld_thompson_debug_intel
+Checking test 100 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.345760
-  0: The maximum resident set size (KB)                   = 1108864
+  0: The total amount of wall time                        = 350.182411
+  0: The maximum resident set size (KB)                   = 1107872
 
-Test 102 rap_progcld_thompson_debug_intel PASS
+Test 100 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_noah_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_noah_debug_intel
-Checking test 103 rap_noah_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_noah_debug_intel
+Checking test 101 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.748567
-  0: The maximum resident set size (KB)                   = 1117008
+  0: The total amount of wall time                        = 342.578959
+  0: The maximum resident set size (KB)                   = 1112716
 
-Test 103 rap_noah_debug_intel PASS
+Test 101 rap_noah_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_sfcdiff_debug_intel
-Checking test 104 rap_sfcdiff_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_debug_intel
+Checking test 102 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.626865
-  0: The maximum resident set size (KB)                   = 1114112
+  0: The total amount of wall time                        = 346.575542
+  0: The maximum resident set size (KB)                   = 1108628
 
-Test 104 rap_sfcdiff_debug_intel PASS
+Test 102 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_noah_sfcdiff_cires_ugwp_debug_intel
-Checking test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_noah_sfcdiff_cires_ugwp_debug_intel
+Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 581.738037
-  0: The maximum resident set size (KB)                   = 1108764
+  0: The total amount of wall time                        = 572.173051
+  0: The maximum resident set size (KB)                   = 1111536
 
-Test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
+Test 103 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rrfs_v1beta_debug_intel
-Checking test 106 rrfs_v1beta_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1beta_debug_intel
+Checking test 104 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.092882
-  0: The maximum resident set size (KB)                   = 1109236
+  0: The total amount of wall time                        = 344.767735
+  0: The maximum resident set size (KB)                   = 1104696
 
-Test 106 rrfs_v1beta_debug_intel PASS
+Test 104 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_clm_lake_debug_intel
-Checking test 107 rap_clm_lake_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_clm_lake_debug_intel
+Checking test 105 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 439.689248
-  0: The maximum resident set size (KB)                   = 1111524
+  0: The total amount of wall time                        = 431.056172
+  0: The maximum resident set size (KB)                   = 1096380
 
-Test 107 rap_clm_lake_debug_intel PASS
+Test 105 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_flake_debug_intel
-Checking test 108 rap_flake_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_flake_debug_intel
+Checking test 106 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 349.214416
-  0: The maximum resident set size (KB)                   = 1115408
+  0: The total amount of wall time                        = 344.851149
+  0: The maximum resident set size (KB)                   = 1111424
 
-Test 108 rap_flake_debug_intel PASS
+Test 106 rap_flake_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_wam_debug_intel
-Checking test 109 control_wam_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wam_debug_intel
+Checking test 107 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 355.792717
-  0: The maximum resident set size (KB)                   = 432992
+  0: The total amount of wall time                        = 354.455800
+  0: The maximum resident set size (KB)                   = 432364
 
-Test 109 control_wam_debug_intel PASS
+Test 107 control_wam_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+Checking test 108 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3642,15 +3595,15 @@ Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 291.331724
-  0: The maximum resident set size (KB)                   = 986788
+  0: The total amount of wall time                        = 288.336473
+  0: The maximum resident set size (KB)                   = 987480
 
-Test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+Test 108 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_control_dyn32_phy32_intel
-Checking test 111 rap_control_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_dyn32_phy32_intel
+Checking test 109 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3696,15 +3649,15 @@ Checking test 111 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 493.697065
-  0: The maximum resident set size (KB)                   = 863340
+  0: The total amount of wall time                        = 482.804390
+  0: The maximum resident set size (KB)                   = 850992
 
-Test 111 rap_control_dyn32_phy32_intel PASS
+Test 109 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_dyn32_phy32_intel
-Checking test 112 hrrr_control_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_dyn32_phy32_intel
+Checking test 110 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3750,15 +3703,15 @@ Checking test 112 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 251.686728
-  0: The maximum resident set size (KB)                   = 826392
+  0: The total amount of wall time                        = 250.727648
+  0: The maximum resident set size (KB)                   = 830996
 
-Test 112 hrrr_control_dyn32_phy32_intel PASS
+Test 110 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_qr_dyn32_phy32_intel
-Checking test 113 hrrr_control_qr_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_qr_dyn32_phy32_intel
+Checking test 111 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3804,15 +3757,15 @@ Checking test 113 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 250.515461
-  0: The maximum resident set size (KB)                   = 834784
+  0: The total amount of wall time                        = 247.346904
+  0: The maximum resident set size (KB)                   = 846108
 
-Test 113 hrrr_control_qr_dyn32_phy32_intel PASS
+Test 111 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_2threads_dyn32_phy32_intel
-Checking test 114 rap_2threads_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_2threads_dyn32_phy32_intel
+Checking test 112 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3858,15 +3811,15 @@ Checking test 114 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 451.635355
-  0: The maximum resident set size (KB)                   = 896916
+  0: The total amount of wall time                        = 460.768182
+  0: The maximum resident set size (KB)                   = 888752
 
-Test 114 rap_2threads_dyn32_phy32_intel PASS
+Test 112 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 115 hrrr_control_2threads_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_2threads_dyn32_phy32_intel
+Checking test 113 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3912,15 +3865,15 @@ Checking test 115 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 233.966173
-  0: The maximum resident set size (KB)                   = 872020
+  0: The total amount of wall time                        = 231.956940
+  0: The maximum resident set size (KB)                   = 880816
 
-Test 115 hrrr_control_2threads_dyn32_phy32_intel PASS
+Test 113 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 116 hrrr_control_decomp_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_decomp_dyn32_phy32_intel
+Checking test 114 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3966,15 +3919,15 @@ Checking test 116 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 274.884543
-  0: The maximum resident set size (KB)                   = 831320
+  0: The total amount of wall time                        = 263.453946
+  0: The maximum resident set size (KB)                   = 830984
 
-Test 116 hrrr_control_decomp_dyn32_phy32_intel PASS
+Test 114 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_restart_dyn32_phy32_intel
-Checking test 117 rap_restart_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_restart_dyn32_phy32_intel
+Checking test 115 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -4012,43 +3965,43 @@ Checking test 117 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 356.575478
-  0: The maximum resident set size (KB)                   = 805600
+  0: The total amount of wall time                        = 352.599030
+  0: The maximum resident set size (KB)                   = 802332
 
-Test 117 rap_restart_dyn32_phy32_intel PASS
+Test 115 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_restart_dyn32_phy32_intel
-Checking test 118 hrrr_control_restart_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_dyn32_phy32_intel
+Checking test 116 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 129.695159
-  0: The maximum resident set size (KB)                   = 761956
+  0: The total amount of wall time                        = 128.417058
+  0: The maximum resident set size (KB)                   = 759368
 
-Test 118 hrrr_control_restart_dyn32_phy32_intel PASS
+Test 116 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_restart_qr_dyn32_phy32_intel
-Checking test 119 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 117 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 132.065597
-  0: The maximum resident set size (KB)                   = 793128
+  0: The total amount of wall time                        = 131.416949
+  0: The maximum resident set size (KB)                   = 785244
 
-Test 119 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+Test 117 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_control_dyn64_phy32_intel
-Checking test 120 rap_control_dyn64_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_dyn64_phy32_intel
+Checking test 118 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4094,82 +4047,82 @@ Checking test 120 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 315.468094
-  0: The maximum resident set size (KB)                   = 878204
+  0: The total amount of wall time                        = 311.247188
+  0: The maximum resident set size (KB)                   = 872632
 
-Test 120 rap_control_dyn64_phy32_intel PASS
+Test 118 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_control_debug_dyn32_phy32_intel
-Checking test 121 rap_control_debug_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_debug_dyn32_phy32_intel
+Checking test 119 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 347.551364
-  0: The maximum resident set size (KB)                   = 997132
+  0: The total amount of wall time                        = 342.837119
+  0: The maximum resident set size (KB)                   = 1002264
 
-Test 121 rap_control_debug_dyn32_phy32_intel PASS
+Test 119 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hrrr_control_debug_dyn32_phy32_intel
-Checking test 122 hrrr_control_debug_dyn32_phy32_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_debug_dyn32_phy32_intel
+Checking test 120 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.420629
-  0: The maximum resident set size (KB)                   = 986656
+  0: The total amount of wall time                        = 338.615567
+  0: The maximum resident set size (KB)                   = 990688
 
-Test 122 hrrr_control_debug_dyn32_phy32_intel PASS
+Test 120 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/rap_control_dyn64_phy32_debug_intel
-Checking test 123 rap_control_dyn64_phy32_debug_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_dyn64_phy32_debug_intel
+Checking test 121 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 355.038324
-  0: The maximum resident set size (KB)                   = 1032256
+  0: The total amount of wall time                        = 344.739325
+  0: The maximum resident set size (KB)                   = 1035480
 
-Test 123 rap_control_dyn64_phy32_debug_intel PASS
+Test 121 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hafs_regional_atm_intel
-Checking test 124 hafs_regional_atm_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_intel
+Checking test 122 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 323.684921
-  0: The maximum resident set size (KB)                   = 1217788
+  0: The total amount of wall time                        = 961.723902
+  0: The maximum resident set size (KB)                   = 1215940
 
-Test 124 hafs_regional_atm_intel PASS
+Test 122 hafs_regional_atm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hafs_regional_atm_thompson_gfdlsf_intel
-Checking test 125 hafs_regional_atm_thompson_gfdlsf_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_thompson_gfdlsf_intel
+Checking test 123 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 390.620692
-  0: The maximum resident set size (KB)                   = 1556332
+  0: The total amount of wall time                        = 1115.626393
+  0: The maximum resident set size (KB)                   = 1588788
 
-Test 125 hafs_regional_atm_thompson_gfdlsf_intel PASS
+Test 123 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hafs_regional_atm_ocn_intel
-Checking test 126 hafs_regional_atm_ocn_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_ocn_intel
+Checking test 124 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4177,15 +4130,15 @@ Checking test 126 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 513.161610
-  0: The maximum resident set size (KB)                   = 1295416
+  0: The total amount of wall time                        = 1207.521701
+  0: The maximum resident set size (KB)                   = 1293848
 
-Test 126 hafs_regional_atm_ocn_intel PASS
+Test 124 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_wav_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hafs_regional_atm_wav_intel
-Checking test 127 hafs_regional_atm_wav_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_wav_intel
+Checking test 125 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4193,15 +4146,15 @@ Checking test 127 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 909.259821
-  0: The maximum resident set size (KB)                   = 1323704
+  0: The total amount of wall time                        = 1587.520121
+  0: The maximum resident set size (KB)                   = 1323848
 
-Test 127 hafs_regional_atm_wav_intel PASS
+Test 125 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_wav_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hafs_regional_atm_ocn_wav_intel
-Checking test 128 hafs_regional_atm_ocn_wav_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_ocn_wav_intel
+Checking test 126 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4211,149 +4164,149 @@ Checking test 128 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 955.860338
-  0: The maximum resident set size (KB)                   = 1331132
+  0: The total amount of wall time                        = 1719.986857
+  0: The maximum resident set size (KB)                   = 1340580
 
-Test 128 hafs_regional_atm_ocn_wav_intel PASS
+Test 126 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hafs_regional_docn_intel
-Checking test 129 hafs_regional_docn_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_docn_intel
+Checking test 127 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 460.062925
-  0: The maximum resident set size (KB)                   = 1303004
+  0: The total amount of wall time                        = 1014.346961
+  0: The maximum resident set size (KB)                   = 1299592
 
-Test 129 hafs_regional_docn_intel PASS
+Test 127 hafs_regional_docn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_oisst_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/hafs_regional_docn_oisst_intel
-Checking test 130 hafs_regional_docn_oisst_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_oisst_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_docn_oisst_intel
+Checking test 128 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 467.332094
-  0: The maximum resident set size (KB)                   = 1295892
+  0: The total amount of wall time                        = 1126.162789
+  0: The maximum resident set size (KB)                   = 1283928
 
-Test 130 hafs_regional_docn_oisst_intel PASS
+Test 128 hafs_regional_docn_oisst_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_control_cfsr_intel
-Checking test 131 datm_cdeps_control_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_control_cfsr_intel
+Checking test 129 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 215.923113
- 0: The maximum resident set size (KB)                   = 958652
+ 0: The total amount of wall time                        = 203.644076
+ 0: The maximum resident set size (KB)                   = 953964
 
-Test 131 datm_cdeps_control_cfsr_intel PASS
+Test 129 datm_cdeps_control_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_restart_cfsr_intel
-Checking test 132 datm_cdeps_restart_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_restart_cfsr_intel
+Checking test 130 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 123.116928
- 0: The maximum resident set size (KB)                   = 930852
+ 0: The total amount of wall time                        = 122.306546
+ 0: The maximum resident set size (KB)                   = 952644
 
-Test 132 datm_cdeps_restart_cfsr_intel PASS
+Test 130 datm_cdeps_restart_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_gefs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_control_gefs_intel
-Checking test 133 datm_cdeps_control_gefs_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_control_gefs_intel
+Checking test 131 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 212.359599
- 0: The maximum resident set size (KB)                   = 861132
+ 0: The total amount of wall time                        = 199.430108
+ 0: The maximum resident set size (KB)                   = 865016
 
-Test 133 datm_cdeps_control_gefs_intel PASS
+Test 131 datm_cdeps_control_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_iau_gefs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_iau_gefs_intel
-Checking test 134 datm_cdeps_iau_gefs_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_iau_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_iau_gefs_intel
+Checking test 132 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 207.255239
- 0: The maximum resident set size (KB)                   = 864356
+ 0: The total amount of wall time                        = 201.503007
+ 0: The maximum resident set size (KB)                   = 852860
 
-Test 134 datm_cdeps_iau_gefs_intel PASS
+Test 132 datm_cdeps_iau_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_stochy_gefs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_stochy_gefs_intel
-Checking test 135 datm_cdeps_stochy_gefs_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_stochy_gefs_intel
+Checking test 133 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 209.350401
- 0: The maximum resident set size (KB)                   = 857868
+ 0: The total amount of wall time                        = 203.641562
+ 0: The maximum resident set size (KB)                   = 858788
 
-Test 135 datm_cdeps_stochy_gefs_intel PASS
+Test 133 datm_cdeps_stochy_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_ciceC_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_ciceC_cfsr_intel
-Checking test 136 datm_cdeps_ciceC_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_ciceC_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_ciceC_cfsr_intel
+Checking test 134 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 211.219957
- 0: The maximum resident set size (KB)                   = 973516
+ 0: The total amount of wall time                        = 205.765666
+ 0: The maximum resident set size (KB)                   = 961560
 
-Test 136 datm_cdeps_ciceC_cfsr_intel PASS
+Test 134 datm_cdeps_ciceC_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_bulk_cfsr_intel
-Checking test 137 datm_cdeps_bulk_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_bulk_cfsr_intel
+Checking test 135 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 209.499301
- 0: The maximum resident set size (KB)                   = 963844
+ 0: The total amount of wall time                        = 205.142450
+ 0: The maximum resident set size (KB)                   = 975772
 
-Test 137 datm_cdeps_bulk_cfsr_intel PASS
+Test 135 datm_cdeps_bulk_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_gefs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_bulk_gefs_intel
-Checking test 138 datm_cdeps_bulk_gefs_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_bulk_gefs_intel
+Checking test 136 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 204.441408
- 0: The maximum resident set size (KB)                   = 867360
+ 0: The total amount of wall time                        = 199.257446
+ 0: The maximum resident set size (KB)                   = 856944
 
-Test 138 datm_cdeps_bulk_gefs_intel PASS
+Test 136 datm_cdeps_bulk_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_mx025_cfsr_intel
-Checking test 139 datm_cdeps_mx025_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_mx025_cfsr_intel
+Checking test 137 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4361,15 +4314,15 @@ Checking test 139 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 550.777854
-  0: The maximum resident set size (KB)                   = 759664
+  0: The total amount of wall time                        = 548.391328
+  0: The maximum resident set size (KB)                   = 761456
 
-Test 139 datm_cdeps_mx025_cfsr_intel PASS
+Test 137 datm_cdeps_mx025_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_gefs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_mx025_gefs_intel
-Checking test 140 datm_cdeps_mx025_gefs_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_mx025_gefs_intel
+Checking test 138 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -4377,78 +4330,78 @@ Checking test 140 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 542.017640
-  0: The maximum resident set size (KB)                   = 735312
+  0: The total amount of wall time                        = 528.510003
+  0: The maximum resident set size (KB)                   = 735248
 
-Test 140 datm_cdeps_mx025_gefs_intel PASS
+Test 138 datm_cdeps_mx025_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_multiple_files_cfsr_intel
-Checking test 141 datm_cdeps_multiple_files_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_multiple_files_cfsr_intel
+Checking test 139 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 209.190354
- 0: The maximum resident set size (KB)                   = 969628
+ 0: The total amount of wall time                        = 203.313014
+ 0: The maximum resident set size (KB)                   = 960480
 
-Test 141 datm_cdeps_multiple_files_cfsr_intel PASS
+Test 139 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_3072x1536_cfsr_intel
-Checking test 142 datm_cdeps_3072x1536_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_3072x1536_cfsr_intel
+Checking test 140 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 295.952253
- 0: The maximum resident set size (KB)                   = 2253300
+ 0: The total amount of wall time                        = 284.615957
+ 0: The maximum resident set size (KB)                   = 2187688
 
-Test 142 datm_cdeps_3072x1536_cfsr_intel PASS
+Test 140 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_gfs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_gfs_intel
-Checking test 143 datm_cdeps_gfs_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_gfs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_gfs_intel
+Checking test 141 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 326.374330
- 0: The maximum resident set size (KB)                   = 2183032
+ 0: The total amount of wall time                        = 294.465776
+ 0: The maximum resident set size (KB)                   = 2251232
 
-Test 143 datm_cdeps_gfs_intel PASS
+Test 141 datm_cdeps_gfs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_debug_cfsr_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_debug_cfsr_intel
-Checking test 144 datm_cdeps_debug_cfsr_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_debug_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_debug_cfsr_intel
+Checking test 142 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 464.054177
- 0: The maximum resident set size (KB)                   = 928132
+ 0: The total amount of wall time                        = 459.817879
+ 0: The maximum resident set size (KB)                   = 911300
 
-Test 144 datm_cdeps_debug_cfsr_intel PASS
+Test 142 datm_cdeps_debug_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_faster_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_control_cfsr_faster_intel
-Checking test 145 datm_cdeps_control_cfsr_faster_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_control_cfsr_faster_intel
+Checking test 143 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 224.381113
- 0: The maximum resident set size (KB)                   = 973712
+ 0: The total amount of wall time                        = 205.384397
+ 0: The maximum resident set size (KB)                   = 971712
 
-Test 145 datm_cdeps_control_cfsr_faster_intel PASS
+Test 143 datm_cdeps_control_cfsr_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_lnd_gswp3_intel
-Checking test 146 datm_cdeps_lnd_gswp3_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_lnd_gswp3_intel
+Checking test 144 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4456,15 +4409,15 @@ Checking test 146 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 10.401163
-  0: The maximum resident set size (KB)                   = 239284
+  0: The total amount of wall time                        = 10.142880
+  0: The maximum resident set size (KB)                   = 245980
 
-Test 146 datm_cdeps_lnd_gswp3_intel PASS
+Test 144 datm_cdeps_lnd_gswp3_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/datm_cdeps_lnd_gswp3_rst_intel
-Checking test 147 datm_cdeps_lnd_gswp3_rst_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_lnd_gswp3_rst_intel
+Checking test 145 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -4472,15 +4425,15 @@ Checking test 147 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 19.140102
-  0: The maximum resident set size (KB)                   = 241648
+  0: The total amount of wall time                        = 18.630930
+  0: The maximum resident set size (KB)                   = 249188
 
-Test 147 datm_cdeps_lnd_gswp3_rst_intel PASS
+Test 145 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_p8_atmlnd_sbs_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_p8_atmlnd_sbs_intel
-Checking test 148 control_p8_atmlnd_sbs_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_atmlnd_sbs_intel
+Checking test 146 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -4564,15 +4517,15 @@ Checking test 148 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 292.035593
-  0: The maximum resident set size (KB)                   = 1606692
+  0: The total amount of wall time                        = 288.438613
+  0: The maximum resident set size (KB)                   = 1597396
 
-Test 148 control_p8_atmlnd_sbs_intel PASS
+Test 146 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/atmwav_control_noaero_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/atmwav_control_noaero_p8_intel
-Checking test 149 atmwav_control_noaero_p8_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmwav_control_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmwav_control_noaero_p8_intel
+Checking test 147 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4614,15 +4567,15 @@ Checking test 149 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 141.123902
-  0: The maximum resident set size (KB)                   = 1571880
+  0: The total amount of wall time                        = 139.580677
+  0: The maximum resident set size (KB)                   = 1567684
 
-Test 149 atmwav_control_noaero_p8_intel PASS
+Test 147 atmwav_control_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/control_atmwav_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/control_atmwav_intel
-Checking test 150 control_atmwav_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_atmwav_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_atmwav_intel
+Checking test 148 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4665,15 +4618,15 @@ Checking test 150 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 118.729577
-  0: The maximum resident set size (KB)                   = 597020
+  0: The total amount of wall time                        = 123.956289
+  0: The maximum resident set size (KB)                   = 597892
 
-Test 150 control_atmwav_intel PASS
+Test 148 control_atmwav_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/atmaero_control_p8_intel
-Checking test 151 atmaero_control_p8_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmaero_control_p8_intel
+Checking test 149 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4716,15 +4669,15 @@ Checking test 151 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 312.653103
-  0: The maximum resident set size (KB)                   = 1639068
+  0: The total amount of wall time                        = 346.034732
+  0: The maximum resident set size (KB)                   = 1655896
 
-Test 151 atmaero_control_p8_intel PASS
+Test 149 atmaero_control_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/atmaero_control_p8_rad_intel
-Checking test 152 atmaero_control_p8_rad_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmaero_control_p8_rad_intel
+Checking test 150 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4767,15 +4720,15 @@ Checking test 152 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 386.274399
-  0: The maximum resident set size (KB)                   = 1660020
+  0: The total amount of wall time                        = 417.463852
+  0: The maximum resident set size (KB)                   = 1673052
 
-Test 152 atmaero_control_p8_rad_intel PASS
+Test 150 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_micro_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_278557/atmaero_control_p8_rad_micro_intel
-Checking test 153 atmaero_control_p8_rad_micro_intel results ....
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmaero_control_p8_rad_micro_intel
+Checking test 151 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4818,250 +4771,12 @@ Checking test 153 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 374.074525
-  0: The maximum resident set size (KB)                   = 1678160
+  0: The total amount of wall time                        = 416.505252
+  0: The maximum resident set size (KB)                   = 1673392
 
-Test 153 atmaero_control_p8_rad_micro_intel PASS
+Test 151 atmaero_control_p8_rad_micro_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Jun 17 23:28:34 UTC 2023
-Elapsed time: 02h:32m:58s. Have a nice day!
-Tue Jun 20 01:52:06 UTC 2023
-Start Regression test
-
-Testing UFSWM Hash: 14ad1f50700400e4152cab9dfcbf54152e4865fc
-Testing With Submodule Hashes:
- 37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
- 2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
- 5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
- cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-1401-gcec8db8)
- cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
- b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
- 24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
- fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
- e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
- c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
- 3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 013 elapsed time 1993 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_114992/hrrr_control_intel
-Checking test 001 hrrr_control_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 568.955309
-  0: The maximum resident set size (KB)                   = 954904
-
-Test 001 hrrr_control_intel PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_114992/hrrr_control_qr_intel
-Checking test 002 hrrr_control_qr_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
-
-  0: The total amount of wall time                        = 558.318319
-  0: The maximum resident set size (KB)                   = 965296
-
-Test 002 hrrr_control_qr_intel PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_114992/hrrr_control_decomp_intel
-Checking test 003 hrrr_control_decomp_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 591.558652
-  0: The maximum resident set size (KB)                   = 947504
-
-Test 003 hrrr_control_decomp_intel PASS
-
-
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs4/HFIP/h-nems/Zachary.Shrader/RT_RUNDIRS/Zachary.Shrader/FV3_RT/rt_114992/hrrr_control_2threads_intel
-Checking test 004 hrrr_control_2threads_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 525.648459
-  0: The maximum resident set size (KB)                   = 1006548
-
-Test 004 hrrr_control_2threads_intel PASS
-
-
-REGRESSION TEST WAS SUCCESSFUL
-Tue Jun 20 02:36:17 UTC 2023
-Elapsed time: 00h:44m:11s. Have a nice day!
+Thu Jun 22 21:22:50 UTC 2023
+Elapsed time: 03h:00m:57s. Have a nice day!

--- a/tests/logs/RegressionTests_orion.log
+++ b/tests/logs/RegressionTests_orion.log
@@ -1,58 +1,59 @@
-Tue Jun 20 11:54:47 CDT 2023
+Thu Jun 22 13:44:53 CDT 2023
 Start Regression test
 
-Testing UFSWM Hash: 01918fea7d7b8a7256dc39148479fd59fef22df4
+Testing UFSWM Hash: 2d5a7ba68ca795af5ce01c7619099940d309bfde
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
+ f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 818 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 906 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 721 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 287 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 250 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 690 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 681 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 874 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 1032 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 238 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 011 elapsed time 748 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 625 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 606 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 601 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 747 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 833 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 875 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 743 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 299 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 269 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 712 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 706 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 856 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 1084 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 268 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 011 elapsed time 724 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 702 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 640 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 625 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 713 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 017 elapsed time 271 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 174 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 624 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 615 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 186 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 682 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 261 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 723 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 703 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 201 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 127 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 201 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 53 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 661 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 650 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 633 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 593 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 179 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 037 elapsed time 624 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 018 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 609 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 603 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 229 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 228 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 669 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 260 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 798 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 740 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 203 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 028 elapsed time 111 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 198 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 52 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 660 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 655 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 682 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 638 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 675 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 193 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 037 elapsed time 622 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_mixedmode_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_p8_mixedmode_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -117,14 +118,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 309.267630
-  0: The maximum resident set size (KB)                   = 3144552
+  0: The total amount of wall time                        = 307.547648
+  0: The maximum resident set size (KB)                   = 3148056
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_gfsv17_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_gfsv17_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -188,14 +189,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 226.012600
-  0: The maximum resident set size (KB)                   = 1693420
+  0: The total amount of wall time                        = 219.637595
+  0: The maximum resident set size (KB)                   = 1702212
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -260,14 +261,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 341.701999
-  0: The maximum resident set size (KB)                   = 3181456
+  0: The total amount of wall time                        = 344.283749
+  0: The maximum resident set size (KB)                   = 3179008
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_restart_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -320,14 +321,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 200.456066
-  0: The maximum resident set size (KB)                   = 3053044
+  0: The total amount of wall time                        = 205.656354
+  0: The maximum resident set size (KB)                   = 3049028
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_qr_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -392,14 +393,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 345.488639
-  0: The maximum resident set size (KB)                   = 3200036
+  0: The total amount of wall time                        = 344.415483
+  0: The maximum resident set size (KB)                   = 3192636
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_restart_qr_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -452,14 +453,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 204.223948
-  0: The maximum resident set size (KB)                   = 3068396
+  0: The total amount of wall time                        = 208.764676
+  0: The maximum resident set size (KB)                   = 3072128
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_2threads_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -512,14 +513,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 403.625325
-  0: The maximum resident set size (KB)                   = 3507432
+  0: The total amount of wall time                        = 399.569326
+  0: The maximum resident set size (KB)                   = 3527784
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_decomp_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -572,14 +573,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 343.771049
-  0: The maximum resident set size (KB)                   = 3172104
+  0: The total amount of wall time                        = 345.670606
+  0: The maximum resident set size (KB)                   = 3175364
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_mpi_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -632,14 +633,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 281.957158
-  0: The maximum resident set size (KB)                   = 3036168
+  0: The total amount of wall time                        = 284.251561
+  0: The maximum resident set size (KB)                   = 3031900
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_ciceC_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_ciceC_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_ciceC_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -704,14 +705,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 351.277308
-  0: The maximum resident set size (KB)                   = 3115348
+  0: The total amount of wall time                        = 344.343463
+  0: The maximum resident set size (KB)                   = 3177708
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c192_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_c192_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c192_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_c192_p8_intel
 Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -764,14 +765,14 @@ Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 635.981635
-  0: The maximum resident set size (KB)                   = 3269084
+  0: The total amount of wall time                        = 629.120664
+  0: The maximum resident set size (KB)                   = 3264800
 
 Test 011 cpld_control_c192_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c192_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_restart_c192_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c192_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_restart_c192_p8_intel
 Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -824,14 +825,14 @@ Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 447.084589
-  0: The maximum resident set size (KB)                   = 3153136
+  0: The total amount of wall time                        = 438.364558
+  0: The maximum resident set size (KB)                   = 3151644
 
 Test 012 cpld_restart_c192_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_bmark_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_bmark_p8_intel
 Checking test 013 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -879,14 +880,14 @@ Checking test 013 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 882.325771
-   0: The maximum resident set size (KB)                   = 4043624
+   0: The total amount of wall time                        = 865.502526
+   0: The maximum resident set size (KB)                   = 4026404
 
 Test 013 cpld_bmark_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_restart_bmark_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_restart_bmark_p8_intel
 Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -934,14 +935,14 @@ Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 531.150033
-   0: The maximum resident set size (KB)                   = 3953264
+   0: The total amount of wall time                        = 532.333221
+   0: The maximum resident set size (KB)                   = 3964160
 
 Test 014 cpld_restart_bmark_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_noaero_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_noaero_p8_intel
 Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1005,14 +1006,14 @@ Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 254.095796
-  0: The maximum resident set size (KB)                   = 1726024
+  0: The total amount of wall time                        = 261.848737
+  0: The maximum resident set size (KB)                   = 1714968
 
 Test 015 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_nowave_noaero_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_nowave_noaero_p8_intel
 Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1074,14 +1075,14 @@ Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 260.247602
-  0: The maximum resident set size (KB)                   = 1773004
+  0: The total amount of wall time                        = 262.127433
+  0: The maximum resident set size (KB)                   = 1766856
 
 Test 016 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_debug_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_debug_p8_intel
 Checking test 017 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1134,14 +1135,14 @@ Checking test 017 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 552.749084
-  0: The maximum resident set size (KB)                   = 3169076
+  0: The total amount of wall time                        = 548.073935
+  0: The maximum resident set size (KB)                   = 3242980
 
 Test 017 cpld_debug_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_noaero_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_debug_noaero_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_debug_noaero_p8_intel
 Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1193,14 +1194,14 @@ Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 378.270757
-  0: The maximum resident set size (KB)                   = 1747128
+  0: The total amount of wall time                        = 377.834881
+  0: The maximum resident set size (KB)                   = 1746936
 
 Test 018 cpld_debug_noaero_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_agrid_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_noaero_p8_agrid_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_noaero_p8_agrid_intel
 Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1262,14 +1263,14 @@ Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 277.059544
-  0: The maximum resident set size (KB)                   = 1688328
+  0: The total amount of wall time                        = 266.910320
+  0: The maximum resident set size (KB)                   = 1768596
 
 Test 019 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_c48_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_c48_intel
 Checking test 020 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1319,14 +1320,14 @@ Checking test 020 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 494.374212
- 0: The maximum resident set size (KB)                   = 2809068
+ 0: The total amount of wall time                        = 495.692890
+ 0: The maximum resident set size (KB)                   = 2802204
 
 Test 020 cpld_control_c48_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_warmstart_c48_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_warmstart_c48_intel
 Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1376,14 +1377,14 @@ Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 135.011485
- 0: The maximum resident set size (KB)                   = 2778368
+ 0: The total amount of wall time                        = 137.140343
+ 0: The maximum resident set size (KB)                   = 2786876
 
 Test 021 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_restart_c48_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_restart_c48_intel
 Checking test 022 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1433,14 +1434,14 @@ Checking test 022 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 73.948257
- 0: The maximum resident set size (KB)                   = 2237300
+ 0: The total amount of wall time                        = 74.121503
+ 0: The maximum resident set size (KB)                   = 2243992
 
 Test 022 cpld_restart_c48_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_p8_faster_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_faster_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_p8_faster_intel
 Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1505,14 +1506,14 @@ Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 320.337736
-  0: The maximum resident set size (KB)                   = 3099992
+  0: The total amount of wall time                        = 325.731725
+  0: The maximum resident set size (KB)                   = 3183360
 
 Test 023 cpld_control_p8_faster_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_control_pdlib_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_control_pdlib_p8_intel
 Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1576,14 +1577,14 @@ Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1195.483045
-  0: The maximum resident set size (KB)                   = 1756524
+  0: The total amount of wall time                        = 1190.533171
+  0: The maximum resident set size (KB)                   = 1760232
 
 Test 024 cpld_control_pdlib_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_restart_pdlib_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_restart_pdlib_p8_intel
 Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1635,14 +1636,14 @@ Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 587.419731
-  0: The maximum resident set size (KB)                   = 970096
+  0: The total amount of wall time                        = 580.919554
+  0: The maximum resident set size (KB)                   = 1029368
 
 Test 025 cpld_restart_pdlib_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_control_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_mpi_pdlib_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_control_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_mpi_pdlib_p8_intel
 Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1706,14 +1707,14 @@ Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1055.082655
-  0: The maximum resident set size (KB)                   = 1656940
+  0: The total amount of wall time                        = 1055.607490
+  0: The maximum resident set size (KB)                   = 1649636
 
 Test 026 cpld_mpi_pdlib_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/cpld_debug_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/cpld_debug_pdlib_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/cpld_debug_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/cpld_debug_pdlib_p8_intel
 Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1765,14 +1766,14 @@ Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1390.270956
-  0: The maximum resident set size (KB)                   = 1714728
+  0: The total amount of wall time                        = 1398.230623
+  0: The maximum resident set size (KB)                   = 1706036
 
 Test 027 cpld_debug_pdlib_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_flake_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_flake_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_flake_intel
 Checking test 028 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1783,14 +1784,14 @@ Checking test 028 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 195.366391
-  0: The maximum resident set size (KB)                   = 679780
+  0: The total amount of wall time                        = 193.738066
+  0: The maximum resident set size (KB)                   = 682812
 
 Test 028 control_flake_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_CubedSphereGrid_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_CubedSphereGrid_intel
 Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1817,28 +1818,28 @@ Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 132.306965
-  0: The maximum resident set size (KB)                   = 628448
+  0: The total amount of wall time                        = 131.387867
+  0: The maximum resident set size (KB)                   = 629060
 
 Test 029 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_parallel_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_CubedSphereGrid_parallel_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_parallel_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_CubedSphereGrid_parallel_intel
 Checking test 030 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 128.021135
-  0: The maximum resident set size (KB)                   = 628000
+  0: The total amount of wall time                        = 127.312937
+  0: The maximum resident set size (KB)                   = 626492
 
 Test 030 control_CubedSphereGrid_parallel_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_latlon_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_latlon_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_latlon_intel
 Checking test 031 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1849,32 +1850,32 @@ Checking test 031 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.362806
-  0: The maximum resident set size (KB)                   = 578880
+  0: The total amount of wall time                        = 133.278894
+  0: The maximum resident set size (KB)                   = 624212
 
 Test 031 control_latlon_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_wrtGauss_netcdf_parallel_intel
 Checking test 032 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.857908
-  0: The maximum resident set size (KB)                   = 631168
+  0: The total amount of wall time                        = 136.807359
+  0: The maximum resident set size (KB)                   = 628400
 
 Test 032 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_c48_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_c48_intel
 Checking test 033 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1913,14 +1914,14 @@ Checking test 033 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 345.824994
-0: The maximum resident set size (KB)                   = 820904
+0: The total amount of wall time                        = 344.968368
+0: The maximum resident set size (KB)                   = 818588
 
 Test 033 control_c48_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c192_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_c192_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_c192_intel
 Checking test 034 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1931,14 +1932,14 @@ Checking test 034 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 525.530770
-  0: The maximum resident set size (KB)                   = 771284
+  0: The total amount of wall time                        = 527.225563
+  0: The maximum resident set size (KB)                   = 771324
 
 Test 034 control_c192_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c384_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_c384_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_c384_intel
 Checking test 035 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1949,14 +1950,14 @@ Checking test 035 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 578.051126
-  0: The maximum resident set size (KB)                   = 1184312
+  0: The total amount of wall time                        = 578.331436
+  0: The maximum resident set size (KB)                   = 1234040
 
 Test 035 control_c384_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_c384gdas_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_c384gdas_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_c384gdas_intel
 Checking test 036 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1999,14 +2000,14 @@ Checking test 036 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 509.241025
-  0: The maximum resident set size (KB)                   = 1333300
+  0: The total amount of wall time                        = 512.865414
+  0: The maximum resident set size (KB)                   = 1338344
 
 Test 036 control_c384gdas_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_stochy_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_stochy_intel
 Checking test 037 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2017,28 +2018,28 @@ Checking test 037 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 87.606354
-  0: The maximum resident set size (KB)                   = 635264
+  0: The total amount of wall time                        = 88.227234
+  0: The maximum resident set size (KB)                   = 634016
 
 Test 037 control_stochy_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_stochy_restart_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_stochy_restart_intel
 Checking test 038 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.144052
-  0: The maximum resident set size (KB)                   = 487232
+  0: The total amount of wall time                        = 48.757589
+  0: The maximum resident set size (KB)                   = 480388
 
 Test 038 control_stochy_restart_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_lndp_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_lndp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_lndp_intel
 Checking test 039 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2049,14 +2050,14 @@ Checking test 039 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.515551
-  0: The maximum resident set size (KB)                   = 636540
+  0: The total amount of wall time                        = 81.163312
+  0: The maximum resident set size (KB)                   = 639648
 
 Test 039 control_lndp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_iovr4_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_iovr4_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_iovr4_intel
 Checking test 040 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2071,14 +2072,14 @@ Checking test 040 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.073349
-  0: The maximum resident set size (KB)                   = 624264
+  0: The total amount of wall time                        = 136.404822
+  0: The maximum resident set size (KB)                   = 632244
 
 Test 040 control_iovr4_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_iovr5_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_iovr5_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_iovr5_intel
 Checking test 041 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2093,14 +2094,14 @@ Checking test 041 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.968708
-  0: The maximum resident set size (KB)                   = 633656
+  0: The total amount of wall time                        = 136.209200
+  0: The maximum resident set size (KB)                   = 622148
 
 Test 041 control_iovr5_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_p8_intel
 Checking test 042 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2147,14 +2148,14 @@ Checking test 042 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.126370
-  0: The maximum resident set size (KB)                   = 1602804
+  0: The total amount of wall time                        = 168.966570
+  0: The maximum resident set size (KB)                   = 1610244
 
 Test 042 control_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_restart_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_restart_p8_intel
 Checking test 043 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2193,14 +2194,14 @@ Checking test 043 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 87.722879
-  0: The maximum resident set size (KB)                   = 874976
+  0: The total amount of wall time                        = 87.748464
+  0: The maximum resident set size (KB)                   = 878140
 
 Test 043 control_restart_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_qr_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_qr_p8_intel
 Checking test 044 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2247,14 +2248,14 @@ Checking test 044 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 167.896743
-  0: The maximum resident set size (KB)                   = 1608168
+  0: The total amount of wall time                        = 169.354569
+  0: The maximum resident set size (KB)                   = 1606792
 
 Test 044 control_qr_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_restart_qr_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_restart_qr_p8_intel
 Checking test 045 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2293,14 +2294,14 @@ Checking test 045 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 90.266030
-  0: The maximum resident set size (KB)                   = 865972
+  0: The total amount of wall time                        = 89.786893
+  0: The maximum resident set size (KB)                   = 859572
 
 Test 045 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_decomp_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_decomp_p8_intel
 Checking test 046 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2343,14 +2344,14 @@ Checking test 046 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.477265
-  0: The maximum resident set size (KB)                   = 1587924
+  0: The total amount of wall time                        = 174.754590
+  0: The maximum resident set size (KB)                   = 1587884
 
 Test 046 control_decomp_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_2threads_p8_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_2threads_p8_intel
 Checking test 047 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2393,14 +2394,14 @@ Checking test 047 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.123786
-  0: The maximum resident set size (KB)                   = 1691980
+  0: The total amount of wall time                        = 174.489577
+  0: The maximum resident set size (KB)                   = 1690164
 
 Test 047 control_2threads_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_lndp_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_p8_lndp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_p8_lndp_intel
 Checking test 048 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2419,14 +2420,14 @@ Checking test 048 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 308.370415
-  0: The maximum resident set size (KB)                   = 1606864
+  0: The total amount of wall time                        = 311.255912
+  0: The maximum resident set size (KB)                   = 1602400
 
 Test 048 control_p8_lndp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_rrtmgp_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_p8_rrtmgp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_p8_rrtmgp_intel
 Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2473,14 +2474,14 @@ Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 226.315519
-  0: The maximum resident set size (KB)                   = 1668432
+  0: The total amount of wall time                        = 230.968698
+  0: The maximum resident set size (KB)                   = 1683584
 
 Test 049 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_mynn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_p8_mynn_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_p8_mynn_intel
 Checking test 050 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2527,14 +2528,14 @@ Checking test 050 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 168.413141
-  0: The maximum resident set size (KB)                   = 1617352
+  0: The total amount of wall time                        = 173.201644
+  0: The maximum resident set size (KB)                   = 1608688
 
 Test 050 control_p8_mynn_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/merra2_thompson_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/merra2_thompson_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/merra2_thompson_intel
 Checking test 051 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2581,14 +2582,14 @@ Checking test 051 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.367895
-  0: The maximum resident set size (KB)                   = 1616220
+  0: The total amount of wall time                        = 193.436822
+  0: The maximum resident set size (KB)                   = 1613280
 
 Test 051 merra2_thompson_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_control_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_control_intel
 Checking test 052 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2599,28 +2600,28 @@ Checking test 052 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 289.372912
-  0: The maximum resident set size (KB)                   = 863572
+  0: The total amount of wall time                        = 291.501605
+  0: The maximum resident set size (KB)                   = 872948
 
 Test 052 regional_control_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_restart_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_restart_intel
 Checking test 053 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 150.471020
-  0: The maximum resident set size (KB)                   = 863544
+  0: The total amount of wall time                        = 146.666698
+  0: The maximum resident set size (KB)                   = 865648
 
 Test 053 regional_restart_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_control_qr_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_control_qr_intel
 Checking test 054 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2631,28 +2632,28 @@ Checking test 054 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 288.846386
-  0: The maximum resident set size (KB)                   = 866824
+  0: The total amount of wall time                        = 290.761958
+  0: The maximum resident set size (KB)                   = 870736
 
 Test 054 regional_control_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_restart_qr_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_restart_qr_intel
 Checking test 055 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 147.818015
-  0: The maximum resident set size (KB)                   = 862680
+  0: The total amount of wall time                        = 146.956762
+  0: The maximum resident set size (KB)                   = 864800
 
 Test 055 regional_restart_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_decomp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_decomp_intel
 Checking test 056 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2663,14 +2664,14 @@ Checking test 056 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 310.202698
-  0: The maximum resident set size (KB)                   = 860672
+  0: The total amount of wall time                        = 308.896908
+  0: The maximum resident set size (KB)                   = 857572
 
 Test 056 regional_decomp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_2threads_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_2threads_intel
 Checking test 057 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2681,14 +2682,14 @@ Checking test 057 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 198.945673
-  0: The maximum resident set size (KB)                   = 847152
+  0: The total amount of wall time                        = 201.032309
+  0: The maximum resident set size (KB)                   = 846832
 
 Test 057 regional_2threads_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_noquilt_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_noquilt_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_noquilt_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_noquilt_intel
 Checking test 058 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2696,28 +2697,28 @@ Checking test 058 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 287.431909
-  0: The maximum resident set size (KB)                   = 860928
+  0: The total amount of wall time                        = 287.978798
+  0: The maximum resident set size (KB)                   = 856768
 
 Test 058 regional_noquilt_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_netcdf_parallel_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_netcdf_parallel_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_netcdf_parallel_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_netcdf_parallel_intel
 Checking test 059 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 285.032518
-  0: The maximum resident set size (KB)                   = 863384
+  0: The total amount of wall time                        = 286.777017
+  0: The maximum resident set size (KB)                   = 865452
 
 Test 059 regional_netcdf_parallel_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_2dwrtdecomp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_2dwrtdecomp_intel
 Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2728,14 +2729,14 @@ Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 290.145753
-  0: The maximum resident set size (KB)                   = 867808
+  0: The total amount of wall time                        = 292.646014
+  0: The maximum resident set size (KB)                   = 874700
 
 Test 060 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/fv3_regional_wofs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_wofs_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/fv3_regional_wofs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_wofs_intel
 Checking test 061 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2746,14 +2747,14 @@ Checking test 061 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 370.129792
-  0: The maximum resident set size (KB)                   = 628376
+  0: The total amount of wall time                        = 367.150098
+  0: The maximum resident set size (KB)                   = 627640
 
 Test 061 regional_wofs_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_control_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_control_intel
 Checking test 062 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2800,14 +2801,14 @@ Checking test 062 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 446.801677
-  0: The maximum resident set size (KB)                   = 1057244
+  0: The total amount of wall time                        = 444.601205
+  0: The maximum resident set size (KB)                   = 1062560
 
 Test 062 rap_control_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_spp_sppt_shum_skeb_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_spp_sppt_shum_skeb_intel
 Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2818,14 +2819,14 @@ Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 259.957736
-  0: The maximum resident set size (KB)                   = 1188640
+  0: The total amount of wall time                        = 262.453066
+  0: The maximum resident set size (KB)                   = 1159572
 
 Test 063 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_decomp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_decomp_intel
 Checking test 064 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2872,14 +2873,14 @@ Checking test 064 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 465.107676
-  0: The maximum resident set size (KB)                   = 1012280
+  0: The total amount of wall time                        = 462.313788
+  0: The maximum resident set size (KB)                   = 999976
 
 Test 064 rap_decomp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_2threads_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_2threads_intel
 Checking test 065 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2926,14 +2927,14 @@ Checking test 065 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 451.693087
-  0: The maximum resident set size (KB)                   = 1140388
+  0: The total amount of wall time                        = 450.459646
+  0: The maximum resident set size (KB)                   = 1143456
 
 Test 065 rap_2threads_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_restart_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_restart_intel
 Checking test 066 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2972,14 +2973,14 @@ Checking test 066 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 226.555669
-  0: The maximum resident set size (KB)                   = 965096
+  0: The total amount of wall time                        = 226.334998
+  0: The maximum resident set size (KB)                   = 965112
 
 Test 066 rap_restart_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_sfcdiff_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_sfcdiff_intel
 Checking test 067 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3026,14 +3027,14 @@ Checking test 067 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 443.559864
-  0: The maximum resident set size (KB)                   = 1066900
+  0: The total amount of wall time                        = 444.039939
+  0: The maximum resident set size (KB)                   = 1063028
 
 Test 067 rap_sfcdiff_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_sfcdiff_decomp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_sfcdiff_decomp_intel
 Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3080,14 +3081,14 @@ Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 468.071833
-  0: The maximum resident set size (KB)                   = 1003172
+  0: The total amount of wall time                        = 467.348694
+  0: The maximum resident set size (KB)                   = 1004120
 
 Test 068 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_sfcdiff_restart_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_sfcdiff_restart_intel
 Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3126,69 +3127,15 @@ Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 335.127520
-  0: The maximum resident set size (KB)                   = 994656
+  0: The total amount of wall time                        = 332.003548
+  0: The maximum resident set size (KB)                   = 993024
 
 Test 069 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_intel
 Checking test 070 hrrr_control_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
-
-  0: The total amount of wall time                        = 430.211577
-  0: The maximum resident set size (KB)                   = 1062000
-
-Test 070 hrrr_control_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_qr_intel
-Checking test 071 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3234,14 +3181,68 @@ Checking test 071 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 430.058307
-  0: The maximum resident set size (KB)                   = 1054420
+  0: The total amount of wall time                        = 428.302148
+  0: The maximum resident set size (KB)                   = 1059632
+
+Test 070 hrrr_control_intel PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_qr_intel
+Checking test 071 hrrr_control_qr_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
+
+  0: The total amount of wall time                        = 428.633807
+  0: The maximum resident set size (KB)                   = 1068192
 
 Test 071 hrrr_control_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_decomp_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_decomp_intel
 Checking test 072 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3257,45 +3258,45 @@ Checking test 072 hrrr_control_decomp_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 446.233552
-  0: The maximum resident set size (KB)                   = 1001316
+  0: The total amount of wall time                        = 446.455291
+  0: The maximum resident set size (KB)                   = 1005672
 
 Test 072 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_2threads_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_2threads_intel
 Checking test 073 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3311,73 +3312,73 @@ Checking test 073 hrrr_control_2threads_intel results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 365.753740
-  0: The maximum resident set size (KB)                   = 1077144
+  0: The total amount of wall time                        = 361.298597
+  0: The maximum resident set size (KB)                   = 1073240
 
 Test 073 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_restart_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_restart_intel
 Checking test 074 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 320.833988
-  0: The maximum resident set size (KB)                   = 987160
+  0: The total amount of wall time                        = 320.449008
+  0: The maximum resident set size (KB)                   = 984768
 
 Test 074 hrrr_control_restart_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_restart_qr_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_restart_qr_intel
 Checking test 075 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 325.639141
-  0: The maximum resident set size (KB)                   = 996132
+  0: The total amount of wall time                        = 324.607704
+  0: The maximum resident set size (KB)                   = 936808
 
 Test 075 hrrr_control_restart_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_v1beta_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_v1beta_intel
 Checking test 076 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3424,14 +3425,14 @@ Checking test 076 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 437.774426
-  0: The maximum resident set size (KB)                   = 1057460
+  0: The total amount of wall time                        = 442.081974
+  0: The maximum resident set size (KB)                   = 1059444
 
 Test 076 rrfs_v1beta_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_v1nssl_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_v1nssl_intel
 Checking test 077 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3446,14 +3447,14 @@ Checking test 077 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 524.753691
-  0: The maximum resident set size (KB)                   = 696932
+  0: The total amount of wall time                        = 522.725286
+  0: The maximum resident set size (KB)                   = 694516
 
 Test 077 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_v1nssl_nohailnoccn_intel
 Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3468,14 +3469,14 @@ Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 510.869812
-  0: The maximum resident set size (KB)                   = 701860
+  0: The total amount of wall time                        = 510.470109
+  0: The maximum resident set size (KB)                   = 755468
 
 Test 078 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3491,15 +3492,31 @@ Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 148.661673
-  0: The maximum resident set size (KB)                   = 1032680
+  0: The total amount of wall time                        = 148.264815
+  0: The maximum resident set size (KB)                   = 1037488
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_hrrr_warm_qr_intel
-Checking test 080 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+Checking test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 96.782989
+  0: The maximum resident set size (KB)                   = 943296
+
+Test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_conus13km_hrrr_warm_intel
+Checking test 081 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3514,15 +3531,15 @@ Checking test 080 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 150.470499
-  0: The maximum resident set size (KB)                   = 1032032
+  0: The total amount of wall time                        = 130.014793
+  0: The maximum resident set size (KB)                   = 992068
 
-Test 080 rrfs_smoke_conus13km_hrrr_warm_qr_intel PASS
+Test 081 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
-Checking test 081 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_smoke_conus13km_radar_tten_warm_intel
+Checking test 082 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3530,78 +3547,27 @@ Checking test 081 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 98.227664
-  0: The maximum resident set size (KB)                   = 953972
+  0: The total amount of wall time                        = 148.416245
+  0: The maximum resident set size (KB)                   = 1042044
 
-Test 081 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_conus13km_hrrr_warm_intel
-Checking test 082 rrfs_conus13km_hrrr_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-  0: The total amount of wall time                        = 132.949835
-  0: The maximum resident set size (KB)                   = 993528
-
-Test 082 rrfs_conus13km_hrrr_warm_intel PASS
+Test 082 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_radar_tten_warm_intel
-Checking test 083 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 149.610605
-  0: The maximum resident set size (KB)                   = 1038788
-
-Test 083 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-Checking test 084 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+Checking test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 82.185931
-  0: The maximum resident set size (KB)                   = 1029276
+  0: The total amount of wall time                        = 82.357946
+  0: The maximum resident set size (KB)                   = 1024004
 
-Test 084 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel
-Checking test 085 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 81.646825
-  0: The maximum resident set size (KB)                   = 1027412
-
-Test 085 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel PASS
+Test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmg_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_csawmg_intel
-Checking test 086 control_csawmg_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmg_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_csawmg_intel
+Checking test 084 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3611,15 +3577,15 @@ Checking test 086 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 336.463929
-  0: The maximum resident set size (KB)                   = 725144
+  0: The total amount of wall time                        = 334.679051
+  0: The maximum resident set size (KB)                   = 729788
 
-Test 086 control_csawmg_intel PASS
+Test 084 control_csawmg_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_csawmgt_intel
-Checking test 087 control_csawmgt_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_csawmgt_intel
+Checking test 085 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3629,15 +3595,15 @@ Checking test 087 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 334.975818
-  0: The maximum resident set size (KB)                   = 733764
+  0: The total amount of wall time                        = 330.134336
+  0: The maximum resident set size (KB)                   = 725832
 
-Test 087 control_csawmgt_intel PASS
+Test 085 control_csawmgt_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_ras_intel
-Checking test 088 control_ras_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_ras_intel
+Checking test 086 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3647,27 +3613,27 @@ Checking test 088 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 183.287538
-  0: The maximum resident set size (KB)                   = 722504
+  0: The total amount of wall time                        = 182.849390
+  0: The maximum resident set size (KB)                   = 728920
 
-Test 088 control_ras_intel PASS
+Test 086 control_ras_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wam_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_wam_intel
-Checking test 089 control_wam_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_wam_intel
+Checking test 087 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 113.865799
-  0: The maximum resident set size (KB)                   = 641600
+  0: The total amount of wall time                        = 111.662078
+  0: The maximum resident set size (KB)                   = 638540
 
-Test 089 control_wam_intel PASS
+Test 087 control_wam_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_p8_faster_intel
-Checking test 090 control_p8_faster_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_p8_faster_intel
+Checking test 088 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3713,15 +3679,15 @@ Checking test 090 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.868381
-  0: The maximum resident set size (KB)                   = 1604288
+  0: The total amount of wall time                        = 156.475308
+  0: The maximum resident set size (KB)                   = 1598148
 
-Test 090 control_p8_faster_intel PASS
+Test 088 control_p8_faster_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_control_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_control_faster_intel
-Checking test 091 regional_control_faster_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_control_faster_intel
+Checking test 089 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3731,57 +3697,57 @@ Checking test 091 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 264.675371
-  0: The maximum resident set size (KB)                   = 871236
+  0: The total amount of wall time                        = 267.419832
+  0: The maximum resident set size (KB)                   = 871436
 
-Test 091 regional_control_faster_intel PASS
+Test 089 regional_control_faster_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-Checking test 092 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+Checking test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 828.887683
-  0: The maximum resident set size (KB)                   = 1061572
+  0: The total amount of wall time                        = 830.756383
+  0: The maximum resident set size (KB)                   = 1061620
 
-Test 092 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
+Test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
-Checking test 093 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+Checking test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 497.866454
-  0: The maximum resident set size (KB)                   = 924116
+  0: The total amount of wall time                        = 487.855387
+  0: The maximum resident set size (KB)                   = 974816
 
-Test 093 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
+Test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_conus13km_hrrr_warm_debug_intel
-Checking test 094 rrfs_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_conus13km_hrrr_warm_debug_intel
+Checking test 092 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 771.072012
-  0: The maximum resident set size (KB)                   = 1017320
+  0: The total amount of wall time                        = 760.507608
+  0: The maximum resident set size (KB)                   = 1011620
 
-Test 094 rrfs_conus13km_hrrr_warm_debug_intel PASS
+Test 092 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_CubedSphereGrid_debug_intel
-Checking test 095 control_CubedSphereGrid_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_CubedSphereGrid_debug_intel
+Checking test 093 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3807,349 +3773,349 @@ Checking test 095 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.476664
-  0: The maximum resident set size (KB)                   = 794628
+  0: The total amount of wall time                        = 152.881622
+  0: The maximum resident set size (KB)                   = 794552
 
-Test 095 control_CubedSphereGrid_debug_intel PASS
+Test 093 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_wrtGauss_netcdf_parallel_debug_intel
-Checking test 096 control_wrtGauss_netcdf_parallel_debug_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc ............ALT CHECK......OK
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_wrtGauss_netcdf_parallel_debug_intel
+Checking test 094 control_wrtGauss_netcdf_parallel_debug_intel results ....
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.372203
-  0: The maximum resident set size (KB)                   = 792084
+  0: The total amount of wall time                        = 151.206402
+  0: The maximum resident set size (KB)                   = 792764
 
-Test 096 control_wrtGauss_netcdf_parallel_debug_intel PASS
+Test 094 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_stochy_debug_intel
-Checking test 097 control_stochy_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_stochy_debug_intel
+Checking test 095 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.250192
-  0: The maximum resident set size (KB)                   = 799416
+  0: The total amount of wall time                        = 173.732198
+  0: The maximum resident set size (KB)                   = 799220
 
-Test 097 control_stochy_debug_intel PASS
+Test 095 control_stochy_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_lndp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_lndp_debug_intel
-Checking test 098 control_lndp_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_lndp_debug_intel
+Checking test 096 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.429455
-  0: The maximum resident set size (KB)                   = 797516
+  0: The total amount of wall time                        = 156.666996
+  0: The maximum resident set size (KB)                   = 797828
 
-Test 098 control_lndp_debug_intel PASS
+Test 096 control_lndp_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmg_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_csawmg_debug_intel
-Checking test 099 control_csawmg_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_csawmg_debug_intel
+Checking test 097 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.741987
-  0: The maximum resident set size (KB)                   = 843296
+  0: The total amount of wall time                        = 234.887362
+  0: The maximum resident set size (KB)                   = 846676
 
-Test 099 control_csawmg_debug_intel PASS
+Test 097 control_csawmg_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_csawmgt_debug_intel
-Checking test 100 control_csawmgt_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_csawmgt_debug_intel
+Checking test 098 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.381309
-  0: The maximum resident set size (KB)                   = 845896
+  0: The total amount of wall time                        = 228.392975
+  0: The maximum resident set size (KB)                   = 848096
 
-Test 100 control_csawmgt_debug_intel PASS
+Test 098 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_ras_debug_intel
-Checking test 101 control_ras_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_ras_debug_intel
+Checking test 099 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.061696
-  0: The maximum resident set size (KB)                   = 807648
+  0: The total amount of wall time                        = 156.513824
+  0: The maximum resident set size (KB)                   = 754472
 
-Test 101 control_ras_debug_intel PASS
+Test 099 control_ras_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_diag_debug_intel
-Checking test 102 control_diag_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_diag_debug_intel
+Checking test 100 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.877896
-  0: The maximum resident set size (KB)                   = 848524
+  0: The total amount of wall time                        = 153.673213
+  0: The maximum resident set size (KB)                   = 855704
 
-Test 102 control_diag_debug_intel PASS
+Test 100 control_diag_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_debug_p8_intel
-Checking test 103 control_debug_p8_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_debug_p8_intel
+Checking test 101 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.652779
-  0: The maximum resident set size (KB)                   = 1622260
+  0: The total amount of wall time                        = 167.625939
+  0: The maximum resident set size (KB)                   = 1621380
 
-Test 103 control_debug_p8_intel PASS
+Test 101 control_debug_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_debug_intel
-Checking test 104 regional_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_debug_intel
+Checking test 102 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1001.162007
-  0: The maximum resident set size (KB)                   = 889716
+  0: The total amount of wall time                        = 1000.687247
+  0: The maximum resident set size (KB)                   = 887228
 
-Test 104 regional_debug_intel PASS
+Test 102 regional_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_control_debug_intel
-Checking test 105 rap_control_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_control_debug_intel
+Checking test 103 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.429220
-  0: The maximum resident set size (KB)                   = 1168296
+  0: The total amount of wall time                        = 276.106324
+  0: The maximum resident set size (KB)                   = 1177940
 
-Test 105 rap_control_debug_intel PASS
+Test 103 rap_control_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_debug_intel
-Checking test 106 hrrr_control_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_debug_intel
+Checking test 104 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.505932
-  0: The maximum resident set size (KB)                   = 1165612
+  0: The total amount of wall time                        = 269.939198
+  0: The maximum resident set size (KB)                   = 1167532
 
-Test 106 hrrr_control_debug_intel PASS
+Test 104 hrrr_control_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_unified_drag_suite_debug_intel
-Checking test 107 rap_unified_drag_suite_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_unified_drag_suite_debug_intel
+Checking test 105 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.935030
-  0: The maximum resident set size (KB)                   = 1171420
+  0: The total amount of wall time                        = 281.425703
+  0: The maximum resident set size (KB)                   = 1171080
 
-Test 107 rap_unified_drag_suite_debug_intel PASS
+Test 105 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_diag_debug_intel
-Checking test 108 rap_diag_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_diag_debug_intel
+Checking test 106 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.069940
-  0: The maximum resident set size (KB)                   = 1200552
+  0: The total amount of wall time                        = 294.692967
+  0: The maximum resident set size (KB)                   = 1257920
 
-Test 108 rap_diag_debug_intel PASS
+Test 106 rap_diag_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_cires_ugwp_debug_intel
-Checking test 109 rap_cires_ugwp_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_cires_ugwp_debug_intel
+Checking test 107 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.708516
-  0: The maximum resident set size (KB)                   = 1177748
+  0: The total amount of wall time                        = 284.211946
+  0: The maximum resident set size (KB)                   = 1167064
 
-Test 109 rap_cires_ugwp_debug_intel PASS
+Test 107 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_unified_ugwp_debug_intel
-Checking test 110 rap_unified_ugwp_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_unified_ugwp_debug_intel
+Checking test 108 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.035437
-  0: The maximum resident set size (KB)                   = 1176396
+  0: The total amount of wall time                        = 293.092429
+  0: The maximum resident set size (KB)                   = 1171056
 
-Test 110 rap_unified_ugwp_debug_intel PASS
+Test 108 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_lndp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_lndp_debug_intel
-Checking test 111 rap_lndp_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_lndp_debug_intel
+Checking test 109 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.274224
-  0: The maximum resident set size (KB)                   = 1168704
+  0: The total amount of wall time                        = 277.625490
+  0: The maximum resident set size (KB)                   = 1178312
 
-Test 111 rap_lndp_debug_intel PASS
+Test 109 rap_lndp_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_progcld_thompson_debug_intel
-Checking test 112 rap_progcld_thompson_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_progcld_thompson_debug_intel
+Checking test 110 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.040541
-  0: The maximum resident set size (KB)                   = 1173056
+  0: The total amount of wall time                        = 277.551802
+  0: The maximum resident set size (KB)                   = 1172096
 
-Test 112 rap_progcld_thompson_debug_intel PASS
+Test 110 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_noah_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_noah_debug_intel
-Checking test 113 rap_noah_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_noah_debug_intel
+Checking test 111 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.516094
-  0: The maximum resident set size (KB)                   = 1175748
+  0: The total amount of wall time                        = 271.137898
+  0: The maximum resident set size (KB)                   = 1171960
 
-Test 113 rap_noah_debug_intel PASS
+Test 111 rap_noah_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_sfcdiff_debug_intel
-Checking test 114 rap_sfcdiff_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_sfcdiff_debug_intel
+Checking test 112 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.404504
-  0: The maximum resident set size (KB)                   = 1180640
+  0: The total amount of wall time                        = 273.224450
+  0: The maximum resident set size (KB)                   = 1174256
 
-Test 114 rap_sfcdiff_debug_intel PASS
+Test 112 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_noah_sfcdiff_cires_ugwp_debug_intel
-Checking test 115 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_noah_sfcdiff_cires_ugwp_debug_intel
+Checking test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 466.920830
-  0: The maximum resident set size (KB)                   = 1175788
+  0: The total amount of wall time                        = 459.717289
+  0: The maximum resident set size (KB)                   = 1169292
 
-Test 115 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
+Test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rrfs_v1beta_debug_intel
-Checking test 116 rrfs_v1beta_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rrfs_v1beta_debug_intel
+Checking test 114 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.252639
-  0: The maximum resident set size (KB)                   = 1168384
+  0: The total amount of wall time                        = 274.610858
+  0: The maximum resident set size (KB)                   = 1168248
 
-Test 116 rrfs_v1beta_debug_intel PASS
+Test 114 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_clm_lake_debug_intel
-Checking test 117 rap_clm_lake_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_clm_lake_debug_intel
+Checking test 115 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 366.380379
-  0: The maximum resident set size (KB)                   = 1181400
+  0: The total amount of wall time                        = 350.540426
+  0: The maximum resident set size (KB)                   = 1179100
 
-Test 117 rap_clm_lake_debug_intel PASS
+Test 115 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_flake_debug_intel
-Checking test 118 rap_flake_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_flake_debug_intel
+Checking test 116 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.598244
-  0: The maximum resident set size (KB)                   = 1177920
+  0: The total amount of wall time                        = 271.216716
+  0: The maximum resident set size (KB)                   = 1171416
 
-Test 118 rap_flake_debug_intel PASS
+Test 116 rap_flake_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_wam_debug_intel
-Checking test 119 control_wam_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_wam_debug_intel
+Checking test 117 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 284.443181
-  0: The maximum resident set size (KB)                   = 530072
+  0: The total amount of wall time                        = 289.416586
+  0: The maximum resident set size (KB)                   = 525368
 
-Test 119 control_wam_debug_intel PASS
+Test 117 control_wam_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 120 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+Checking test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -4159,15 +4125,15 @@ Checking test 120 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 245.423171
-  0: The maximum resident set size (KB)                   = 1075556
+  0: The total amount of wall time                        = 244.090592
+  0: The maximum resident set size (KB)                   = 1078504
 
-Test 120 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+Test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_control_dyn32_phy32_intel
-Checking test 121 rap_control_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_control_dyn32_phy32_intel
+Checking test 119 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4213,15 +4179,15 @@ Checking test 121 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 366.346009
-  0: The maximum resident set size (KB)                   = 1001680
+  0: The total amount of wall time                        = 369.629371
+  0: The maximum resident set size (KB)                   = 1001520
 
-Test 121 rap_control_dyn32_phy32_intel PASS
+Test 119 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_dyn32_phy32_intel
-Checking test 122 hrrr_control_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_dyn32_phy32_intel
+Checking test 120 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4267,15 +4233,15 @@ Checking test 122 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.667695
-  0: The maximum resident set size (KB)                   = 952312
+  0: The total amount of wall time                        = 189.428478
+  0: The maximum resident set size (KB)                   = 960928
 
-Test 122 hrrr_control_dyn32_phy32_intel PASS
+Test 120 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_qr_dyn32_phy32_intel
-Checking test 123 hrrr_control_qr_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_qr_dyn32_phy32_intel
+Checking test 121 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4321,15 +4287,15 @@ Checking test 123 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.477753
-  0: The maximum resident set size (KB)                   = 971020
+  0: The total amount of wall time                        = 191.498678
+  0: The maximum resident set size (KB)                   = 963392
 
-Test 123 hrrr_control_qr_dyn32_phy32_intel PASS
+Test 121 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_2threads_dyn32_phy32_intel
-Checking test 124 rap_2threads_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_2threads_dyn32_phy32_intel
+Checking test 122 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4375,15 +4341,15 @@ Checking test 124 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 378.222642
-  0: The maximum resident set size (KB)                   = 1019488
+  0: The total amount of wall time                        = 380.221498
+  0: The maximum resident set size (KB)                   = 1022732
 
-Test 124 rap_2threads_dyn32_phy32_intel PASS
+Test 122 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 125 hrrr_control_2threads_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_2threads_dyn32_phy32_intel
+Checking test 123 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4429,15 +4395,15 @@ Checking test 125 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 164.677039
-  0: The maximum resident set size (KB)                   = 943788
+  0: The total amount of wall time                        = 165.269043
+  0: The maximum resident set size (KB)                   = 932480
 
-Test 125 hrrr_control_2threads_dyn32_phy32_intel PASS
+Test 123 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 126 hrrr_control_decomp_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_decomp_dyn32_phy32_intel
+Checking test 124 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4483,15 +4449,15 @@ Checking test 126 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.992734
-  0: The maximum resident set size (KB)                   = 908324
+  0: The total amount of wall time                        = 201.831512
+  0: The maximum resident set size (KB)                   = 903320
 
-Test 126 hrrr_control_decomp_dyn32_phy32_intel PASS
+Test 124 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_restart_dyn32_phy32_intel
-Checking test 127 rap_restart_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_restart_dyn32_phy32_intel
+Checking test 125 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -4529,43 +4495,43 @@ Checking test 127 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.296619
-  0: The maximum resident set size (KB)                   = 950672
+  0: The total amount of wall time                        = 274.818866
+  0: The maximum resident set size (KB)                   = 948132
 
-Test 127 rap_restart_dyn32_phy32_intel PASS
+Test 125 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_restart_dyn32_phy32_intel
-Checking test 128 hrrr_control_restart_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_restart_dyn32_phy32_intel
+Checking test 126 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 98.851742
-  0: The maximum resident set size (KB)                   = 858076
+  0: The total amount of wall time                        = 98.924070
+  0: The maximum resident set size (KB)                   = 865108
 
-Test 128 hrrr_control_restart_dyn32_phy32_intel PASS
+Test 126 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_restart_qr_dyn32_phy32_intel
-Checking test 129 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 127 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.348302
-  0: The maximum resident set size (KB)                   = 869392
+  0: The total amount of wall time                        = 100.604726
+  0: The maximum resident set size (KB)                   = 880052
 
-Test 129 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+Test 127 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_control_dyn64_phy32_intel
-Checking test 130 rap_control_dyn64_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_control_dyn64_phy32_intel
+Checking test 128 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4611,82 +4577,82 @@ Checking test 130 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.455277
-  0: The maximum resident set size (KB)                   = 964468
+  0: The total amount of wall time                        = 239.243495
+  0: The maximum resident set size (KB)                   = 972628
 
-Test 130 rap_control_dyn64_phy32_intel PASS
+Test 128 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_control_debug_dyn32_phy32_intel
-Checking test 131 rap_control_debug_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_control_debug_dyn32_phy32_intel
+Checking test 129 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.156408
-  0: The maximum resident set size (KB)                   = 1053128
+  0: The total amount of wall time                        = 276.563549
+  0: The maximum resident set size (KB)                   = 1058156
 
-Test 131 rap_control_debug_dyn32_phy32_intel PASS
+Test 129 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hrrr_control_debug_dyn32_phy32_intel
-Checking test 132 hrrr_control_debug_dyn32_phy32_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hrrr_control_debug_dyn32_phy32_intel
+Checking test 130 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 261.796144
-  0: The maximum resident set size (KB)                   = 1062520
+  0: The total amount of wall time                        = 266.750223
+  0: The maximum resident set size (KB)                   = 1059664
 
-Test 132 hrrr_control_debug_dyn32_phy32_intel PASS
+Test 130 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/rap_control_dyn64_phy32_debug_intel
-Checking test 133 rap_control_dyn64_phy32_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/rap_control_dyn64_phy32_debug_intel
+Checking test 131 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.403615
-  0: The maximum resident set size (KB)                   = 1101868
+  0: The total amount of wall time                        = 277.947592
+  0: The maximum resident set size (KB)                   = 1095292
 
-Test 133 rap_control_dyn64_phy32_debug_intel PASS
+Test 131 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_atm_intel
-Checking test 134 hafs_regional_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_atm_intel
+Checking test 132 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 252.078866
-  0: The maximum resident set size (KB)                   = 1057252
+  0: The total amount of wall time                        = 251.896724
+  0: The maximum resident set size (KB)                   = 1052596
 
-Test 134 hafs_regional_atm_intel PASS
+Test 132 hafs_regional_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_atm_thompson_gfdlsf_intel
-Checking test 135 hafs_regional_atm_thompson_gfdlsf_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_atm_thompson_gfdlsf_intel
+Checking test 133 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 389.090340
-  0: The maximum resident set size (KB)                   = 1420624
+  0: The total amount of wall time                        = 390.231489
+  0: The maximum resident set size (KB)                   = 1423508
 
-Test 135 hafs_regional_atm_thompson_gfdlsf_intel PASS
+Test 133 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_atm_ocn_intel
-Checking test 136 hafs_regional_atm_ocn_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_atm_ocn_intel
+Checking test 134 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4694,15 +4660,15 @@ Checking test 136 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 377.101329
-  0: The maximum resident set size (KB)                   = 1229048
+  0: The total amount of wall time                        = 374.019770
+  0: The maximum resident set size (KB)                   = 1242608
 
-Test 136 hafs_regional_atm_ocn_intel PASS
+Test 134 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_wav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_atm_wav_intel
-Checking test 137 hafs_regional_atm_wav_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_atm_wav_intel
+Checking test 135 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4710,15 +4676,15 @@ Checking test 137 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 731.099595
-  0: The maximum resident set size (KB)                   = 1262248
+  0: The total amount of wall time                        = 728.764475
+  0: The maximum resident set size (KB)                   = 1252452
 
-Test 137 hafs_regional_atm_wav_intel PASS
+Test 135 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_wav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_atm_ocn_wav_intel
-Checking test 138 hafs_regional_atm_ocn_wav_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_atm_ocn_wav_intel
+Checking test 136 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4728,15 +4694,15 @@ Checking test 138 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 829.665787
-  0: The maximum resident set size (KB)                   = 1281568
+  0: The total amount of wall time                        = 834.570475
+  0: The maximum resident set size (KB)                   = 1281204
 
-Test 138 hafs_regional_atm_ocn_wav_intel PASS
+Test 136 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_1nest_atm_intel
-Checking test 139 hafs_regional_1nest_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_1nest_atm_intel
+Checking test 137 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4757,15 +4723,15 @@ Checking test 139 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 339.333424
-  0: The maximum resident set size (KB)                   = 510616
+  0: The total amount of wall time                        = 340.813114
+  0: The maximum resident set size (KB)                   = 453964
 
-Test 139 hafs_regional_1nest_atm_intel PASS
+Test 137 hafs_regional_1nest_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_1nest_atm_qr_intel
-Checking test 140 hafs_regional_1nest_atm_qr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_1nest_atm_qr_intel
+Checking test 138 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4786,15 +4752,15 @@ Checking test 140 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 345.126290
-  0: The maximum resident set size (KB)                   = 483480
+  0: The total amount of wall time                        = 347.829381
+  0: The maximum resident set size (KB)                   = 474828
 
-Test 140 hafs_regional_1nest_atm_qr_intel PASS
+Test 138 hafs_regional_1nest_atm_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_telescopic_2nests_atm_intel
-Checking test 141 hafs_regional_telescopic_2nests_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_telescopic_2nests_atm_intel
+Checking test 139 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4802,15 +4768,15 @@ Checking test 141 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 385.954453
-  0: The maximum resident set size (KB)                   = 519112
+  0: The total amount of wall time                        = 389.129538
+  0: The maximum resident set size (KB)                   = 520368
 
-Test 141 hafs_regional_telescopic_2nests_atm_intel PASS
+Test 139 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_global_1nest_atm_intel
-Checking test 142 hafs_global_1nest_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_global_1nest_atm_intel
+Checking test 140 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4856,15 +4822,15 @@ Checking test 142 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 165.410923
-  0: The maximum resident set size (KB)                   = 354820
+  0: The total amount of wall time                        = 164.353957
+  0: The maximum resident set size (KB)                   = 357960
 
-Test 142 hafs_global_1nest_atm_intel PASS
+Test 140 hafs_global_1nest_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_global_1nest_atm_qr_intel
-Checking test 143 hafs_global_1nest_atm_qr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_global_1nest_atm_qr_intel
+Checking test 141 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4910,15 +4876,15 @@ Checking test 143 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 166.724207
-  0: The maximum resident set size (KB)                   = 353820
+  0: The total amount of wall time                        = 167.190910
+  0: The maximum resident set size (KB)                   = 356204
 
-Test 143 hafs_global_1nest_atm_qr_intel PASS
+Test 141 hafs_global_1nest_atm_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_global_multiple_4nests_atm_intel
-Checking test 144 hafs_global_multiple_4nests_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_global_multiple_4nests_atm_intel
+Checking test 142 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4999,15 +4965,15 @@ Checking test 144 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 432.135756
-  0: The maximum resident set size (KB)                   = 394100
+  0: The total amount of wall time                        = 435.978882
+  0: The maximum resident set size (KB)                   = 428408
 
-Test 144 hafs_global_multiple_4nests_atm_intel PASS
+Test 142 hafs_global_multiple_4nests_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_global_multiple_4nests_atm_qr_intel
-Checking test 145 hafs_global_multiple_4nests_atm_qr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_global_multiple_4nests_atm_qr_intel
+Checking test 143 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5088,15 +5054,15 @@ Checking test 145 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 450.550149
-  0: The maximum resident set size (KB)                   = 453652
+  0: The total amount of wall time                        = 453.675158
+  0: The maximum resident set size (KB)                   = 452332
 
-Test 145 hafs_global_multiple_4nests_atm_qr_intel PASS
+Test 143 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_specified_moving_1nest_atm_intel
-Checking test 146 hafs_regional_specified_moving_1nest_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_specified_moving_1nest_atm_intel
+Checking test 144 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5104,15 +5070,15 @@ Checking test 146 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 217.805402
-  0: The maximum resident set size (KB)                   = 522932
+  0: The total amount of wall time                        = 219.002049
+  0: The maximum resident set size (KB)                   = 525780
 
-Test 146 hafs_regional_specified_moving_1nest_atm_intel PASS
+Test 144 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_storm_following_1nest_atm_intel
-Checking test 147 hafs_regional_storm_following_1nest_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_storm_following_1nest_atm_intel
+Checking test 145 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5133,15 +5099,15 @@ Checking test 147 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 204.088469
-  0: The maximum resident set size (KB)                   = 526112
+  0: The total amount of wall time                        = 205.262653
+  0: The maximum resident set size (KB)                   = 521924
 
-Test 147 hafs_regional_storm_following_1nest_atm_intel PASS
+Test 145 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_storm_following_1nest_atm_qr_intel
-Checking test 148 hafs_regional_storm_following_1nest_atm_qr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_storm_following_1nest_atm_qr_intel
+Checking test 146 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5162,15 +5128,15 @@ Checking test 148 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 213.495711
-  0: The maximum resident set size (KB)                   = 504072
+  0: The total amount of wall time                        = 215.180277
+  0: The maximum resident set size (KB)                   = 503160
 
-Test 148 hafs_regional_storm_following_1nest_atm_qr_intel PASS
+Test 146 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_storm_following_1nest_atm_ocn_intel
-Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_storm_following_1nest_atm_ocn_intel
+Checking test 147 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5178,43 +5144,43 @@ Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 285.107088
-  0: The maximum resident set size (KB)                   = 569496
+  0: The total amount of wall time                        = 284.824831
+  0: The maximum resident set size (KB)                   = 565932
 
-Test 149 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
+Test 147 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_global_storm_following_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_global_storm_following_1nest_atm_intel
-Checking test 150 hafs_global_storm_following_1nest_atm_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_global_storm_following_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_global_storm_following_1nest_atm_intel
+Checking test 148 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 65.551276
-  0: The maximum resident set size (KB)                   = 370592
+  0: The total amount of wall time                        = 66.174224
+  0: The maximum resident set size (KB)                   = 371392
 
-Test 150 hafs_global_storm_following_1nest_atm_intel PASS
+Test 148 hafs_global_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-Checking test 151 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 764.112566
-  0: The maximum resident set size (KB)                   = 585028
+  0: The total amount of wall time                        = 737.172015
+  0: The maximum resident set size (KB)                   = 585960
 
-Test 151 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
+Test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-Checking test 152 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+Checking test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -5224,162 +5190,162 @@ Checking test 152 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 533.891053
-  0: The maximum resident set size (KB)                   = 617072
+  0: The total amount of wall time                        = 536.079843
+  0: The maximum resident set size (KB)                   = 616796
 
-Test 152 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
+Test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_docn_intel
-Checking test 153 hafs_regional_docn_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_docn_intel
+Checking test 151 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 341.145784
-  0: The maximum resident set size (KB)                   = 1243676
+  0: The total amount of wall time                        = 349.263016
+  0: The maximum resident set size (KB)                   = 1232548
 
-Test 153 hafs_regional_docn_intel PASS
+Test 151 hafs_regional_docn_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_docn_oisst_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_docn_oisst_intel
-Checking test 154 hafs_regional_docn_oisst_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_oisst_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_docn_oisst_intel
+Checking test 152 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 338.497399
-  0: The maximum resident set size (KB)                   = 1218748
+  0: The total amount of wall time                        = 339.897790
+  0: The maximum resident set size (KB)                   = 1222276
 
-Test 154 hafs_regional_docn_oisst_intel PASS
+Test 152 hafs_regional_docn_oisst_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/hafs_regional_datm_cdeps_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/hafs_regional_datm_cdeps_intel
-Checking test 155 hafs_regional_datm_cdeps_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/hafs_regional_datm_cdeps_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/hafs_regional_datm_cdeps_intel
+Checking test 153 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 939.464643
-  0: The maximum resident set size (KB)                   = 1033616
+  0: The total amount of wall time                        = 957.158581
+  0: The maximum resident set size (KB)                   = 1043236
 
-Test 155 hafs_regional_datm_cdeps_intel PASS
+Test 153 hafs_regional_datm_cdeps_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_control_cfsr_intel
-Checking test 156 datm_cdeps_control_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_control_cfsr_intel
+Checking test 154 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.960412
- 0: The maximum resident set size (KB)                   = 1057224
+ 0: The total amount of wall time                        = 142.568739
+ 0: The maximum resident set size (KB)                   = 1081808
 
-Test 156 datm_cdeps_control_cfsr_intel PASS
+Test 154 datm_cdeps_control_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_restart_cfsr_intel
-Checking test 157 datm_cdeps_restart_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_restart_cfsr_intel
+Checking test 155 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 90.945460
- 0: The maximum resident set size (KB)                   = 1012632
+ 0: The total amount of wall time                        = 89.525055
+ 0: The maximum resident set size (KB)                   = 1033220
 
-Test 157 datm_cdeps_restart_cfsr_intel PASS
+Test 155 datm_cdeps_restart_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_control_gefs_intel
-Checking test 158 datm_cdeps_control_gefs_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_gefs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_control_gefs_intel
+Checking test 156 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.723466
- 0: The maximum resident set size (KB)                   = 961976
+ 0: The total amount of wall time                        = 139.586169
+ 0: The maximum resident set size (KB)                   = 973824
 
-Test 158 datm_cdeps_control_gefs_intel PASS
+Test 156 datm_cdeps_control_gefs_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_iau_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_iau_gefs_intel
-Checking test 159 datm_cdeps_iau_gefs_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_iau_gefs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_iau_gefs_intel
+Checking test 157 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.383204
- 0: The maximum resident set size (KB)                   = 958096
+ 0: The total amount of wall time                        = 142.562307
+ 0: The maximum resident set size (KB)                   = 966888
 
-Test 159 datm_cdeps_iau_gefs_intel PASS
+Test 157 datm_cdeps_iau_gefs_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_stochy_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_stochy_gefs_intel
-Checking test 160 datm_cdeps_stochy_gefs_intel results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_stochy_gefs_intel
+Checking test 158 datm_cdeps_stochy_gefs_intel results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc ............ALT CHECK......NOT OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.065780
- 0: The maximum resident set size (KB)                   = 968432
+ 0: The total amount of wall time                        = 154.746435
+ 0: The maximum resident set size (KB)                   = 965108
 
-Test 160 datm_cdeps_stochy_gefs_intel PASS
+Test 158 datm_cdeps_stochy_gefs_intel FAIL Tries: 2
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_ciceC_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_ciceC_cfsr_intel
-Checking test 161 datm_cdeps_ciceC_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_ciceC_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_ciceC_cfsr_intel
+Checking test 159 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 144.255007
- 0: The maximum resident set size (KB)                   = 1050868
+ 0: The total amount of wall time                        = 147.162115
+ 0: The maximum resident set size (KB)                   = 1025080
 
-Test 161 datm_cdeps_ciceC_cfsr_intel PASS
+Test 159 datm_cdeps_ciceC_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_bulk_cfsr_intel
-Checking test 162 datm_cdeps_bulk_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_bulk_cfsr_intel
+Checking test 160 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.658508
- 0: The maximum resident set size (KB)                   = 1068232
+ 0: The total amount of wall time                        = 147.533739
+ 0: The maximum resident set size (KB)                   = 1065412
 
-Test 162 datm_cdeps_bulk_cfsr_intel PASS
+Test 160 datm_cdeps_bulk_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_bulk_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_bulk_gefs_intel
-Checking test 163 datm_cdeps_bulk_gefs_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_gefs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_bulk_gefs_intel
+Checking test 161 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.496463
- 0: The maximum resident set size (KB)                   = 969092
+ 0: The total amount of wall time                        = 138.045711
+ 0: The maximum resident set size (KB)                   = 954064
 
-Test 163 datm_cdeps_bulk_gefs_intel PASS
+Test 161 datm_cdeps_bulk_gefs_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_mx025_cfsr_intel
-Checking test 164 datm_cdeps_mx025_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_mx025_cfsr_intel
+Checking test 162 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -5387,15 +5353,15 @@ Checking test 164 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 455.508769
-  0: The maximum resident set size (KB)                   = 876848
+  0: The total amount of wall time                        = 441.438483
+  0: The maximum resident set size (KB)                   = 880176
 
-Test 164 datm_cdeps_mx025_cfsr_intel PASS
+Test 162 datm_cdeps_mx025_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_mx025_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_mx025_gefs_intel
-Checking test 165 datm_cdeps_mx025_gefs_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_gefs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_mx025_gefs_intel
+Checking test 163 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_2.nc .........OK
@@ -5403,78 +5369,78 @@ Checking test 165 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 448.990209
-  0: The maximum resident set size (KB)                   = 931868
+  0: The total amount of wall time                        = 432.950189
+  0: The maximum resident set size (KB)                   = 931596
 
-Test 165 datm_cdeps_mx025_gefs_intel PASS
+Test 163 datm_cdeps_mx025_gefs_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_multiple_files_cfsr_intel
-Checking test 166 datm_cdeps_multiple_files_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_multiple_files_cfsr_intel
+Checking test 164 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.064649
- 0: The maximum resident set size (KB)                   = 1056352
+ 0: The total amount of wall time                        = 147.042559
+ 0: The maximum resident set size (KB)                   = 1070412
 
-Test 166 datm_cdeps_multiple_files_cfsr_intel PASS
+Test 164 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_3072x1536_cfsr_intel
-Checking test 167 datm_cdeps_3072x1536_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_3072x1536_cfsr_intel
+Checking test 165 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 196.865122
- 0: The maximum resident set size (KB)                   = 2362564
+ 0: The total amount of wall time                        = 192.396355
+ 0: The maximum resident set size (KB)                   = 2370512
 
-Test 167 datm_cdeps_3072x1536_cfsr_intel PASS
+Test 165 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_gfs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_gfs_intel
-Checking test 168 datm_cdeps_gfs_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_gfs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_gfs_intel
+Checking test 166 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 200.229146
- 0: The maximum resident set size (KB)                   = 2313240
+ 0: The total amount of wall time                        = 194.757919
+ 0: The maximum resident set size (KB)                   = 2371376
 
-Test 168 datm_cdeps_gfs_intel PASS
+Test 166 datm_cdeps_gfs_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_debug_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_debug_cfsr_intel
-Checking test 169 datm_cdeps_debug_cfsr_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_debug_cfsr_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_debug_cfsr_intel
+Checking test 167 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 355.150166
- 0: The maximum resident set size (KB)                   = 1005360
+ 0: The total amount of wall time                        = 356.789850
+ 0: The maximum resident set size (KB)                   = 991808
 
-Test 169 datm_cdeps_debug_cfsr_intel PASS
+Test 167 datm_cdeps_debug_cfsr_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_control_cfsr_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_control_cfsr_faster_intel
-Checking test 170 datm_cdeps_control_cfsr_faster_intel results ....
- Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_control_cfsr_faster_intel
+Checking test 168 datm_cdeps_control_cfsr_faster_intel results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc ............ALT CHECK......NOT OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.106064
- 0: The maximum resident set size (KB)                   = 1055328
+ 0: The total amount of wall time                        = 144.107149
+ 0: The maximum resident set size (KB)                   = 1060316
 
-Test 170 datm_cdeps_control_cfsr_faster_intel PASS
+Test 168 datm_cdeps_control_cfsr_faster_intel FAIL Tries: 2
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_lnd_gswp3_intel
-Checking test 171 datm_cdeps_lnd_gswp3_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_lnd_gswp3_intel
+Checking test 169 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5482,15 +5448,15 @@ Checking test 171 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 7.848864
-  0: The maximum resident set size (KB)                   = 261152
+  0: The total amount of wall time                        = 7.452698
+  0: The maximum resident set size (KB)                   = 263852
 
-Test 171 datm_cdeps_lnd_gswp3_intel PASS
+Test 169 datm_cdeps_lnd_gswp3_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/datm_cdeps_lnd_gswp3_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/datm_cdeps_lnd_gswp3_rst_intel
-Checking test 172 datm_cdeps_lnd_gswp3_rst_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/datm_cdeps_lnd_gswp3_rst_intel
+Checking test 170 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile3.nc .........OK
@@ -5498,15 +5464,15 @@ Checking test 172 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 13.650908
-  0: The maximum resident set size (KB)                   = 269124
+  0: The total amount of wall time                        = 12.929058
+  0: The maximum resident set size (KB)                   = 272608
 
-Test 172 datm_cdeps_lnd_gswp3_rst_intel PASS
+Test 170 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_p8_atmlnd_sbs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_p8_atmlnd_sbs_intel
-Checking test 173 control_p8_atmlnd_sbs_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_p8_atmlnd_sbs_intel
+Checking test 171 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -5590,15 +5556,65 @@ Checking test 173 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 263.405238
-  0: The maximum resident set size (KB)                   = 1615244
+  0: The total amount of wall time                        = 203.051419
+  0: The maximum resident set size (KB)                   = 1611996
 
-Test 173 control_p8_atmlnd_sbs_intel PASS
+Test 171 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/control_atmwav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/control_atmwav_intel
-Checking test 175 control_atmwav_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmwav_control_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/atmwav_control_noaero_p8_intel
+Checking test 172 atmwav_control_noaero_p8_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing RESTART/20210322.180000.coupler.res .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/ufs.atmw.cpl.r.2021-03-22-64800.nc .........OK
+ Comparing 20210322.180000.out_pnt.ww3 .........OK
+ Comparing 20210322.180000.out_grd.ww3 .........OK
+ Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
+
+  0: The total amount of wall time                        = 93.549537
+  0: The maximum resident set size (KB)                   = 1644232
+
+Test 172 atmwav_control_noaero_p8_intel PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/control_atmwav_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/control_atmwav_intel
+Checking test 173 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5641,15 +5657,15 @@ Checking test 175 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 89.086989
-  0: The maximum resident set size (KB)                   = 664140
+  0: The total amount of wall time                        = 88.008604
+  0: The maximum resident set size (KB)                   = 664348
 
-Test 175 control_atmwav_intel PASS
+Test 173 control_atmwav_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/atmaero_control_p8_intel
-Checking test 176 atmaero_control_p8_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/atmaero_control_p8_intel
+Checking test 174 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5692,15 +5708,15 @@ Checking test 176 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.200988
-  0: The maximum resident set size (KB)                   = 2983940
+  0: The total amount of wall time                        = 226.910256
+  0: The maximum resident set size (KB)                   = 2979804
 
-Test 176 atmaero_control_p8_intel PASS
+Test 174 atmaero_control_p8_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/atmaero_control_p8_rad_intel
-Checking test 177 atmaero_control_p8_rad_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/atmaero_control_p8_rad_intel
+Checking test 175 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5743,15 +5759,15 @@ Checking test 177 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 278.983294
-  0: The maximum resident set size (KB)                   = 3049044
+  0: The total amount of wall time                        = 279.596061
+  0: The maximum resident set size (KB)                   = 3044524
 
-Test 177 atmaero_control_p8_rad_intel PASS
+Test 175 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_micro_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/atmaero_control_p8_rad_micro_intel
-Checking test 178 atmaero_control_p8_rad_micro_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/atmaero_control_p8_rad_micro_intel
+Checking test 176 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5794,15 +5810,15 @@ Checking test 178 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 283.264487
-  0: The maximum resident set size (KB)                   = 3056868
+  0: The total amount of wall time                        = 285.960622
+  0: The maximum resident set size (KB)                   = 3060060
 
-Test 178 atmaero_control_p8_rad_micro_intel PASS
+Test 176 atmaero_control_p8_rad_micro_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_atmaq_intel
-Checking test 179 regional_atmaq_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_atmaq_intel
+Checking test 177 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5817,15 +5833,15 @@ Checking test 179 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 627.532721
-  0: The maximum resident set size (KB)                   = 1483388
+  0: The total amount of wall time                        = 633.584396
+  0: The maximum resident set size (KB)                   = 1474584
 
-Test 179 regional_atmaq_intel PASS
+Test 177 regional_atmaq_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_atmaq_debug_intel
-Checking test 180 regional_atmaq_debug_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_debug_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_atmaq_debug_intel
+Checking test 178 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
@@ -5838,15 +5854,15 @@ Checking test 180 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1252.928697
-  0: The maximum resident set size (KB)                   = 1408440
+  0: The total amount of wall time                        = 1248.860351
+  0: The maximum resident set size (KB)                   = 1404808
 
-Test 180 regional_atmaq_debug_intel PASS
+Test 178 regional_atmaq_debug_intel PASS
 
 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1769/stmp/zshrader/FV3_RT/rt_331034/regional_atmaq_faster_intel
-Checking test 181 regional_atmaq_faster_intel results ....
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_faster_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_140689/regional_atmaq_faster_intel
+Checking test 179 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5861,12 +5877,39 @@ Checking test 181 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 548.197502
-  0: The maximum resident set size (KB)                   = 1480116
+  0: The total amount of wall time                        = 560.829709
+  0: The maximum resident set size (KB)                   = 1476496
 
-Test 181 regional_atmaq_faster_intel PASS
+Test 179 regional_atmaq_faster_intel PASS
 
 
-REGRESSION TEST SUCCESSFUL
-Tue Jun 20 13:18:40 CDT 2023
-Elapsed time: 01h:23m:54s. Have a nice day!
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_151444/datm_cdeps_control_cfsr_faster_intel
+Checking test 001 datm_cdeps_control_cfsr_faster_intel results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 143.822289
+ 0: The maximum resident set size (KB)                   = 1082824
+
+Test 001 datm_cdeps_control_cfsr_faster_intel PASS
+
+ 
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
+working dir  = /work/noaa/epic-ps/zshrader/rt-1776/stmp/zshrader/FV3_RT/rt_237940/datm_cdeps_stochy_gefs_intel
+Checking test 001 datm_cdeps_stochy_gefs_intel results ....
+ Comparing RESTART/20111002.000000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2011-10-02-00000.nc .........OK
+ Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
+
+ 0: The total amount of wall time                        = 142.477926
+ 0: The maximum resident set size (KB)                   = 969796
+
+Test 001 datm_cdeps_stochy_gefs_intel PASS
+
+
+REGRESSION TEST WAS SUCCESSFUL
+Thu Jun 22 18:39:01 CDT 2023
+Elapsed time: 00h:09m:32s. Have a nice day!

--- a/tests/logs/RegressionTests_wcoss2.log
+++ b/tests/logs/RegressionTests_wcoss2.log
@@ -1,47 +1,47 @@
-Tue Jun 20 15:10:32 UTC 2023
+Fri Jun 23 12:09:19 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: f845b3e43b08cfdd9c1a9b271ef3ab425d47fe6c
+Testing UFSWM Hash: d927a6627cfc1bb9815fa5f37502428bd49a9fe3
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 0c64f47e19fd8d1f0535063e126dfa1f8436615b ../FV3 (remotes/origin/refactor-restart)
+ f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 613 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 623 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1082 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 538 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1863 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 1186 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 948 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1786 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 862 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 510 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 978 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 297 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 2641 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 1104 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 574 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 412 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 950 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 1999 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 591 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 2429 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 1678 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 1052 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 755 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 1796 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 797 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 626 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 594 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 1126 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1951 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 653 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 1374 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 513 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 1154 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 1557 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 1762 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 569 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 610 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 584 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 1374 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 493 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 1143 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 696 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 256 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 957 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 749 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 697 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 1052 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 351 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_mixedmode_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_p8_mixedmode_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -106,14 +106,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 337.841684
-The maximum resident set size (KB)                   = 2959276
+The total amount of wall time                        = 337.589933
+The maximum resident set size (KB)                   = 2955836
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_gfsv17_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_gfsv17_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -177,14 +177,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 258.327543
-The maximum resident set size (KB)                   = 1563768
+The total amount of wall time                        = 256.057677
+The maximum resident set size (KB)                   = 1568720
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -249,14 +249,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 384.063959
-The maximum resident set size (KB)                   = 2979716
+The total amount of wall time                        = 386.174182
+The maximum resident set size (KB)                   = 2979452
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_restart_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -309,14 +309,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 232.805539
-The maximum resident set size (KB)                   = 2864812
+The total amount of wall time                        = 236.571319
+The maximum resident set size (KB)                   = 2864040
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_qr_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -381,14 +381,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 385.792601
-The maximum resident set size (KB)                   = 2993248
+The total amount of wall time                        = 389.835538
+The maximum resident set size (KB)                   = 2990800
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_restart_qr_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -441,14 +441,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 235.679072
-The maximum resident set size (KB)                   = 2883592
+The total amount of wall time                        = 235.879362
+The maximum resident set size (KB)                   = 2876968
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_2threads_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -501,14 +501,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 366.564650
-The maximum resident set size (KB)                   = 3287120
+The total amount of wall time                        = 368.634771
+The maximum resident set size (KB)                   = 3288016
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_decomp_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -561,14 +561,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 382.780177
-The maximum resident set size (KB)                   = 2978328
+The total amount of wall time                        = 383.368816
+The maximum resident set size (KB)                   = 2981884
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_mpi_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -621,14 +621,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 316.851454
-The maximum resident set size (KB)                   = 2914328
+The total amount of wall time                        = 318.042932
+The maximum resident set size (KB)                   = 2910296
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_ciceC_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_ciceC_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_ciceC_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -693,14 +693,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 383.146851
-The maximum resident set size (KB)                   = 2979668
+The total amount of wall time                        = 388.046111
+The maximum resident set size (KB)                   = 2982548
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_bmark_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_bmark_p8_intel
 Checking test 011 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -748,14 +748,14 @@ Checking test 011 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 941.388464
-The maximum resident set size (KB)                   = 3921204
+The total amount of wall time                        = 939.823262
+The maximum resident set size (KB)                   = 3915928
 
 Test 011 cpld_bmark_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_bmark_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_restart_bmark_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_bmark_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_restart_bmark_p8_intel
 Checking test 012 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -803,14 +803,14 @@ Checking test 012 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 654.725283
-The maximum resident set size (KB)                   = 3878868
+The total amount of wall time                        = 659.321206
+The maximum resident set size (KB)                   = 3883868
 
 Test 012 cpld_restart_bmark_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_noaero_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_noaero_p8_intel
 Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -874,14 +874,14 @@ Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 283.262587
-The maximum resident set size (KB)                   = 1574112
+The total amount of wall time                        = 297.806204
+The maximum resident set size (KB)                   = 1573276
 
 Test 013 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_c96_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_nowave_noaero_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_nowave_noaero_p8_intel
 Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -943,14 +943,14 @@ Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 299.902209
-The maximum resident set size (KB)                   = 1629060
+The total amount of wall time                        = 312.563676
+The maximum resident set size (KB)                   = 1627392
 
 Test 014 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_noaero_p8_agrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_noaero_p8_agrid_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_noaero_p8_agrid_intel
 Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1012,14 +1012,14 @@ Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 308.861046
-The maximum resident set size (KB)                   = 1625560
+The total amount of wall time                        = 308.505356
+The maximum resident set size (KB)                   = 1634588
 
 Test 015 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_c48_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_c48_intel
 Checking test 016 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1069,14 +1069,14 @@ Checking test 016 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 430.841855
-The maximum resident set size (KB)                   = 2638584
+The total amount of wall time                        = 433.677089
+The maximum resident set size (KB)                   = 2641012
 
 Test 016 cpld_control_c48_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_warmstart_c48_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_warmstart_c48_intel
 Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1126,14 +1126,14 @@ Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 121.281118
-The maximum resident set size (KB)                   = 2646008
+The total amount of wall time                        = 125.134494
+The maximum resident set size (KB)                   = 2642820
 
 Test 017 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_restart_c48_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_restart_c48_intel
 Checking test 018 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1183,14 +1183,14 @@ Checking test 018 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 67.468486
-The maximum resident set size (KB)                   = 2054828
+The total amount of wall time                        = 67.727196
+The maximum resident set size (KB)                   = 2059492
 
 Test 018 cpld_restart_c48_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/cpld_control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/cpld_control_p8_faster_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/cpld_control_p8_faster_intel
 Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 380.953887
-The maximum resident set size (KB)                   = 2980192
+The total amount of wall time                        = 381.372484
+The maximum resident set size (KB)                   = 2980464
 
 Test 019 cpld_control_p8_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_flake_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_flake_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_flake_intel
 Checking test 020 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 020 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 214.323492
-The maximum resident set size (KB)                   = 568968
+The total amount of wall time                        = 216.159313
+The maximum resident set size (KB)                   = 569948
 
 Test 020 control_flake_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_CubedSphereGrid_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_CubedSphereGrid_intel
 Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1307,14 +1307,14 @@ Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 130.158699
-The maximum resident set size (KB)                   = 518056
+The total amount of wall time                        = 130.587441
+The maximum resident set size (KB)                   = 514348
 
 Test 021 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_latlon_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_latlon_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_latlon_intel
 Checking test 022 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1325,14 +1325,14 @@ Checking test 022 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 132.001929
-The maximum resident set size (KB)                   = 518384
+The total amount of wall time                        = 132.169026
+The maximum resident set size (KB)                   = 518024
 
 Test 022 control_latlon_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_wrtGauss_netcdf_parallel_intel
 Checking test 023 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1343,14 +1343,14 @@ Checking test 023 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 134.536639
-The maximum resident set size (KB)                   = 517040
+The total amount of wall time                        = 138.619435
+The maximum resident set size (KB)                   = 518756
 
 Test 023 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_c48_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_c48_intel
 Checking test 024 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1389,14 +1389,14 @@ Checking test 024 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 325.807305
-The maximum resident set size (KB)                   = 676504
+The total amount of wall time                        = 326.616504
+The maximum resident set size (KB)                   = 674224
 
 Test 024 control_c48_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c192_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_c192_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_c192_intel
 Checking test 025 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1407,14 +1407,14 @@ Checking test 025 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 528.219187
-The maximum resident set size (KB)                   = 617768
+The total amount of wall time                        = 529.261839
+The maximum resident set size (KB)                   = 618924
 
 Test 025 control_c192_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c384_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_c384_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_c384_intel
 Checking test 026 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1425,14 +1425,14 @@ Checking test 026 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 564.686199
-The maximum resident set size (KB)                   = 931752
+The total amount of wall time                        = 564.969424
+The maximum resident set size (KB)                   = 927328
 
 Test 026 control_c384_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_c384gdas_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_c384gdas_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_c384gdas_intel
 Checking test 027 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1475,14 +1475,14 @@ Checking test 027 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 497.281506
-The maximum resident set size (KB)                   = 1062156
+The total amount of wall time                        = 498.692296
+The maximum resident set size (KB)                   = 1059132
 
 Test 027 control_c384gdas_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_stochy_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_stochy_intel
 Checking test 028 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1493,28 +1493,28 @@ Checking test 028 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 90.581647
-The maximum resident set size (KB)                   = 522672
+The total amount of wall time                        = 93.482103
+The maximum resident set size (KB)                   = 523904
 
 Test 028 control_stochy_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_stochy_restart_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_stochy_restart_intel
 Checking test 029 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 49.306925
-The maximum resident set size (KB)                   = 291044
+The total amount of wall time                        = 49.931038
+The maximum resident set size (KB)                   = 291448
 
 Test 029 control_stochy_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_lndp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_lndp_intel
 Checking test 030 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1525,14 +1525,14 @@ Checking test 030 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 83.769834
-The maximum resident set size (KB)                   = 520556
+The total amount of wall time                        = 84.557225
+The maximum resident set size (KB)                   = 522160
 
 Test 030 control_lndp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_iovr4_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_iovr4_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_iovr4_intel
 Checking test 031 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1547,14 +1547,14 @@ Checking test 031 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 137.469524
-The maximum resident set size (KB)                   = 515624
+The total amount of wall time                        = 137.762590
+The maximum resident set size (KB)                   = 514868
 
 Test 031 control_iovr4_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_iovr5_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_iovr5_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_iovr5_intel
 Checking test 032 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1569,14 +1569,14 @@ Checking test 032 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 136.763529
-The maximum resident set size (KB)                   = 516704
+The total amount of wall time                        = 136.521569
+The maximum resident set size (KB)                   = 517980
 
 Test 032 control_iovr5_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_p8_intel
 Checking test 033 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1623,14 +1623,14 @@ Checking test 033 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.409674
-The maximum resident set size (KB)                   = 1500584
+The total amount of wall time                        = 180.125638
+The maximum resident set size (KB)                   = 1499176
 
 Test 033 control_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_restart_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_restart_p8_intel
 Checking test 034 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1669,14 +1669,14 @@ Checking test 034 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 99.639222
-The maximum resident set size (KB)                   = 659508
+The total amount of wall time                        = 112.284360
+The maximum resident set size (KB)                   = 663784
 
 Test 034 control_restart_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_qr_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_qr_p8_intel
 Checking test 035 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1723,14 +1723,14 @@ Checking test 035 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 177.590479
-The maximum resident set size (KB)                   = 1502536
+The total amount of wall time                        = 177.821344
+The maximum resident set size (KB)                   = 1500260
 
 Test 035 control_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_restart_qr_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_restart_qr_p8_intel
 Checking test 036 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1769,14 +1769,14 @@ Checking test 036 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 102.339190
-The maximum resident set size (KB)                   = 667828
+The total amount of wall time                        = 101.814966
+The maximum resident set size (KB)                   = 667544
 
 Test 036 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_decomp_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_decomp_p8_intel
 Checking test 037 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1819,14 +1819,14 @@ Checking test 037 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 182.143891
-The maximum resident set size (KB)                   = 1483964
+The total amount of wall time                        = 183.892273
+The maximum resident set size (KB)                   = 1483552
 
 Test 037 control_decomp_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_2threads_p8_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_2threads_p8_intel
 Checking test 038 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1869,14 +1869,14 @@ Checking test 038 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 155.116100
-The maximum resident set size (KB)                   = 1576408
+The total amount of wall time                        = 157.806005
+The maximum resident set size (KB)                   = 1574512
 
 Test 038 control_2threads_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_p8_lndp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_p8_lndp_intel
 Checking test 039 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1895,14 +1895,14 @@ Checking test 039 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 319.706676
-The maximum resident set size (KB)                   = 1487740
+The total amount of wall time                        = 322.189772
+The maximum resident set size (KB)                   = 1498184
 
 Test 039 control_p8_lndp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_rrtmgp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_p8_rrtmgp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_p8_rrtmgp_intel
 Checking test 040 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1949,14 +1949,14 @@ Checking test 040 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 238.057793
-The maximum resident set size (KB)                   = 1551672
+The total amount of wall time                        = 237.201090
+The maximum resident set size (KB)                   = 1546080
 
 Test 040 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_mynn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_p8_mynn_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_p8_mynn_intel
 Checking test 041 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2003,14 +2003,14 @@ Checking test 041 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 183.839258
-The maximum resident set size (KB)                   = 1495104
+The total amount of wall time                        = 182.647907
+The maximum resident set size (KB)                   = 1494688
 
 Test 041 control_p8_mynn_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/merra2_thompson_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/merra2_thompson_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/merra2_thompson_intel
 Checking test 042 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2057,14 +2057,14 @@ Checking test 042 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 207.391857
-The maximum resident set size (KB)                   = 1497952
+The total amount of wall time                        = 206.166528
+The maximum resident set size (KB)                   = 1493372
 
 Test 042 merra2_thompson_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_control_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_control_intel
 Checking test 043 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2075,28 +2075,28 @@ Checking test 043 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 281.388547
-The maximum resident set size (KB)                   = 654612
+The total amount of wall time                        = 282.211921
+The maximum resident set size (KB)                   = 653936
 
 Test 043 regional_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_restart_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_restart_intel
 Checking test 044 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 154.575798
-The maximum resident set size (KB)                   = 651324
+The total amount of wall time                        = 151.241404
+The maximum resident set size (KB)                   = 650132
 
 Test 044 regional_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_control_qr_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_control_qr_intel
 Checking test 045 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2107,28 +2107,28 @@ Checking test 045 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 283.746943
-The maximum resident set size (KB)                   = 655216
+The total amount of wall time                        = 282.839141
+The maximum resident set size (KB)                   = 655984
 
 Test 045 regional_control_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_restart_qr_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_restart_qr_intel
 Checking test 046 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 153.365121
-The maximum resident set size (KB)                   = 657156
+The total amount of wall time                        = 152.936402
+The maximum resident set size (KB)                   = 656520
 
 Test 046 regional_restart_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_decomp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_decomp_intel
 Checking test 047 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2139,14 +2139,14 @@ Checking test 047 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 296.245138
-The maximum resident set size (KB)                   = 656608
+The total amount of wall time                        = 297.147118
+The maximum resident set size (KB)                   = 653884
 
 Test 047 regional_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_2threads_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_2threads_intel
 Checking test 048 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2157,14 +2157,14 @@ Checking test 048 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 173.101474
-The maximum resident set size (KB)                   = 700736
+The total amount of wall time                        = 174.443603
+The maximum resident set size (KB)                   = 698940
 
 Test 048 regional_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_noquilt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_noquilt_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_noquilt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_noquilt_intel
 Checking test 049 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2172,28 +2172,28 @@ Checking test 049 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 280.763107
-The maximum resident set size (KB)                   = 645984
+The total amount of wall time                        = 282.997674
+The maximum resident set size (KB)                   = 646940
 
 Test 049 regional_noquilt_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_netcdf_parallel_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_netcdf_parallel_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_netcdf_parallel_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_netcdf_parallel_intel
 Checking test 050 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-The total amount of wall time                        = 277.732536
-The maximum resident set size (KB)                   = 653288
+The total amount of wall time                        = 285.526197
+The maximum resident set size (KB)                   = 650972
 
 Test 050 regional_netcdf_parallel_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_2dwrtdecomp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_2dwrtdecomp_intel
 Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2204,14 +2204,14 @@ Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 283.660497
-The maximum resident set size (KB)                   = 652724
+The total amount of wall time                        = 281.274526
+The maximum resident set size (KB)                   = 653224
 
 Test 051 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/fv3_regional_wofs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_wofs_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/fv3_regional_wofs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_wofs_intel
 Checking test 052 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2222,14 +2222,14 @@ Checking test 052 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 358.737254
-The maximum resident set size (KB)                   = 342912
+The total amount of wall time                        = 375.725146
+The maximum resident set size (KB)                   = 342920
 
 Test 052 regional_wofs_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_control_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_control_intel
 Checking test 053 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2276,14 +2276,14 @@ Checking test 053 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 404.619032
-The maximum resident set size (KB)                   = 898372
+The total amount of wall time                        = 428.820913
+The maximum resident set size (KB)                   = 896660
 
 Test 053 rap_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_spp_sppt_shum_skeb_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_spp_sppt_shum_skeb_intel
 Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2294,14 +2294,14 @@ Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 241.672688
-The maximum resident set size (KB)                   = 983096
+The total amount of wall time                        = 262.699638
+The maximum resident set size (KB)                   = 986756
 
 Test 054 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_decomp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_decomp_intel
 Checking test 055 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2348,14 +2348,14 @@ Checking test 055 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 418.979320
-The maximum resident set size (KB)                   = 896932
+The total amount of wall time                        = 428.287097
+The maximum resident set size (KB)                   = 898460
 
 Test 055 rap_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_2threads_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_2threads_intel
 Checking test 056 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2402,14 +2402,14 @@ Checking test 056 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 365.797278
-The maximum resident set size (KB)                   = 977656
+The total amount of wall time                        = 366.611793
+The maximum resident set size (KB)                   = 979252
 
 Test 056 rap_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_restart_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_restart_intel
 Checking test 057 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2448,14 +2448,14 @@ Checking test 057 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 206.726051
-The maximum resident set size (KB)                   = 641596
+The total amount of wall time                        = 206.797624
+The maximum resident set size (KB)                   = 635748
 
 Test 057 rap_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_sfcdiff_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_sfcdiff_intel
 Checking test 058 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2502,14 +2502,14 @@ Checking test 058 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 407.270621
-The maximum resident set size (KB)                   = 895240
+The total amount of wall time                        = 413.022761
+The maximum resident set size (KB)                   = 896348
 
 Test 058 rap_sfcdiff_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_sfcdiff_decomp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_sfcdiff_decomp_intel
 Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2556,14 +2556,14 @@ Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 423.490115
-The maximum resident set size (KB)                   = 895468
+The total amount of wall time                        = 431.285215
+The maximum resident set size (KB)                   = 897872
 
 Test 059 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_sfcdiff_restart_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_sfcdiff_restart_intel
 Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2602,14 +2602,14 @@ Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 301.007770
-The maximum resident set size (KB)                   = 644688
+The total amount of wall time                        = 299.929880
+The maximum resident set size (KB)                   = 642228
 
 Test 060 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_intel
 Checking test 061 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2656,14 +2656,14 @@ Checking test 061 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 390.215542
-The maximum resident set size (KB)                   = 892104
+The total amount of wall time                        = 392.328278
+The maximum resident set size (KB)                   = 892624
 
 Test 061 hrrr_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_qr_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_qr_intel
 Checking test 062 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2710,14 +2710,14 @@ Checking test 062 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 399.092579
-The maximum resident set size (KB)                   = 903140
+The total amount of wall time                        = 388.783688
+The maximum resident set size (KB)                   = 903460
 
 Test 062 hrrr_control_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_decomp_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_decomp_intel
 Checking test 063 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2764,14 +2764,14 @@ Checking test 063 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 411.866423
-The maximum resident set size (KB)                   = 893008
+The total amount of wall time                        = 426.706829
+The maximum resident set size (KB)                   = 895668
 
 Test 063 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_2threads_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_2threads_intel
 Checking test 064 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2818,42 +2818,42 @@ Checking test 064 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 359.111668
-The maximum resident set size (KB)                   = 964580
+The total amount of wall time                        = 364.293102
+The maximum resident set size (KB)                   = 964192
 
 Test 064 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_restart_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_restart_intel
 Checking test 065 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 288.647820
-The maximum resident set size (KB)                   = 642564
+The total amount of wall time                        = 288.401042
+The maximum resident set size (KB)                   = 638328
 
 Test 065 hrrr_control_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_restart_qr_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_restart_qr_intel
 Checking test 066 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 289.410482
-The maximum resident set size (KB)                   = 654484
+The total amount of wall time                        = 290.115834
+The maximum resident set size (KB)                   = 652868
 
 Test 066 hrrr_control_restart_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_v1beta_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_v1beta_intel
 Checking test 067 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2900,14 +2900,14 @@ Checking test 067 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 404.580768
-The maximum resident set size (KB)                   = 891220
+The total amount of wall time                        = 402.991421
+The maximum resident set size (KB)                   = 893140
 
 Test 067 rrfs_v1beta_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_v1nssl_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_v1nssl_intel
 Checking test 068 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2922,14 +2922,14 @@ Checking test 068 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 466.428684
-The maximum resident set size (KB)                   = 578292
+The total amount of wall time                        = 487.879551
+The maximum resident set size (KB)                   = 579464
 
 Test 068 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_v1nssl_nohailnoccn_intel
 Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2944,14 +2944,14 @@ Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 456.067478
-The maximum resident set size (KB)                   = 569076
+The total amount of wall time                        = 456.944842
+The maximum resident set size (KB)                   = 571452
 
 Test 069 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2967,15 +2967,31 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 149.196986
-The maximum resident set size (KB)                   = 802208
+The total amount of wall time                        = 166.319678
+The maximum resident set size (KB)                   = 799056
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_hrrr_warm_qr_intel
-Checking test 071 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
+
+The total amount of wall time                        = 123.581549
+The maximum resident set size (KB)                   = 803496
+
+Test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
+
+
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_conus13km_hrrr_warm_intel
+Checking test 072 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -2990,15 +3006,15 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 149.140240
-The maximum resident set size (KB)                   = 802392
+The total amount of wall time                        = 138.510954
+The maximum resident set size (KB)                   = 781880
 
-Test 071 rrfs_smoke_conus13km_hrrr_warm_qr_intel PASS
+Test 072 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
-Checking test 072 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_smoke_conus13km_radar_tten_warm_intel
+Checking test 073 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing sfcf002.nc .........OK
@@ -3006,78 +3022,27 @@ Checking test 072 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 104.936439
-The maximum resident set size (KB)                   = 807388
+The total amount of wall time                        = 168.469746
+The maximum resident set size (KB)                   = 800960
 
-Test 072 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
-
-
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_conus13km_hrrr_warm_intel
-Checking test 073 rrfs_conus13km_hrrr_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
- Comparing RESTART/20210512.170000.coupler.res .........OK
- Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
- Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
- Comparing RESTART/20210512.170000.sfc_data.nc .........OK
-
-The total amount of wall time                        = 135.370397
-The maximum resident set size (KB)                   = 783152
-
-Test 073 rrfs_conus13km_hrrr_warm_intel PASS
+Test 073 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_radar_tten_warm_intel
-Checking test 074 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
-
-The total amount of wall time                        = 149.134247
-The maximum resident set size (KB)                   = 800340
-
-Test 074 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
-
-
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-Checking test 075 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+Checking test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 95.780103
-The maximum resident set size (KB)                   = 793496
+The total amount of wall time                        = 98.405651
+The maximum resident set size (KB)                   = 793172
 
-Test 075 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
-
-
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel
-Checking test 076 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-The total amount of wall time                        = 98.395871
-The maximum resident set size (KB)                   = 796132
-
-Test 076 rrfs_smoke_conus13km_hrrr_warm_restart_qr_mismatch_intel PASS
+Test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmg_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_csawmg_intel
-Checking test 077 control_csawmg_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmg_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_csawmg_intel
+Checking test 075 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3087,15 +3052,15 @@ Checking test 077 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 341.759601
-The maximum resident set size (KB)                   = 584696
+The total amount of wall time                        = 341.425776
+The maximum resident set size (KB)                   = 586632
 
-Test 077 control_csawmg_intel PASS
+Test 075 control_csawmg_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_csawmgt_intel
-Checking test 078 control_csawmgt_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_csawmgt_intel
+Checking test 076 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3105,15 +3070,15 @@ Checking test 078 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 337.466167
-The maximum resident set size (KB)                   = 585876
+The total amount of wall time                        = 337.509960
+The maximum resident set size (KB)                   = 586792
 
-Test 078 control_csawmgt_intel PASS
+Test 076 control_csawmgt_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_ras_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_ras_intel
-Checking test 079 control_ras_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_ras_intel
+Checking test 077 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -3123,27 +3088,27 @@ Checking test 079 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 183.283723
-The maximum resident set size (KB)                   = 553556
+The total amount of wall time                        = 183.695179
+The maximum resident set size (KB)                   = 553500
 
-Test 079 control_ras_intel PASS
+Test 077 control_ras_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wam_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_wam_intel
-Checking test 080 control_wam_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_wam_intel
+Checking test 078 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 117.503844
-The maximum resident set size (KB)                   = 278552
+The total amount of wall time                        = 119.071306
+The maximum resident set size (KB)                   = 294852
 
-Test 080 control_wam_intel PASS
+Test 078 control_wam_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_p8_faster_intel
-Checking test 081 control_p8_faster_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_p8_faster_intel
+Checking test 079 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3189,15 +3154,15 @@ Checking test 081 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.003307
-The maximum resident set size (KB)                   = 1487796
+The total amount of wall time                        = 177.784381
+The maximum resident set size (KB)                   = 1486848
 
-Test 081 control_p8_faster_intel PASS
+Test 079 control_p8_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_control_faster_intel
-Checking test 082 regional_control_faster_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_control_faster_intel
+Checking test 080 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3207,57 +3172,57 @@ Checking test 082 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 272.469043
-The maximum resident set size (KB)                   = 658676
+The total amount of wall time                        = 274.166581
+The maximum resident set size (KB)                   = 655204
 
-Test 082 regional_control_faster_intel PASS
+Test 080 regional_control_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-Checking test 083 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 925.014278
-The maximum resident set size (KB)                   = 824952
+The total amount of wall time                        = 921.154304
+The maximum resident set size (KB)                   = 827084
 
-Test 083 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
+Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
-Checking test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 530.916606
-The maximum resident set size (KB)                   = 829972
+The total amount of wall time                        = 530.945181
+The maximum resident set size (KB)                   = 832308
 
-Test 084 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
+Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_conus13km_hrrr_warm_debug_intel
-Checking test 085 rrfs_conus13km_hrrr_warm_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_conus13km_hrrr_warm_debug_intel
+Checking test 083 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 817.873307
-The maximum resident set size (KB)                   = 808872
+The total amount of wall time                        = 820.442877
+The maximum resident set size (KB)                   = 807764
 
-Test 085 rrfs_conus13km_hrrr_warm_debug_intel PASS
+Test 083 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_CubedSphereGrid_debug_intel
-Checking test 086 control_CubedSphereGrid_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_CubedSphereGrid_debug_intel
+Checking test 084 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -3283,349 +3248,349 @@ Checking test 086 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 159.837597
-The maximum resident set size (KB)                   = 673824
+The total amount of wall time                        = 160.022638
+The maximum resident set size (KB)                   = 673852
 
-Test 086 control_CubedSphereGrid_debug_intel PASS
+Test 084 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_wrtGauss_netcdf_parallel_debug_intel
-Checking test 087 control_wrtGauss_netcdf_parallel_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_wrtGauss_netcdf_parallel_debug_intel
+Checking test 085 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.566936
-The maximum resident set size (KB)                   = 675692
+The total amount of wall time                        = 161.025086
+The maximum resident set size (KB)                   = 681692
 
-Test 087 control_wrtGauss_netcdf_parallel_debug_intel PASS
+Test 085 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_stochy_debug_intel
-Checking test 088 control_stochy_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_stochy_debug_intel
+Checking test 086 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 181.115925
-The maximum resident set size (KB)                   = 683256
+The total amount of wall time                        = 180.792761
+The maximum resident set size (KB)                   = 680544
 
-Test 088 control_stochy_debug_intel PASS
+Test 086 control_stochy_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_lndp_debug_intel
-Checking test 089 control_lndp_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_lndp_debug_intel
+Checking test 087 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.183366
-The maximum resident set size (KB)                   = 686272
+The total amount of wall time                        = 162.368477
+The maximum resident set size (KB)                   = 681028
 
-Test 089 control_lndp_debug_intel PASS
+Test 087 control_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_csawmg_debug_intel
-Checking test 090 control_csawmg_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_csawmg_debug_intel
+Checking test 088 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 261.880475
-The maximum resident set size (KB)                   = 717320
+The total amount of wall time                        = 256.083666
+The maximum resident set size (KB)                   = 717144
 
-Test 090 control_csawmg_debug_intel PASS
+Test 088 control_csawmg_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_csawmgt_debug_intel
-Checking test 091 control_csawmgt_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_csawmgt_debug_intel
+Checking test 089 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 258.634701
-The maximum resident set size (KB)                   = 717880
+The total amount of wall time                        = 252.771446
+The maximum resident set size (KB)                   = 719300
 
-Test 091 control_csawmgt_debug_intel PASS
+Test 089 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_ras_debug_intel
-Checking test 092 control_ras_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_ras_debug_intel
+Checking test 090 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.347493
-The maximum resident set size (KB)                   = 690808
+The total amount of wall time                        = 163.013956
+The maximum resident set size (KB)                   = 689596
 
-Test 092 control_ras_debug_intel PASS
+Test 090 control_ras_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_diag_debug_intel
-Checking test 093 control_diag_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_diag_debug_intel
+Checking test 091 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 164.784283
-The maximum resident set size (KB)                   = 735588
+The total amount of wall time                        = 164.977397
+The maximum resident set size (KB)                   = 738388
 
-Test 093 control_diag_debug_intel PASS
+Test 091 control_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_debug_p8_intel
-Checking test 094 control_debug_p8_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_debug_p8_intel
+Checking test 092 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 187.690676
-The maximum resident set size (KB)                   = 1507020
+The total amount of wall time                        = 186.987434
+The maximum resident set size (KB)                   = 1505180
 
-Test 094 control_debug_p8_intel PASS
+Test 092 control_debug_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_debug_intel
-Checking test 095 regional_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_debug_intel
+Checking test 093 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1047.414097
-The maximum resident set size (KB)                   = 673660
+The total amount of wall time                        = 1049.792230
+The maximum resident set size (KB)                   = 675280
 
-Test 095 regional_debug_intel PASS
+Test 093 regional_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_control_debug_intel
-Checking test 096 rap_control_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_control_debug_intel
+Checking test 094 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.752706
-The maximum resident set size (KB)                   = 1052220
+The total amount of wall time                        = 299.732915
+The maximum resident set size (KB)                   = 1051524
 
-Test 096 rap_control_debug_intel PASS
+Test 094 rap_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_debug_intel
-Checking test 097 hrrr_control_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_debug_intel
+Checking test 095 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.264392
-The maximum resident set size (KB)                   = 1046740
+The total amount of wall time                        = 295.500455
+The maximum resident set size (KB)                   = 1050900
 
-Test 097 hrrr_control_debug_intel PASS
+Test 095 hrrr_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_unified_drag_suite_debug_intel
-Checking test 098 rap_unified_drag_suite_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_unified_drag_suite_debug_intel
+Checking test 096 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.271140
-The maximum resident set size (KB)                   = 1054504
+The total amount of wall time                        = 299.245706
+The maximum resident set size (KB)                   = 1056612
 
-Test 098 rap_unified_drag_suite_debug_intel PASS
+Test 096 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_diag_debug_intel
-Checking test 099 rap_diag_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_diag_debug_intel
+Checking test 097 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 311.264963
-The maximum resident set size (KB)                   = 1135196
+The total amount of wall time                        = 310.441961
+The maximum resident set size (KB)                   = 1133888
 
-Test 099 rap_diag_debug_intel PASS
+Test 097 rap_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_cires_ugwp_debug_intel
-Checking test 100 rap_cires_ugwp_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_cires_ugwp_debug_intel
+Checking test 098 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.038724
-The maximum resident set size (KB)                   = 1055980
+The total amount of wall time                        = 305.764404
+The maximum resident set size (KB)                   = 1054620
 
-Test 100 rap_cires_ugwp_debug_intel PASS
+Test 098 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_unified_ugwp_debug_intel
-Checking test 101 rap_unified_ugwp_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_unified_ugwp_debug_intel
+Checking test 099 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 305.472168
-The maximum resident set size (KB)                   = 1054720
+The total amount of wall time                        = 305.262481
+The maximum resident set size (KB)                   = 1052260
 
-Test 101 rap_unified_ugwp_debug_intel PASS
+Test 099 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_lndp_debug_intel
-Checking test 102 rap_lndp_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_lndp_debug_intel
+Checking test 100 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.605463
-The maximum resident set size (KB)                   = 1054084
+The total amount of wall time                        = 302.582089
+The maximum resident set size (KB)                   = 1052152
 
-Test 102 rap_lndp_debug_intel PASS
+Test 100 rap_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_progcld_thompson_debug_intel
-Checking test 103 rap_progcld_thompson_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_progcld_thompson_debug_intel
+Checking test 101 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.274698
-The maximum resident set size (KB)                   = 1057352
+The total amount of wall time                        = 299.175753
+The maximum resident set size (KB)                   = 1054388
 
-Test 103 rap_progcld_thompson_debug_intel PASS
+Test 101 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_noah_debug_intel
-Checking test 104 rap_noah_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_noah_debug_intel
+Checking test 102 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.137690
-The maximum resident set size (KB)                   = 1054252
+The total amount of wall time                        = 299.475901
+The maximum resident set size (KB)                   = 1052104
 
-Test 104 rap_noah_debug_intel PASS
+Test 102 rap_noah_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_sfcdiff_debug_intel
-Checking test 105 rap_sfcdiff_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_sfcdiff_debug_intel
+Checking test 103 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.803499
-The maximum resident set size (KB)                   = 1055448
+The total amount of wall time                        = 300.742887
+The maximum resident set size (KB)                   = 1055988
 
-Test 105 rap_sfcdiff_debug_intel PASS
+Test 103 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_noah_sfcdiff_cires_ugwp_debug_intel
-Checking test 106 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_noah_sfcdiff_cires_ugwp_debug_intel
+Checking test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 489.412981
-The maximum resident set size (KB)                   = 1056776
+The total amount of wall time                        = 490.541049
+The maximum resident set size (KB)                   = 1054176
 
-Test 106 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
+Test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rrfs_v1beta_debug_intel
-Checking test 107 rrfs_v1beta_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rrfs_v1beta_debug_intel
+Checking test 105 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.956073
-The maximum resident set size (KB)                   = 1048720
+The total amount of wall time                        = 293.753907
+The maximum resident set size (KB)                   = 1050428
 
-Test 107 rrfs_v1beta_debug_intel PASS
+Test 105 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_clm_lake_debug_intel
-Checking test 108 rap_clm_lake_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_clm_lake_debug_intel
+Checking test 106 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 356.795173
-The maximum resident set size (KB)                   = 1058860
+The total amount of wall time                        = 356.115566
+The maximum resident set size (KB)                   = 1057244
 
-Test 108 rap_clm_lake_debug_intel PASS
+Test 106 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_flake_debug_intel
-Checking test 109 rap_flake_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_flake_debug_intel
+Checking test 107 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.729117
-The maximum resident set size (KB)                   = 1053272
+The total amount of wall time                        = 298.638551
+The maximum resident set size (KB)                   = 1054256
 
-Test 109 rap_flake_debug_intel PASS
+Test 107 rap_flake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_wam_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_wam_debug_intel
-Checking test 110 control_wam_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_wam_debug_intel
+Checking test 108 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 296.143253
-The maximum resident set size (KB)                   = 303276
+The total amount of wall time                        = 297.483546
+The maximum resident set size (KB)                   = 303144
 
-Test 110 control_wam_debug_intel PASS
+Test 108 control_wam_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
@@ -3635,15 +3600,15 @@ Checking test 111 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 227.949091
-The maximum resident set size (KB)                   = 892812
+The total amount of wall time                        = 230.902639
+The maximum resident set size (KB)                   = 891936
 
-Test 111 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+Test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_control_dyn32_phy32_intel
-Checking test 112 rap_control_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_control_dyn32_phy32_intel
+Checking test 110 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3689,15 +3654,15 @@ Checking test 112 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 338.632222
-The maximum resident set size (KB)                   = 773388
+The total amount of wall time                        = 338.875247
+The maximum resident set size (KB)                   = 776388
 
-Test 112 rap_control_dyn32_phy32_intel PASS
+Test 110 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_dyn32_phy32_intel
-Checking test 113 hrrr_control_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_dyn32_phy32_intel
+Checking test 111 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3743,15 +3708,15 @@ Checking test 113 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 178.736597
-The maximum resident set size (KB)                   = 774408
+The total amount of wall time                        = 179.623961
+The maximum resident set size (KB)                   = 774856
 
-Test 113 hrrr_control_dyn32_phy32_intel PASS
+Test 111 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_qr_dyn32_phy32_intel
-Checking test 114 hrrr_control_qr_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_qr_dyn32_phy32_intel
+Checking test 112 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3797,15 +3762,15 @@ Checking test 114 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 176.334860
-The maximum resident set size (KB)                   = 781520
+The total amount of wall time                        = 176.819372
+The maximum resident set size (KB)                   = 783860
 
-Test 114 hrrr_control_qr_dyn32_phy32_intel PASS
+Test 112 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_2threads_dyn32_phy32_intel
-Checking test 115 rap_2threads_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_2threads_dyn32_phy32_intel
+Checking test 113 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3851,15 +3816,15 @@ Checking test 115 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 306.254835
-The maximum resident set size (KB)                   = 831060
+The total amount of wall time                        = 306.811871
+The maximum resident set size (KB)                   = 833348
 
-Test 115 rap_2threads_dyn32_phy32_intel PASS
+Test 113 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 116 hrrr_control_2threads_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_2threads_dyn32_phy32_intel
+Checking test 114 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3905,15 +3870,15 @@ Checking test 116 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 168.558278
-The maximum resident set size (KB)                   = 821968
+The total amount of wall time                        = 162.757193
+The maximum resident set size (KB)                   = 815876
 
-Test 116 hrrr_control_2threads_dyn32_phy32_intel PASS
+Test 114 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 117 hrrr_control_decomp_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_decomp_dyn32_phy32_intel
+Checking test 115 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3959,15 +3924,15 @@ Checking test 117 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 193.061688
-The maximum resident set size (KB)                   = 773832
+The total amount of wall time                        = 190.426136
+The maximum resident set size (KB)                   = 775296
 
-Test 117 hrrr_control_decomp_dyn32_phy32_intel PASS
+Test 115 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_restart_dyn32_phy32_intel
-Checking test 118 rap_restart_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_restart_dyn32_phy32_intel
+Checking test 116 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -4005,43 +3970,43 @@ Checking test 118 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 248.666500
-The maximum resident set size (KB)                   = 611540
+The total amount of wall time                        = 249.632330
+The maximum resident set size (KB)                   = 609376
 
-Test 118 rap_restart_dyn32_phy32_intel PASS
+Test 116 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_restart_dyn32_phy32_intel
-Checking test 119 hrrr_control_restart_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_restart_dyn32_phy32_intel
+Checking test 117 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 93.717821
-The maximum resident set size (KB)                   = 607044
+The total amount of wall time                        = 93.668252
+The maximum resident set size (KB)                   = 604048
 
-Test 119 hrrr_control_restart_dyn32_phy32_intel PASS
+Test 117 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_restart_qr_dyn32_phy32_intel
-Checking test 120 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 118 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 93.492328
-The maximum resident set size (KB)                   = 624440
+The total amount of wall time                        = 93.633493
+The maximum resident set size (KB)                   = 623176
 
-Test 120 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+Test 118 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_control_dyn64_phy32_intel
-Checking test 121 rap_control_dyn64_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_control_dyn64_phy32_intel
+Checking test 119 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4087,82 +4052,82 @@ Checking test 121 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 228.884409
-The maximum resident set size (KB)                   = 801604
+The total amount of wall time                        = 230.738891
+The maximum resident set size (KB)                   = 799988
 
-Test 121 rap_control_dyn64_phy32_intel PASS
+Test 119 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_control_debug_dyn32_phy32_intel
-Checking test 122 rap_control_debug_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_control_debug_dyn32_phy32_intel
+Checking test 120 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.208846
-The maximum resident set size (KB)                   = 941464
+The total amount of wall time                        = 299.891723
+The maximum resident set size (KB)                   = 943980
 
-Test 122 rap_control_debug_dyn32_phy32_intel PASS
+Test 120 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hrrr_control_debug_dyn32_phy32_intel
-Checking test 123 hrrr_control_debug_dyn32_phy32_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hrrr_control_debug_dyn32_phy32_intel
+Checking test 121 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.795118
-The maximum resident set size (KB)                   = 940492
+The total amount of wall time                        = 291.323041
+The maximum resident set size (KB)                   = 938000
 
-Test 123 hrrr_control_debug_dyn32_phy32_intel PASS
+Test 121 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/rap_control_dyn64_phy32_debug_intel
-Checking test 124 rap_control_dyn64_phy32_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/rap_control_dyn64_phy32_debug_intel
+Checking test 122 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.782362
-The maximum resident set size (KB)                   = 961224
+The total amount of wall time                        = 298.098794
+The maximum resident set size (KB)                   = 961564
 
-Test 124 rap_control_dyn64_phy32_debug_intel PASS
+Test 122 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_atm_intel
-Checking test 125 hafs_regional_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_atm_intel
+Checking test 123 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 255.560971
-The maximum resident set size (KB)                   = 823216
+The total amount of wall time                        = 257.634321
+The maximum resident set size (KB)                   = 822636
 
-Test 125 hafs_regional_atm_intel PASS
+Test 123 hafs_regional_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_atm_thompson_gfdlsf_intel
-Checking test 126 hafs_regional_atm_thompson_gfdlsf_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_atm_thompson_gfdlsf_intel
+Checking test 124 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 307.690917
-The maximum resident set size (KB)                   = 1185468
+The total amount of wall time                        = 317.731250
+The maximum resident set size (KB)                   = 1176748
 
-Test 126 hafs_regional_atm_thompson_gfdlsf_intel PASS
+Test 124 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_atm_ocn_intel
-Checking test 127 hafs_regional_atm_ocn_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_atm_ocn_intel
+Checking test 125 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4170,15 +4135,15 @@ Checking test 127 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 385.364353
-The maximum resident set size (KB)                   = 859300
+The total amount of wall time                        = 387.296226
+The maximum resident set size (KB)                   = 860224
 
-Test 127 hafs_regional_atm_ocn_intel PASS
+Test 125 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_atm_wav_intel
-Checking test 128 hafs_regional_atm_wav_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_atm_wav_intel
+Checking test 126 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing 20190829.060000.out_grd.ww3 .........OK
@@ -4186,15 +4151,15 @@ Checking test 128 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 707.715931
-The maximum resident set size (KB)                   = 891348
+The total amount of wall time                        = 708.827153
+The maximum resident set size (KB)                   = 889144
 
-Test 128 hafs_regional_atm_wav_intel PASS
+Test 126 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_atm_ocn_wav_intel
-Checking test 129 hafs_regional_atm_ocn_wav_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_atm_ocn_wav_intel
+Checking test 127 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
@@ -4204,15 +4169,15 @@ Checking test 129 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 906.256712
-The maximum resident set size (KB)                   = 915440
+The total amount of wall time                        = 904.461919
+The maximum resident set size (KB)                   = 913556
 
-Test 129 hafs_regional_atm_ocn_wav_intel PASS
+Test 127 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_1nest_atm_intel
-Checking test 130 hafs_regional_1nest_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_1nest_atm_intel
+Checking test 128 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4233,15 +4198,15 @@ Checking test 130 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 306.829100
-The maximum resident set size (KB)                   = 394172
+The total amount of wall time                        = 310.562318
+The maximum resident set size (KB)                   = 391340
 
-Test 130 hafs_regional_1nest_atm_intel PASS
+Test 128 hafs_regional_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_1nest_atm_qr_intel
-Checking test 131 hafs_regional_1nest_atm_qr_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_1nest_atm_qr_intel
+Checking test 129 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4262,15 +4227,15 @@ Checking test 131 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 331.963658
-The maximum resident set size (KB)                   = 367292
+The total amount of wall time                        = 333.034199
+The maximum resident set size (KB)                   = 371116
 
-Test 131 hafs_regional_1nest_atm_qr_intel PASS
+Test 129 hafs_regional_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_telescopic_2nests_atm_intel
-Checking test 132 hafs_regional_telescopic_2nests_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_telescopic_2nests_atm_intel
+Checking test 130 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4278,15 +4243,15 @@ Checking test 132 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 371.470338
-The maximum resident set size (KB)                   = 403244
+The total amount of wall time                        = 372.512675
+The maximum resident set size (KB)                   = 400616
 
-Test 132 hafs_regional_telescopic_2nests_atm_intel PASS
+Test 130 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_global_1nest_atm_intel
-Checking test 133 hafs_global_1nest_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_global_1nest_atm_intel
+Checking test 131 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4332,15 +4297,15 @@ Checking test 133 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 161.626368
-The maximum resident set size (KB)                   = 262408
+The total amount of wall time                        = 161.266033
+The maximum resident set size (KB)                   = 264388
 
-Test 133 hafs_global_1nest_atm_intel PASS
+Test 131 hafs_global_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_global_1nest_atm_qr_intel
-Checking test 134 hafs_global_1nest_atm_qr_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_global_1nest_atm_qr_intel
+Checking test 132 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4386,15 +4351,15 @@ Checking test 134 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 168.409714
-The maximum resident set size (KB)                   = 274440
+The total amount of wall time                        = 170.133017
+The maximum resident set size (KB)                   = 276812
 
-Test 134 hafs_global_1nest_atm_qr_intel PASS
+Test 132 hafs_global_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_global_multiple_4nests_atm_intel
-Checking test 135 hafs_global_multiple_4nests_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_global_multiple_4nests_atm_intel
+Checking test 133 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4475,15 +4440,15 @@ Checking test 135 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 461.959904
-The maximum resident set size (KB)                   = 343996
+The total amount of wall time                        = 461.165251
+The maximum resident set size (KB)                   = 345592
 
-Test 135 hafs_global_multiple_4nests_atm_intel PASS
+Test 133 hafs_global_multiple_4nests_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_global_multiple_4nests_atm_qr_intel
-Checking test 136 hafs_global_multiple_4nests_atm_qr_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_multiple_4nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_global_multiple_4nests_atm_qr_intel
+Checking test 134 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4564,15 +4529,15 @@ Checking test 136 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 512.193064
-The maximum resident set size (KB)                   = 373836
+The total amount of wall time                        = 512.610560
+The maximum resident set size (KB)                   = 372640
 
-Test 136 hafs_global_multiple_4nests_atm_qr_intel PASS
+Test 134 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_specified_moving_1nest_atm_intel
-Checking test 137 hafs_regional_specified_moving_1nest_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_specified_moving_1nest_atm_intel
+Checking test 135 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4580,15 +4545,15 @@ Checking test 137 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 206.156476
-The maximum resident set size (KB)                   = 407392
+The total amount of wall time                        = 209.091645
+The maximum resident set size (KB)                   = 405044
 
-Test 137 hafs_regional_specified_moving_1nest_atm_intel PASS
+Test 135 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_storm_following_1nest_atm_intel
-Checking test 138 hafs_regional_storm_following_1nest_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_storm_following_1nest_atm_intel
+Checking test 136 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4609,15 +4574,15 @@ Checking test 138 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 194.292486
-The maximum resident set size (KB)                   = 405764
+The total amount of wall time                        = 195.517495
+The maximum resident set size (KB)                   = 409932
 
-Test 138 hafs_regional_storm_following_1nest_atm_intel PASS
+Test 136 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_storm_following_1nest_atm_qr_intel
-Checking test 139 hafs_regional_storm_following_1nest_atm_qr_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_storm_following_1nest_atm_qr_intel
+Checking test 137 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4638,15 +4603,15 @@ Checking test 139 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 219.072455
-The maximum resident set size (KB)                   = 391660
+The total amount of wall time                        = 220.392042
+The maximum resident set size (KB)                   = 396636
 
-Test 139 hafs_regional_storm_following_1nest_atm_qr_intel PASS
+Test 137 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_storm_following_1nest_atm_ocn_intel
-Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_storm_following_1nest_atm_ocn_intel
+Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4654,43 +4619,43 @@ Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 250.070849
-The maximum resident set size (KB)                   = 468552
+The total amount of wall time                        = 252.865237
+The maximum resident set size (KB)                   = 475656
 
-Test 140 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
+Test 138 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_global_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_global_storm_following_1nest_atm_intel
-Checking test 141 hafs_global_storm_following_1nest_atm_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_global_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_global_storm_following_1nest_atm_intel
+Checking test 139 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 82.594236
-The maximum resident set size (KB)                   = 281216
+The total amount of wall time                        = 83.071636
+The maximum resident set size (KB)                   = 280812
 
-Test 141 hafs_global_storm_following_1nest_atm_intel PASS
+Test 139 hafs_global_storm_following_1nest_atm_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 802.828145
-The maximum resident set size (KB)                   = 495024
+The total amount of wall time                        = 802.147117
+The maximum resident set size (KB)                   = 495192
 
-Test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
+Test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
@@ -4700,15 +4665,15 @@ Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 504.863586
-The maximum resident set size (KB)                   = 522412
+The total amount of wall time                        = 505.284025
+The maximum resident set size (KB)                   = 530076
 
-Test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
+Test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/control_p8_atmlnd_sbs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/control_p8_atmlnd_sbs_intel
-Checking test 144 control_p8_atmlnd_sbs_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/control_p8_atmlnd_sbs_intel
+Checking test 142 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
  Comparing sfcf000.tile3.nc .........OK
@@ -4792,15 +4757,15 @@ Checking test 144 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 237.480903
-The maximum resident set size (KB)                   = 1543924
+The total amount of wall time                        = 243.790351
+The maximum resident set size (KB)                   = 1545468
 
-Test 144 control_p8_atmlnd_sbs_intel PASS
+Test 142 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/atmaero_control_p8_intel
-Checking test 145 atmaero_control_p8_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/atmaero_control_p8_intel
+Checking test 143 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4843,15 +4808,15 @@ Checking test 145 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 251.231901
-The maximum resident set size (KB)                   = 2817160
+The total amount of wall time                        = 246.685617
+The maximum resident set size (KB)                   = 2815916
 
-Test 145 atmaero_control_p8_intel PASS
+Test 143 atmaero_control_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/atmaero_control_p8_rad_intel
-Checking test 146 atmaero_control_p8_rad_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/atmaero_control_p8_rad_intel
+Checking test 144 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4894,15 +4859,15 @@ Checking test 146 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 288.241822
-The maximum resident set size (KB)                   = 2879960
+The total amount of wall time                        = 285.395560
+The maximum resident set size (KB)                   = 2877732
 
-Test 146 atmaero_control_p8_rad_intel PASS
+Test 144 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/atmaero_control_p8_rad_micro_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/atmaero_control_p8_rad_micro_intel
-Checking test 147 atmaero_control_p8_rad_micro_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/atmaero_control_p8_rad_micro_intel
+Checking test 145 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4945,15 +4910,15 @@ Checking test 147 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 288.598720
-The maximum resident set size (KB)                   = 2887904
+The total amount of wall time                        = 291.801240
+The maximum resident set size (KB)                   = 2887244
 
-Test 147 atmaero_control_p8_rad_micro_intel PASS
+Test 145 atmaero_control_p8_rad_micro_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_atmaq_intel
-Checking test 148 regional_atmaq_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_atmaq_intel
+Checking test 146 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4968,15 +4933,15 @@ Checking test 148 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 682.470218
-The maximum resident set size (KB)                   = 1257720
+The total amount of wall time                        = 678.178746
+The maximum resident set size (KB)                   = 1257052
 
-Test 148 regional_atmaq_intel PASS
+Test 146 regional_atmaq_intel PASS
 
 
-baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230616/regional_atmaq_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_185682/regional_atmaq_debug_intel
-Checking test 149 regional_atmaq_debug_intel results ....
+baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230621/regional_atmaq_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_14064/regional_atmaq_debug_intel
+Checking test 147 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
@@ -4989,12 +4954,12 @@ Checking test 149 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1302.149122
-The maximum resident set size (KB)                   = 1288864
+The total amount of wall time                        = 1297.983836
+The maximum resident set size (KB)                   = 1293816
 
-Test 149 regional_atmaq_debug_intel PASS
+Test 147 regional_atmaq_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Jun 20 16:50:22 UTC 2023
-Elapsed time: 01h:39m:51s. Have a nice day!
+Fri Jun 23 13:16:54 UTC 2023
+Elapsed time: 01h:07m:35s. Have a nice day!

--- a/tests/parm/datm.streams.IN
+++ b/tests/parm/datm.streams.IN
@@ -4,7 +4,7 @@ mapalgo01:                 bilinear
 tInterpAlgo01:             linear
 readMode01:                single
 dtlimit01:                 1.0
-stream_offset01:           0
+stream_offset01:           @[STREAM_OFFSET]
 yearFirst01:               @[SYEAR]
 yearLast01:                @[SYEAR]
 yearAlign01:               @[SYEAR]

--- a/tests/parm/nems.configure.datm_cdeps.IN
+++ b/tests/parm/nems.configure.datm_cdeps.IN
@@ -91,8 +91,8 @@ DRIVER_attributes::
 ::
 
 MED_attributes::
-      Verbosity = 5
-      dbug_flag = 5
+      Verbosity = 0
+      dbug_flag = 0
       ATM_model = @[atm_model]
       ICE_model = @[ice_model]
       OCN_model = @[ocn_model]

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -607,11 +607,6 @@ if [[ $ECFLOW == true ]]; then
     MAX_BUILDS=1
   fi
 
-  if [[ $MACHINE_ID = hera ]] && [[ ! $HOSTNAME = hecflow* ]]; then
-    echo "ERROR: To use ECFlow on Hera we must be logged into 'hecflow01' login node."
-    exit 1
-  fi
-
   ECFLOW_RUN=${PATHRT}/ecflow_run
   ECFLOW_SUITE=regtest_$$
   rm -rf ${ECFLOW_RUN}
@@ -645,13 +640,6 @@ EOF
     QUEUE=regular
   else
     die "ecFlow is not supported on this machine $MACHINE_ID"
-  fi
-
-else
-
-  if [[ $MACHINE_ID = hera ]] && [[ $HOSTNAME = hecflow* ]]; then
-    echo "ERROR: To run without using ECFlow on Hera, please do not use ecflow node."
-    exit 1
   fi
 
 fi

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -626,9 +626,6 @@ EOF
 
 ecflow_run() {
 
-  # in rare instances when UID is greater then 58500 (like Ratko's UID on theia)
-  [[ $ECF_PORT -gt 49151 ]] && ECF_PORT=12179
-
   ECF_HOST="${ECF_HOST:-$HOSTNAME}"
 
   set +e
@@ -646,9 +643,9 @@ ecflow_run() {
       fi
       MYCOMM="bash -l -c \"module load ecflow && ecflow_start.sh -p ${ECF_PORT} \""
       ssh $ECF_HOST "${MYCOMM}"
-    elif [[ ${MACHINE_ID} == jet ]]; then
+    elif [[ ${MACHINE_ID} == hera || ${MACHINE_ID} == jet ]]; then
       module load ecflow
-      echo "Using special Jet ECFLOW start procedure"
+      echo "On ${MACHINE_ID}, start ecFlow server on dedicated node ${ECF_HOST}"
       MYCOMM="bash -l -c \"module load ecflow && ${ECFLOW_START} -d ${RUNDIR_ROOT}/ecflow_server\""
       ssh $ECF_HOST "${MYCOMM}"
     else

--- a/tests/tests/datm_cdeps_bulk_gefs
+++ b/tests/tests/datm_cdeps_bulk_gefs
@@ -23,6 +23,7 @@ export FILENAME_BASE='gefs.'
 export mesh_file="gefs_mesh.nc"
 export MESH_ATM="DATM_INPUT/${mesh_file}"
 export stream_files="DATM_INPUT/${FILENAME_BASE}201110.nc"
+export STREAM_OFFSET=-21600
 
 export RESTART_N=12
 export flux_scheme='-1'

--- a/tests/tests/datm_cdeps_control_gefs
+++ b/tests/tests/datm_cdeps_control_gefs
@@ -24,6 +24,7 @@ export FILENAME_BASE='gefs.'
 export mesh_file="gefs_mesh.nc"
 export MESH_ATM="DATM_INPUT/${mesh_file}"
 export stream_files="DATM_INPUT/${FILENAME_BASE}201110.nc"
+export STREAM_OFFSET=-21600
 export RESTART_N=12
 export eps_imesh='2.5e-1'
 export TOPOEDITS=ufs.topo_edits_011818.nc

--- a/tests/tests/datm_cdeps_iau_gefs
+++ b/tests/tests/datm_cdeps_iau_gefs
@@ -25,6 +25,7 @@ export FILENAME_BASE='gefs.'
 export mesh_file="gefs_mesh.nc"
 export MESH_ATM="DATM_INPUT/${mesh_file}"
 export stream_files="DATM_INPUT/${FILENAME_BASE}201110.nc"
+export STREAM_OFFSET=-21600
 export RESTART_N=12
 export eps_imesh='2.5e-1'
 export TOPOEDITS=ufs.topo_edits_011818.nc

--- a/tests/tests/datm_cdeps_mx025_gefs
+++ b/tests/tests/datm_cdeps_mx025_gefs
@@ -31,6 +31,7 @@ export FILENAME_BASE='gefs.'
 export mesh_file="gefs_mesh.nc"
 export MESH_ATM="DATM_INPUT/${mesh_file}"
 export stream_files="DATM_INPUT/${FILENAME_BASE}201110.nc"
+export STREAM_OFFSET=-21600
 
 ATM_compute_tasks=${ATM_compute_tasks_cdeps_025}
 OCN_tasks=${OCN_tasks_cdeps_025}

--- a/tests/tests/datm_cdeps_stochy_gefs
+++ b/tests/tests/datm_cdeps_stochy_gefs
@@ -24,6 +24,7 @@ export FILENAME_BASE='gefs.'
 export mesh_file="gefs_mesh.nc"
 export MESH_ATM="DATM_INPUT/${mesh_file}"
 export stream_files="DATM_INPUT/${FILENAME_BASE}201110.nc"
+export STREAM_OFFSET=-21600
 export RESTART_N=12
 export eps_imesh='2.5e-1'
 export FV3_RUN=cpld_datm_cdeps.IN


### PR DESCRIPTION
## Description
The shortwave radiation fields in the GEFS forcing file show that the maximum incoming shortwave radiation fields do not occur at local noon but at 18:00 local time. The stream_offset parameter in the datm.streams file will be used to make the 6-hour time shift.

### Input data additions/changes
- [x] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Anticipated changes to regression tests:
- [ ] No changes are expected to any regression test.
- [x] Changes are expected to the following tests:
datm_cdeps_control_gefs
datm_cdeps_iau_gefs
datm_cdeps_stochy_gefs
datm_cdeps_bulk_gefs
datm_cdeps_mx025_gefs

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [x] none

### Combined with PR's (If Applicable):

## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [x] Link PR's from all sub-components involved in section below
- [x] Confirm reviews completed in ALL sub-component PR's
- [x] Add all appropriate labels to this PR.
- [x] Run full RT suite on either Hera/Cheyenne AND attach log to a PR comment.
- [x] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
- Closes #1770 


## Testing Day Checklist:
<!--
Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.
-->
- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - [x] Hera
  - [x] Orion
  - [x] Jet
  - [x] Gaea
  - [x] Cheyenne
- WCOSS2
  - [x] Dogwood/Cactus
  - [x] Acorn
- CI
  - [x] Completed
- opnReqTest
  - [ ] N/A
  - [x] Log attached to comment
RegressionTests_hera