### PR TITLE
Move unused ccpp suites to 'suites_not_used' directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/DusanJovic-NOAA/fv3atm
-  branch = unused_ccpp_suites
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/DusanJovic-NOAA/fv3atm
+  branch = unused_ccpp_suites
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/logs/RegressionTests_acorn.log
+++ b/tests/logs/RegressionTests_acorn.log
@@ -1,54 +1,54 @@
-Mon Jun 26 14:05:07 UTC 2023
+Wed Jun 28 13:45:52 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: eb51ae1a92f27efc83117fcff3ab5be62d887b37
+Testing UFSWM Hash: ba897e418f82f1c0a1b787c52b198706c8c7f7ed
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
+ 596f540cff635a802d07cacf652d49b30d62ea6e ../FV3 (remotes/origin/unused_ccpp_suites)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 1249 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 587 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 691 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 1042 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 521 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 630 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 1504 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 893 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1130 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 492 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 997 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 570 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 1183 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 1063 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 734 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 581 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 561 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 381 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 929 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 460 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 832 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 689 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 256 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 029 elapsed time 166 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 684 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 911 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 499 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 1023 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 866 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 533 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 625 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 582 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 559 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 543 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 1309 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1084 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1068 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 985 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 436 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DREQUIRE_IFI=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 475 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 1199 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 1098 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 721 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 576 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 794 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 913 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 533 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 319 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 657 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 242 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 643 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 526 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 495 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 029 elapsed time 316 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 383 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 659 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 809 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 663 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 480 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 471 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 260 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_mixedmode_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_p8_mixedmode_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -113,14 +113,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 332.092128
-The maximum resident set size (KB)                   = 2948164
+The total amount of wall time                        = 326.162795
+The maximum resident set size (KB)                   = 2945616
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_gfsv17_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_gfsv17_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -184,14 +184,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 253.179709
-The maximum resident set size (KB)                   = 1547552
+The total amount of wall time                        = 245.398890
+The maximum resident set size (KB)                   = 1557632
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -256,14 +256,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 389.992931
-The maximum resident set size (KB)                   = 2977560
+The total amount of wall time                        = 374.143023
+The maximum resident set size (KB)                   = 2972892
 
 Test 003 cpld_control_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_restart_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -316,14 +316,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 234.469561
-The maximum resident set size (KB)                   = 2864516
+The total amount of wall time                        = 222.761424
+The maximum resident set size (KB)                   = 2862924
 
 Test 004 cpld_restart_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -388,14 +388,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 388.753865
-The maximum resident set size (KB)                   = 2988064
+The total amount of wall time                        = 378.333391
+The maximum resident set size (KB)                   = 2984300
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_restart_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -448,14 +448,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 232.921989
-The maximum resident set size (KB)                   = 2881236
+The total amount of wall time                        = 224.481279
+The maximum resident set size (KB)                   = 2872432
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_2threads_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -508,14 +508,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 366.681512
-The maximum resident set size (KB)                   = 3282684
+The total amount of wall time                        = 355.257832
+The maximum resident set size (KB)                   = 3279916
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_decomp_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -568,14 +568,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 384.971257
-The maximum resident set size (KB)                   = 2978204
+The total amount of wall time                        = 370.205939
+The maximum resident set size (KB)                   = 2972424
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_mpi_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -628,14 +628,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 320.883571
-The maximum resident set size (KB)                   = 2907624
+The total amount of wall time                        = 310.300088
+The maximum resident set size (KB)                   = 2901212
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_ciceC_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_ciceC_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -700,14 +700,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.098063
-The maximum resident set size (KB)                   = 2977776
+The total amount of wall time                        = 376.007162
+The maximum resident set size (KB)                   = 2971076
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_noaero_p8_intel
 Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -771,14 +771,14 @@ Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 285.015257
-The maximum resident set size (KB)                   = 1572044
+The total amount of wall time                        = 274.556691
+The maximum resident set size (KB)                   = 1572956
 
 Test 011 cpld_control_noaero_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_nowave_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_nowave_noaero_p8_intel
 Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -840,14 +840,14 @@ Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 299.000310
-The maximum resident set size (KB)                   = 1621780
+The total amount of wall time                        = 287.525273
+The maximum resident set size (KB)                   = 1623592
 
 Test 012 cpld_control_nowave_noaero_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_agrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_noaero_p8_agrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_noaero_p8_agrid_intel
 Checking test 013 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -909,14 +909,14 @@ Checking test 013 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 306.412663
-The maximum resident set size (KB)                   = 1619884
+The total amount of wall time                        = 296.554059
+The maximum resident set size (KB)                   = 1628044
 
 Test 013 cpld_control_noaero_p8_agrid_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_c48_intel
 Checking test 014 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -966,14 +966,14 @@ Checking test 014 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 433.703175
-The maximum resident set size (KB)                   = 2623932
+The total amount of wall time                        = 428.217336
+The maximum resident set size (KB)                   = 2624776
 
 Test 014 cpld_control_c48_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_warmstart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_warmstart_c48_intel
 Checking test 015 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1023,14 +1023,14 @@ Checking test 015 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 123.236596
-The maximum resident set size (KB)                   = 2638544
+The total amount of wall time                        = 116.455501
+The maximum resident set size (KB)                   = 2637656
 
 Test 015 cpld_warmstart_c48_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_restart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_restart_c48_intel
 Checking test 016 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1080,14 +1080,14 @@ Checking test 016 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 67.673211
-The maximum resident set size (KB)                   = 2046540
+The total amount of wall time                        = 61.356407
+The maximum resident set size (KB)                   = 2050404
 
 Test 016 cpld_restart_c48_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/cpld_control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/cpld_control_p8_faster_intel
 Checking test 017 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1152,14 +1152,14 @@ Checking test 017 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 377.563748
-The maximum resident set size (KB)                   = 2982808
+The total amount of wall time                        = 368.112988
+The maximum resident set size (KB)                   = 2974440
 
 Test 017 cpld_control_p8_faster_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_flake_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_flake_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_flake_intel
 Checking test 018 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1170,14 +1170,14 @@ Checking test 018 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 214.347875
-The maximum resident set size (KB)                   = 564648
+The total amount of wall time                        = 212.732433
+The maximum resident set size (KB)                   = 566692
 
 Test 018 control_flake_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_CubedSphereGrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_CubedSphereGrid_intel
 Checking test 019 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1204,14 +1204,14 @@ Checking test 019 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 130.404193
-The maximum resident set size (KB)                   = 513156
+The total amount of wall time                        = 128.983789
+The maximum resident set size (KB)                   = 515256
 
 Test 019 control_CubedSphereGrid_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_latlon_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_latlon_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_latlon_intel
 Checking test 020 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1222,14 +1222,14 @@ Checking test 020 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 133.638908
-The maximum resident set size (KB)                   = 511208
+The total amount of wall time                        = 131.993983
+The maximum resident set size (KB)                   = 514824
 
 Test 020 control_latlon_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_wrtGauss_netcdf_parallel_intel
 Checking test 021 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1240,14 +1240,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 134.252729
-The maximum resident set size (KB)                   = 513600
+The total amount of wall time                        = 134.781228
+The maximum resident set size (KB)                   = 514652
 
 Test 021 control_wrtGauss_netcdf_parallel_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_c48_intel
 Checking test 022 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1286,14 +1286,14 @@ Checking test 022 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 330.174810
-The maximum resident set size (KB)                   = 669956
+The total amount of wall time                        = 328.727033
+The maximum resident set size (KB)                   = 673416
 
 Test 022 control_c48_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c192_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_c192_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_c192_intel
 Checking test 023 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1304,14 +1304,14 @@ Checking test 023 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 529.285097
-The maximum resident set size (KB)                   = 614912
+The total amount of wall time                        = 524.069463
+The maximum resident set size (KB)                   = 615808
 
 Test 023 control_c192_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c384_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_c384_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_c384_intel
 Checking test 024 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1322,14 +1322,14 @@ Checking test 024 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 568.422174
-The maximum resident set size (KB)                   = 926920
+The total amount of wall time                        = 562.349968
+The maximum resident set size (KB)                   = 923740
 
 Test 024 control_c384_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c384gdas_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_c384gdas_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_c384gdas_intel
 Checking test 025 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1372,14 +1372,14 @@ Checking test 025 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 513.704639
-The maximum resident set size (KB)                   = 1056740
+The total amount of wall time                        = 489.524195
+The maximum resident set size (KB)                   = 1057756
 
 Test 025 control_c384gdas_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_stochy_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_stochy_intel
 Checking test 026 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1390,28 +1390,28 @@ Checking test 026 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 90.207012
-The maximum resident set size (KB)                   = 522328
+The total amount of wall time                        = 89.927383
+The maximum resident set size (KB)                   = 519216
 
 Test 026 control_stochy_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_stochy_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_stochy_restart_intel
 Checking test 027 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 49.882186
-The maximum resident set size (KB)                   = 287456
+The total amount of wall time                        = 49.236323
+The maximum resident set size (KB)                   = 288908
 
 Test 027 control_stochy_restart_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_lndp_intel
 Checking test 028 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1422,14 +1422,14 @@ Checking test 028 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 84.293616
-The maximum resident set size (KB)                   = 517508
+The total amount of wall time                        = 83.735190
+The maximum resident set size (KB)                   = 518716
 
 Test 028 control_lndp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_iovr4_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_iovr4_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_iovr4_intel
 Checking test 029 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1444,14 +1444,14 @@ Checking test 029 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 136.345982
-The maximum resident set size (KB)                   = 510800
+The total amount of wall time                        = 134.948657
+The maximum resident set size (KB)                   = 516064
 
 Test 029 control_iovr4_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_iovr5_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_iovr5_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_iovr5_intel
 Checking test 030 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1466,14 +1466,14 @@ Checking test 030 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.787824
-The maximum resident set size (KB)                   = 513876
+The total amount of wall time                        = 135.054710
+The maximum resident set size (KB)                   = 516388
 
 Test 030 control_iovr5_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_p8_intel
 Checking test 031 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1520,14 +1520,14 @@ Checking test 031 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 180.161926
-The maximum resident set size (KB)                   = 1486564
+The total amount of wall time                        = 171.165382
+The maximum resident set size (KB)                   = 1487948
 
 Test 031 control_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_restart_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_restart_p8_intel
 Checking test 032 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1566,14 +1566,14 @@ Checking test 032 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 99.016426
-The maximum resident set size (KB)                   = 653420
+The total amount of wall time                        = 93.008576
+The maximum resident set size (KB)                   = 652016
 
 Test 032 control_restart_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_qr_p8_intel
 Checking test 033 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1620,14 +1620,14 @@ Checking test 033 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 176.162224
-The maximum resident set size (KB)                   = 1497700
+The total amount of wall time                        = 167.821926
+The maximum resident set size (KB)                   = 1500336
 
 Test 033 control_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_restart_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_restart_qr_p8_intel
 Checking test 034 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1666,14 +1666,14 @@ Checking test 034 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 98.465978
-The maximum resident set size (KB)                   = 666176
+The total amount of wall time                        = 92.377691
+The maximum resident set size (KB)                   = 669632
 
 Test 034 control_restart_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_decomp_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_decomp_p8_intel
 Checking test 035 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1716,14 +1716,14 @@ Checking test 035 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 181.726786
-The maximum resident set size (KB)                   = 1485756
+The total amount of wall time                        = 173.939457
+The maximum resident set size (KB)                   = 1483484
 
 Test 035 control_decomp_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_2threads_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_2threads_p8_intel
 Checking test 036 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1766,14 +1766,14 @@ Checking test 036 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 154.735645
-The maximum resident set size (KB)                   = 1573288
+The total amount of wall time                        = 146.862759
+The maximum resident set size (KB)                   = 1570728
 
 Test 036 control_2threads_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_p8_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_p8_lndp_intel
 Checking test 037 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1792,14 +1792,14 @@ Checking test 037 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 317.836194
-The maximum resident set size (KB)                   = 1487252
+The total amount of wall time                        = 310.788755
+The maximum resident set size (KB)                   = 1484120
 
 Test 037 control_p8_lndp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_rrtmgp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_p8_rrtmgp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_p8_rrtmgp_intel
 Checking test 038 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1846,14 +1846,14 @@ Checking test 038 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 233.459278
-The maximum resident set size (KB)                   = 1546200
+The total amount of wall time                        = 227.001630
+The maximum resident set size (KB)                   = 1548504
 
 Test 038 control_p8_rrtmgp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_mynn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_p8_mynn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_p8_mynn_intel
 Checking test 039 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1900,14 +1900,14 @@ Checking test 039 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 178.383793
-The maximum resident set size (KB)                   = 1492304
+The total amount of wall time                        = 172.632279
+The maximum resident set size (KB)                   = 1492344
 
 Test 039 control_p8_mynn_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/merra2_thompson_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/merra2_thompson_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/merra2_thompson_intel
 Checking test 040 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1954,14 +1954,14 @@ Checking test 040 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 201.655979
-The maximum resident set size (KB)                   = 1494200
+The total amount of wall time                        = 195.081545
+The maximum resident set size (KB)                   = 1493340
 
 Test 040 merra2_thompson_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_control_intel
 Checking test 041 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1972,28 +1972,28 @@ Checking test 041 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 281.873171
-The maximum resident set size (KB)                   = 650664
+The total amount of wall time                        = 276.125349
+The maximum resident set size (KB)                   = 649788
 
 Test 041 regional_control_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_restart_intel
 Checking test 042 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 149.797833
-The maximum resident set size (KB)                   = 651324
+The total amount of wall time                        = 147.953131
+The maximum resident set size (KB)                   = 650360
 
 Test 042 regional_restart_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_control_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_control_qr_intel
 Checking test 043 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2004,28 +2004,28 @@ Checking test 043 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 281.960655
-The maximum resident set size (KB)                   = 651016
+The total amount of wall time                        = 279.047310
+The maximum resident set size (KB)                   = 649720
 
 Test 043 regional_control_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_restart_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_restart_qr_intel
 Checking test 044 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 149.364960
-The maximum resident set size (KB)                   = 646712
+The total amount of wall time                        = 147.913446
+The maximum resident set size (KB)                   = 652048
 
 Test 044 regional_restart_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_decomp_intel
 Checking test 045 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2036,14 +2036,14 @@ Checking test 045 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 294.127605
-The maximum resident set size (KB)                   = 652612
+The total amount of wall time                        = 291.288605
+The maximum resident set size (KB)                   = 651928
 
 Test 045 regional_decomp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_2threads_intel
 Checking test 046 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2054,14 +2054,14 @@ Checking test 046 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 169.780326
-The maximum resident set size (KB)                   = 694080
+The total amount of wall time                        = 161.971338
+The maximum resident set size (KB)                   = 687624
 
 Test 046 regional_2threads_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_noquilt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_noquilt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_noquilt_intel
 Checking test 047 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2069,14 +2069,14 @@ Checking test 047 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 281.857286
-The maximum resident set size (KB)                   = 641848
+The total amount of wall time                        = 274.043823
+The maximum resident set size (KB)                   = 646412
 
 Test 047 regional_noquilt_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_2dwrtdecomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_2dwrtdecomp_intel
 Checking test 048 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2087,14 +2087,14 @@ Checking test 048 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 280.634029
-The maximum resident set size (KB)                   = 654604
+The total amount of wall time                        = 277.301299
+The maximum resident set size (KB)                   = 650576
 
 Test 048 regional_2dwrtdecomp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/fv3_regional_wofs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_wofs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_wofs_intel
 Checking test 049 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2105,14 +2105,14 @@ Checking test 049 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 358.356459
-The maximum resident set size (KB)                   = 340004
+The total amount of wall time                        = 352.431874
+The maximum resident set size (KB)                   = 339976
 
 Test 049 regional_wofs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_ifi_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_ifi_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_ifi_control_intel
 Checking test 050 regional_ifi_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2123,14 +2123,14 @@ Checking test 050 regional_ifi_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 316.317831
-The maximum resident set size (KB)                   = 653196
+The total amount of wall time                        = 307.256291
+The maximum resident set size (KB)                   = 648840
 
 Test 050 regional_ifi_control_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_ifi_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_ifi_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_ifi_decomp_intel
 Checking test 051 regional_ifi_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2141,14 +2141,14 @@ Checking test 051 regional_ifi_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 328.907647
-The maximum resident set size (KB)                   = 653672
+The total amount of wall time                        = 324.776766
+The maximum resident set size (KB)                   = 651904
 
 Test 051 regional_ifi_decomp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_ifi_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_ifi_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_ifi_2threads_intel
 Checking test 052 regional_ifi_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2159,14 +2159,14 @@ Checking test 052 regional_ifi_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 194.767929
-The maximum resident set size (KB)                   = 694780
+The total amount of wall time                        = 183.073089
+The maximum resident set size (KB)                   = 693440
 
 Test 052 regional_ifi_2threads_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_control_intel
 Checking test 053 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2213,14 +2213,14 @@ Checking test 053 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 404.027991
-The maximum resident set size (KB)                   = 889764
+The total amount of wall time                        = 402.832465
+The maximum resident set size (KB)                   = 891180
 
 Test 053 rap_control_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_spp_sppt_shum_skeb_intel
 Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2231,14 +2231,14 @@ Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 241.163777
-The maximum resident set size (KB)                   = 987076
+The total amount of wall time                        = 231.622458
+The maximum resident set size (KB)                   = 988444
 
 Test 054 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_decomp_intel
 Checking test 055 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2285,14 +2285,14 @@ Checking test 055 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 419.219974
-The maximum resident set size (KB)                   = 892080
+The total amount of wall time                        = 416.508656
+The maximum resident set size (KB)                   = 890812
 
 Test 055 rap_decomp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_2threads_intel
 Checking test 056 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2339,14 +2339,14 @@ Checking test 056 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 364.829409
-The maximum resident set size (KB)                   = 975404
+The total amount of wall time                        = 363.344391
+The maximum resident set size (KB)                   = 973932
 
 Test 056 rap_2threads_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_restart_intel
 Checking test 057 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2385,14 +2385,14 @@ Checking test 057 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 206.573734
-The maximum resident set size (KB)                   = 635692
+The total amount of wall time                        = 205.303006
+The maximum resident set size (KB)                   = 637592
 
 Test 057 rap_restart_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_sfcdiff_intel
 Checking test 058 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2439,14 +2439,14 @@ Checking test 058 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 406.827312
-The maximum resident set size (KB)                   = 890560
+The total amount of wall time                        = 406.262953
+The maximum resident set size (KB)                   = 892884
 
 Test 058 rap_sfcdiff_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_sfcdiff_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_sfcdiff_decomp_intel
 Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2493,14 +2493,14 @@ Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 423.528412
-The maximum resident set size (KB)                   = 891904
+The total amount of wall time                        = 421.773668
+The maximum resident set size (KB)                   = 891876
 
 Test 059 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_sfcdiff_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_sfcdiff_restart_intel
 Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2539,14 +2539,14 @@ Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 300.365635
-The maximum resident set size (KB)                   = 639796
+The total amount of wall time                        = 297.918513
+The maximum resident set size (KB)                   = 640280
 
 Test 060 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_intel
 Checking test 061 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2593,14 +2593,14 @@ Checking test 061 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 389.863555
-The maximum resident set size (KB)                   = 891368
+The total amount of wall time                        = 390.100739
+The maximum resident set size (KB)                   = 888060
 
 Test 061 hrrr_control_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_qr_intel
 Checking test 062 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2647,14 +2647,14 @@ Checking test 062 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 384.231416
-The maximum resident set size (KB)                   = 897064
+The total amount of wall time                        = 382.659018
+The maximum resident set size (KB)                   = 901828
 
 Test 062 hrrr_control_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_decomp_intel
 Checking test 063 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2701,14 +2701,14 @@ Checking test 063 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 403.434381
-The maximum resident set size (KB)                   = 890108
+The total amount of wall time                        = 402.684938
+The maximum resident set size (KB)                   = 894308
 
 Test 063 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_2threads_intel
 Checking test 064 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2755,42 +2755,42 @@ Checking test 064 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 350.384591
-The maximum resident set size (KB)                   = 957560
+The total amount of wall time                        = 348.908403
+The maximum resident set size (KB)                   = 958084
 
 Test 064 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_restart_intel
 Checking test 065 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 287.395575
-The maximum resident set size (KB)                   = 634940
+The total amount of wall time                        = 286.946577
+The maximum resident set size (KB)                   = 634976
 
 Test 065 hrrr_control_restart_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_restart_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_restart_qr_intel
 Checking test 066 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 288.304335
-The maximum resident set size (KB)                   = 651796
+The total amount of wall time                        = 287.758770
+The maximum resident set size (KB)                   = 651288
 
 Test 066 hrrr_control_restart_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_v1beta_intel
 Checking test 067 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2837,14 +2837,14 @@ Checking test 067 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 401.558630
-The maximum resident set size (KB)                   = 891536
+The total amount of wall time                        = 401.142268
+The maximum resident set size (KB)                   = 891196
 
 Test 067 rrfs_v1beta_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_v1nssl_intel
 Checking test 068 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2859,14 +2859,14 @@ Checking test 068 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 468.024171
-The maximum resident set size (KB)                   = 574424
+The total amount of wall time                        = 465.166633
+The maximum resident set size (KB)                   = 581100
 
 Test 068 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_v1nssl_nohailnoccn_intel
 Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2881,14 +2881,14 @@ Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 458.024434
-The maximum resident set size (KB)                   = 568200
+The total amount of wall time                        = 455.994258
+The maximum resident set size (KB)                   = 570948
 
 Test 069 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2904,14 +2904,14 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 148.236650
-The maximum resident set size (KB)                   = 795484
+The total amount of wall time                        = 138.548040
+The maximum resident set size (KB)                   = 794628
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
 Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2920,14 +2920,14 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 103.539735
-The maximum resident set size (KB)                   = 802436
+The total amount of wall time                        = 93.176420
+The maximum resident set size (KB)                   = 802792
 
 Test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_conus13km_hrrr_warm_intel
 Checking test 072 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2943,14 +2943,14 @@ Checking test 072 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 135.272021
-The maximum resident set size (KB)                   = 777788
+The total amount of wall time                        = 124.128340
+The maximum resident set size (KB)                   = 783384
 
 Test 072 rrfs_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_smoke_conus13km_radar_tten_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_smoke_conus13km_radar_tten_warm_intel
 Checking test 073 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2959,26 +2959,26 @@ Checking test 073 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 147.917429
-The maximum resident set size (KB)                   = 792888
+The total amount of wall time                        = 138.112422
+The maximum resident set size (KB)                   = 799628
 
 Test 073 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 93.776422
-The maximum resident set size (KB)                   = 788572
+The total amount of wall time                        = 80.868253
+The maximum resident set size (KB)                   = 795868
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmg_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_csawmg_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_csawmg_intel
 Checking test 075 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2989,14 +2989,14 @@ Checking test 075 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 344.789866
-The maximum resident set size (KB)                   = 584072
+The total amount of wall time                        = 332.031127
+The maximum resident set size (KB)                   = 583544
 
 Test 075 control_csawmg_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_csawmgt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_csawmgt_intel
 Checking test 076 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3007,14 +3007,14 @@ Checking test 076 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 342.126055
-The maximum resident set size (KB)                   = 582248
+The total amount of wall time                        = 328.503670
+The maximum resident set size (KB)                   = 584232
 
 Test 076 control_csawmgt_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_ras_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_ras_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_ras_intel
 Checking test 077 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3025,26 +3025,26 @@ Checking test 077 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 182.323577
-The maximum resident set size (KB)                   = 548444
+The total amount of wall time                        = 181.552699
+The maximum resident set size (KB)                   = 549280
 
 Test 077 control_ras_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_wam_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_wam_intel
 Checking test 078 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 118.194926
-The maximum resident set size (KB)                   = 272652
+The total amount of wall time                        = 117.167508
+The maximum resident set size (KB)                   = 271896
 
 Test 078 control_wam_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_p8_faster_intel
 Checking test 079 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3091,14 +3091,14 @@ Checking test 079 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 173.937927
-The maximum resident set size (KB)                   = 1485384
+The total amount of wall time                        = 165.620063
+The maximum resident set size (KB)                   = 1485388
 
 Test 079 control_p8_faster_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_control_faster_intel
 Checking test 080 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3109,56 +3109,56 @@ Checking test 080 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 270.543022
-The maximum resident set size (KB)                   = 650580
+The total amount of wall time                        = 269.229485
+The maximum resident set size (KB)                   = 650124
 
 Test 080 regional_control_faster_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_smoke_conus13km_hrrr_warm_debug_intel
 Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 925.180512
-The maximum resident set size (KB)                   = 825332
+The total amount of wall time                        = 893.093700
+The maximum resident set size (KB)                   = 819552
 
 Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
 Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 518.225955
-The maximum resident set size (KB)                   = 833260
+The total amount of wall time                        = 508.618136
+The maximum resident set size (KB)                   = 833200
 
 Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_conus13km_hrrr_warm_debug_intel
 Checking test 083 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 812.833471
-The maximum resident set size (KB)                   = 805488
+The total amount of wall time                        = 799.128097
+The maximum resident set size (KB)                   = 812548
 
 Test 083 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_CubedSphereGrid_debug_intel
 Checking test 084 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3185,348 +3185,348 @@ Checking test 084 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 158.240459
-The maximum resident set size (KB)                   = 675620
+The total amount of wall time                        = 158.312640
+The maximum resident set size (KB)                   = 672612
 
 Test 084 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 085 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 158.332090
-The maximum resident set size (KB)                   = 675080
+The total amount of wall time                        = 158.183429
+The maximum resident set size (KB)                   = 675860
 
 Test 085 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_stochy_debug_intel
 Checking test 086 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 177.996970
-The maximum resident set size (KB)                   = 682260
+The total amount of wall time                        = 178.965663
+The maximum resident set size (KB)                   = 683392
 
 Test 086 control_stochy_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_lndp_debug_intel
 Checking test 087 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.531720
-The maximum resident set size (KB)                   = 684860
+The total amount of wall time                        = 161.058505
+The maximum resident set size (KB)                   = 681480
 
 Test 087 control_lndp_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_csawmg_debug_intel
 Checking test 088 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 255.521803
-The maximum resident set size (KB)                   = 718464
+The total amount of wall time                        = 249.735930
+The maximum resident set size (KB)                   = 718028
 
 Test 088 control_csawmg_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_csawmgt_debug_intel
 Checking test 089 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 252.893558
-The maximum resident set size (KB)                   = 717564
+The total amount of wall time                        = 246.770157
+The maximum resident set size (KB)                   = 716960
 
 Test 089 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_ras_debug_intel
 Checking test 090 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.212911
-The maximum resident set size (KB)                   = 689864
+The total amount of wall time                        = 162.400621
+The maximum resident set size (KB)                   = 691940
 
 Test 090 control_ras_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_diag_debug_intel
 Checking test 091 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.253069
-The maximum resident set size (KB)                   = 734204
+The total amount of wall time                        = 163.118921
+The maximum resident set size (KB)                   = 737472
 
 Test 091 control_diag_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_debug_p8_intel
 Checking test 092 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 187.080635
-The maximum resident set size (KB)                   = 1502344
+The total amount of wall time                        = 181.626610
+The maximum resident set size (KB)                   = 1509400
 
 Test 092 control_debug_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_debug_intel
 Checking test 093 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1038.322256
-The maximum resident set size (KB)                   = 676520
+The total amount of wall time                        = 1038.129762
+The maximum resident set size (KB)                   = 674208
 
 Test 093 regional_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_control_debug_intel
 Checking test 094 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.214352
-The maximum resident set size (KB)                   = 1055280
+The total amount of wall time                        = 296.762566
+The maximum resident set size (KB)                   = 1049376
 
 Test 094 rap_control_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_debug_intel
 Checking test 095 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 293.004226
-The maximum resident set size (KB)                   = 1044900
+The total amount of wall time                        = 289.123053
+The maximum resident set size (KB)                   = 1045796
 
 Test 095 hrrr_control_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_unified_drag_suite_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_unified_drag_suite_debug_intel
 Checking test 096 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.519618
-The maximum resident set size (KB)                   = 1054256
+The total amount of wall time                        = 296.779869
+The maximum resident set size (KB)                   = 1053608
 
 Test 096 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_diag_debug_intel
 Checking test 097 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 309.396084
-The maximum resident set size (KB)                   = 1139712
+The total amount of wall time                        = 307.723739
+The maximum resident set size (KB)                   = 1134624
 
 Test 097 rap_diag_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_cires_ugwp_debug_intel
 Checking test 098 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 304.989825
-The maximum resident set size (KB)                   = 1054468
+The total amount of wall time                        = 303.545740
+The maximum resident set size (KB)                   = 1055932
 
 Test 098 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_unified_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_unified_ugwp_debug_intel
 Checking test 099 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 304.671301
-The maximum resident set size (KB)                   = 1055868
+The total amount of wall time                        = 303.473924
+The maximum resident set size (KB)                   = 1050608
 
 Test 099 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_lndp_debug_intel
 Checking test 100 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.002640
-The maximum resident set size (KB)                   = 1049500
+The total amount of wall time                        = 298.532965
+The maximum resident set size (KB)                   = 1055536
 
 Test 100 rap_lndp_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_progcld_thompson_debug_intel
 Checking test 101 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.232788
-The maximum resident set size (KB)                   = 1051028
+The total amount of wall time                        = 297.604932
+The maximum resident set size (KB)                   = 1053848
 
 Test 101 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_noah_debug_intel
 Checking test 102 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 292.995897
-The maximum resident set size (KB)                   = 1049964
+The total amount of wall time                        = 290.695933
+The maximum resident set size (KB)                   = 1054736
 
 Test 102 rap_noah_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_sfcdiff_debug_intel
 Checking test 103 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.548969
-The maximum resident set size (KB)                   = 1055052
+The total amount of wall time                        = 296.841490
+The maximum resident set size (KB)                   = 1050300
 
 Test 103 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 488.752443
-The maximum resident set size (KB)                   = 1052084
+The total amount of wall time                        = 487.495691
+The maximum resident set size (KB)                   = 1055348
 
 Test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rrfs_v1beta_debug_intel
 Checking test 105 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 292.521570
-The maximum resident set size (KB)                   = 1053176
+The total amount of wall time                        = 292.039670
+The maximum resident set size (KB)                   = 1049160
 
 Test 105 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_clm_lake_debug_intel
 Checking test 106 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 354.807343
-The maximum resident set size (KB)                   = 1050460
+The total amount of wall time                        = 353.777449
+The maximum resident set size (KB)                   = 1056268
 
 Test 106 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_flake_debug_intel
 Checking test 107 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.505135
-The maximum resident set size (KB)                   = 1053828
+The total amount of wall time                        = 296.840468
+The maximum resident set size (KB)                   = 1055536
 
 Test 107 rap_flake_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_wam_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_wam_debug_intel
 Checking test 108 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 297.852331
-The maximum resident set size (KB)                   = 301752
+The total amount of wall time                        = 296.764231
+The maximum resident set size (KB)                   = 303600
 
 Test 108 control_wam_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3537,14 +3537,14 @@ Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 227.284174
-The maximum resident set size (KB)                   = 894636
+The total amount of wall time                        = 221.664186
+The maximum resident set size (KB)                   = 899312
 
 Test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_control_dyn32_phy32_intel
 Checking test 110 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3591,14 +3591,14 @@ Checking test 110 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 340.539101
-The maximum resident set size (KB)                   = 774460
+The total amount of wall time                        = 336.485077
+The maximum resident set size (KB)                   = 771452
 
 Test 110 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_dyn32_phy32_intel
 Checking test 111 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3645,14 +3645,14 @@ Checking test 111 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 178.949484
-The maximum resident set size (KB)                   = 773580
+The total amount of wall time                        = 177.578953
+The maximum resident set size (KB)                   = 771880
 
 Test 111 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_qr_dyn32_phy32_intel
 Checking test 112 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3699,14 +3699,14 @@ Checking test 112 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 175.908815
-The maximum resident set size (KB)                   = 784880
+The total amount of wall time                        = 174.432209
+The maximum resident set size (KB)                   = 778696
 
 Test 112 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_2threads_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_2threads_dyn32_phy32_intel
 Checking test 113 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3753,14 +3753,14 @@ Checking test 113 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 306.245590
-The maximum resident set size (KB)                   = 833680
+The total amount of wall time                        = 305.596079
+The maximum resident set size (KB)                   = 832780
 
 Test 113 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 114 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3807,14 +3807,14 @@ Checking test 114 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 160.455426
-The maximum resident set size (KB)                   = 816120
+The total amount of wall time                        = 158.929212
+The maximum resident set size (KB)                   = 812788
 
 Test 114 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 115 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3861,14 +3861,14 @@ Checking test 115 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 185.783519
-The maximum resident set size (KB)                   = 775996
+The total amount of wall time                        = 185.410904
+The maximum resident set size (KB)                   = 772516
 
 Test 115 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_restart_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_restart_dyn32_phy32_intel
 Checking test 116 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3907,42 +3907,42 @@ Checking test 116 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 251.533734
-The maximum resident set size (KB)                   = 608948
+The total amount of wall time                        = 246.746308
+The maximum resident set size (KB)                   = 607000
 
 Test 116 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_restart_dyn32_phy32_intel
 Checking test 117 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 93.155471
-The maximum resident set size (KB)                   = 607372
+The total amount of wall time                        = 92.482200
+The maximum resident set size (KB)                   = 602724
 
 Test 117 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_restart_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_restart_qr_dyn32_phy32_intel
 Checking test 118 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 93.499266
-The maximum resident set size (KB)                   = 621392
+The total amount of wall time                        = 92.392902
+The maximum resident set size (KB)                   = 621736
 
 Test 118 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_control_dyn64_phy32_intel
 Checking test 119 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3989,81 +3989,81 @@ Checking test 119 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 229.685483
-The maximum resident set size (KB)                   = 797980
+The total amount of wall time                        = 226.815387
+The maximum resident set size (KB)                   = 797856
 
 Test 119 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_control_debug_dyn32_phy32_intel
 Checking test 120 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.150322
-The maximum resident set size (KB)                   = 937320
+The total amount of wall time                        = 288.899026
+The maximum resident set size (KB)                   = 939408
 
 Test 120 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hrrr_control_debug_dyn32_phy32_intel
 Checking test 121 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 284.757704
-The maximum resident set size (KB)                   = 936612
+The total amount of wall time                        = 282.053812
+The maximum resident set size (KB)                   = 939372
 
 Test 121 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/rap_control_dyn64_phy32_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/rap_control_dyn64_phy32_debug_intel
 Checking test 122 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.602609
-The maximum resident set size (KB)                   = 953800
+The total amount of wall time                        = 293.701206
+The maximum resident set size (KB)                   = 953688
 
 Test 122 rap_control_dyn64_phy32_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_atm_intel
 Checking test 123 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 255.731307
-The maximum resident set size (KB)                   = 822024
+The total amount of wall time                        = 248.483246
+The maximum resident set size (KB)                   = 822272
 
 Test 123 hafs_regional_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 124 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 309.034016
-The maximum resident set size (KB)                   = 1177180
+The total amount of wall time                        = 301.058774
+The maximum resident set size (KB)                   = 1183252
 
 Test 124 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_atm_ocn_intel
 Checking test 125 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4072,14 +4072,14 @@ Checking test 125 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 385.752603
-The maximum resident set size (KB)                   = 857956
+The total amount of wall time                        = 377.427640
+The maximum resident set size (KB)                   = 861476
 
 Test 125 hafs_regional_atm_ocn_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_atm_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_atm_wav_intel
 Checking test 126 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4088,14 +4088,14 @@ Checking test 126 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 707.244308
-The maximum resident set size (KB)                   = 888768
+The total amount of wall time                        = 698.746850
+The maximum resident set size (KB)                   = 889188
 
 Test 126 hafs_regional_atm_wav_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_atm_ocn_wav_intel
 Checking test 127 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4106,14 +4106,14 @@ Checking test 127 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 894.545517
-The maximum resident set size (KB)                   = 916136
+The total amount of wall time                        = 896.004474
+The maximum resident set size (KB)                   = 915656
 
 Test 127 hafs_regional_atm_ocn_wav_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_1nest_atm_intel
 Checking test 128 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4135,14 +4135,14 @@ Checking test 128 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 307.216118
-The maximum resident set size (KB)                   = 396668
+The total amount of wall time                        = 306.143764
+The maximum resident set size (KB)                   = 394716
 
 Test 128 hafs_regional_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_1nest_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_1nest_atm_qr_intel
 Checking test 129 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4164,14 +4164,14 @@ Checking test 129 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 329.669272
-The maximum resident set size (KB)                   = 372212
+The total amount of wall time                        = 320.372748
+The maximum resident set size (KB)                   = 371824
 
 Test 129 hafs_regional_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_telescopic_2nests_atm_intel
 Checking test 130 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4180,14 +4180,14 @@ Checking test 130 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 375.440367
-The maximum resident set size (KB)                   = 401684
+The total amount of wall time                        = 367.019585
+The maximum resident set size (KB)                   = 402924
 
 Test 130 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_global_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_global_1nest_atm_intel
 Checking test 131 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4234,14 +4234,14 @@ Checking test 131 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 162.686221
-The maximum resident set size (KB)                   = 266104
+The total amount of wall time                        = 159.148990
+The maximum resident set size (KB)                   = 264888
 
 Test 131 hafs_global_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_global_1nest_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_global_1nest_atm_qr_intel
 Checking test 132 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4288,14 +4288,14 @@ Checking test 132 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 170.645349
-The maximum resident set size (KB)                   = 272016
+The total amount of wall time                        = 164.322864
+The maximum resident set size (KB)                   = 273476
 
 Test 132 hafs_global_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_global_multiple_4nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_global_multiple_4nests_atm_intel
 Checking test 133 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4377,14 +4377,14 @@ Checking test 133 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 463.409958
-The maximum resident set size (KB)                   = 349004
+The total amount of wall time                        = 455.999250
+The maximum resident set size (KB)                   = 348072
 
 Test 133 hafs_global_multiple_4nests_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_global_multiple_4nests_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_global_multiple_4nests_atm_qr_intel
 Checking test 134 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4466,14 +4466,14 @@ Checking test 134 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 511.665643
-The maximum resident set size (KB)                   = 374472
+The total amount of wall time                        = 493.217657
+The maximum resident set size (KB)                   = 374656
 
 Test 134 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_specified_moving_1nest_atm_intel
 Checking test 135 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4482,14 +4482,14 @@ Checking test 135 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 207.485316
-The maximum resident set size (KB)                   = 412288
+The total amount of wall time                        = 202.736936
+The maximum resident set size (KB)                   = 408140
 
 Test 135 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_storm_following_1nest_atm_intel
 Checking test 136 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4511,14 +4511,14 @@ Checking test 136 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 195.371170
-The maximum resident set size (KB)                   = 407028
+The total amount of wall time                        = 190.970528
+The maximum resident set size (KB)                   = 407872
 
 Test 136 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_storm_following_1nest_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_storm_following_1nest_atm_qr_intel
 Checking test 137 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4540,14 +4540,14 @@ Checking test 137 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 216.138078
-The maximum resident set size (KB)                   = 396024
+The total amount of wall time                        = 209.804867
+The maximum resident set size (KB)                   = 395836
 
 Test 137 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_storm_following_1nest_atm_ocn_intel
 Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4556,42 +4556,42 @@ Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 249.760073
-The maximum resident set size (KB)                   = 475516
+The total amount of wall time                        = 246.688704
+The maximum resident set size (KB)                   = 469112
 
 Test 138 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_global_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_global_storm_following_1nest_atm_intel
 Checking test 139 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 83.671219
-The maximum resident set size (KB)                   = 283424
+The total amount of wall time                        = 80.969887
+The maximum resident set size (KB)                   = 283380
 
 Test 139 hafs_global_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
 Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 802.977004
-The maximum resident set size (KB)                   = 490364
+The total amount of wall time                        = 796.471442
+The maximum resident set size (KB)                   = 492476
 
 Test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
 Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4602,14 +4602,14 @@ Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 500.458358
-The maximum resident set size (KB)                   = 521956
+The total amount of wall time                        = 497.214807
+The maximum resident set size (KB)                   = 521408
 
 Test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_docn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_docn_intel
 Checking test 142 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4617,14 +4617,14 @@ Checking test 142 hafs_regional_docn_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 352.632147
-The maximum resident set size (KB)                   = 857920
+The total amount of wall time                        = 344.082517
+The maximum resident set size (KB)                   = 858580
 
 Test 142 hafs_regional_docn_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_oisst_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_docn_oisst_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_docn_oisst_intel
 Checking test 143 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4632,131 +4632,131 @@ Checking test 143 hafs_regional_docn_oisst_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 350.934672
-The maximum resident set size (KB)                   = 845812
+The total amount of wall time                        = 344.150992
+The maximum resident set size (KB)                   = 848096
 
 Test 143 hafs_regional_docn_oisst_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_datm_cdeps_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/hafs_regional_datm_cdeps_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/hafs_regional_datm_cdeps_intel
 Checking test 144 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-The total amount of wall time                        = 945.821411
-The maximum resident set size (KB)                   = 833084
+The total amount of wall time                        = 947.417042
+The maximum resident set size (KB)                   = 835648
 
 Test 144 hafs_regional_datm_cdeps_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_control_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_control_cfsr_intel
 Checking test 145 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 142.512465
-The maximum resident set size (KB)                   = 734464
+The total amount of wall time                        = 143.480795
+The maximum resident set size (KB)                   = 734028
 
 Test 145 datm_cdeps_control_cfsr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_restart_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_restart_cfsr_intel
 Checking test 146 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 86.696579
-The maximum resident set size (KB)                   = 729716
+The total amount of wall time                        = 89.172052
+The maximum resident set size (KB)                   = 728416
 
 Test 146 datm_cdeps_restart_cfsr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_control_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_control_gefs_intel
 Checking test 147 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 136.338745
-The maximum resident set size (KB)                   = 615356
+The total amount of wall time                        = 135.794631
+The maximum resident set size (KB)                   = 612696
 
 Test 147 datm_cdeps_control_gefs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_iau_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_iau_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_iau_gefs_intel
 Checking test 148 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 137.207127
-The maximum resident set size (KB)                   = 612792
+The total amount of wall time                        = 138.107246
+The maximum resident set size (KB)                   = 614168
 
 Test 148 datm_cdeps_iau_gefs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_stochy_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_stochy_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_stochy_gefs_intel
 Checking test 149 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 138.922847
-The maximum resident set size (KB)                   = 614492
+The total amount of wall time                        = 138.699519
+The maximum resident set size (KB)                   = 614804
 
 Test 149 datm_cdeps_stochy_gefs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_ciceC_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_ciceC_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_ciceC_cfsr_intel
 Checking test 150 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 143.090396
-The maximum resident set size (KB)                   = 736772
+The total amount of wall time                        = 143.581568
+The maximum resident set size (KB)                   = 733472
 
 Test 150 datm_cdeps_ciceC_cfsr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_bulk_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_bulk_cfsr_intel
 Checking test 151 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 144.432504
-The maximum resident set size (KB)                   = 734304
+The total amount of wall time                        = 144.229232
+The maximum resident set size (KB)                   = 734520
 
 Test 151 datm_cdeps_bulk_cfsr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_bulk_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_bulk_gefs_intel
 Checking test 152 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 137.146324
-The maximum resident set size (KB)                   = 611816
+The total amount of wall time                        = 135.526572
+The maximum resident set size (KB)                   = 614576
 
 Test 152 datm_cdeps_bulk_gefs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_mx025_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_mx025_cfsr_intel
 Checking test 153 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4765,14 +4765,14 @@ Checking test 153 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 426.902317
-The maximum resident set size (KB)                   = 566496
+The total amount of wall time                        = 433.236602
+The maximum resident set size (KB)                   = 571484
 
 Test 153 datm_cdeps_mx025_cfsr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_gefs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_mx025_gefs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_mx025_gefs_intel
 Checking test 154 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4781,64 +4781,64 @@ Checking test 154 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-The total amount of wall time                        = 427.648837
-The maximum resident set size (KB)                   = 553232
+The total amount of wall time                        = 439.984324
+The maximum resident set size (KB)                   = 547416
 
 Test 154 datm_cdeps_mx025_gefs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_multiple_files_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_multiple_files_cfsr_intel
 Checking test 155 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 143.295188
-The maximum resident set size (KB)                   = 733412
+The total amount of wall time                        = 143.487838
+The maximum resident set size (KB)                   = 731648
 
 Test 155 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_3072x1536_cfsr_intel
 Checking test 156 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 249.002300
-The maximum resident set size (KB)                   = 1979192
+The total amount of wall time                        = 250.644919
+The maximum resident set size (KB)                   = 1979088
 
 Test 156 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_gfs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_gfs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_gfs_intel
 Checking test 157 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 249.494169
-The maximum resident set size (KB)                   = 1980472
+The total amount of wall time                        = 251.196397
+The maximum resident set size (KB)                   = 1984008
 
 Test 157 datm_cdeps_gfs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_control_cfsr_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_control_cfsr_faster_intel
 Checking test 158 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-The total amount of wall time                        = 142.476251
-The maximum resident set size (KB)                   = 731524
+The total amount of wall time                        = 143.026073
+The maximum resident set size (KB)                   = 732004
 
 Test 158 datm_cdeps_control_cfsr_faster_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_lnd_gswp3_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_lnd_gswp3_intel
 Checking test 159 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4847,14 +4847,14 @@ Checking test 159 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 22.355745
-The maximum resident set size (KB)                   = 236076
+The total amount of wall time                        = 22.207113
+The maximum resident set size (KB)                   = 231176
 
 Test 159 datm_cdeps_lnd_gswp3_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/datm_cdeps_lnd_gswp3_rst_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/datm_cdeps_lnd_gswp3_rst_intel
 Checking test 160 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4863,14 +4863,14 @@ Checking test 160 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-The total amount of wall time                        = 28.406895
-The maximum resident set size (KB)                   = 229372
+The total amount of wall time                        = 28.392996
+The maximum resident set size (KB)                   = 233252
 
 Test 160 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_atmlnd_sbs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_p8_atmlnd_sbs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_p8_atmlnd_sbs_intel
 Checking test 161 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4955,14 +4955,14 @@ Checking test 161 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 234.317504
-The maximum resident set size (KB)                   = 1543212
+The total amount of wall time                        = 229.955035
+The maximum resident set size (KB)                   = 1549580
 
 Test 161 control_p8_atmlnd_sbs_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/atmwav_control_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/atmwav_control_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/atmwav_control_noaero_p8_intel
 Checking test 162 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5005,14 +5005,14 @@ Checking test 162 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-The total amount of wall time                        = 109.190617
-The maximum resident set size (KB)                   = 1525524
+The total amount of wall time                        = 103.743495
+The maximum resident set size (KB)                   = 1534400
 
 Test 162 atmwav_control_noaero_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_atmwav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/control_atmwav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/control_atmwav_intel
 Checking test 163 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5056,14 +5056,14 @@ Checking test 163 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-The total amount of wall time                        = 92.165222
-The maximum resident set size (KB)                   = 537060
+The total amount of wall time                        = 91.690686
+The maximum resident set size (KB)                   = 539924
 
 Test 163 control_atmwav_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/atmaero_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/atmaero_control_p8_intel
 Checking test 164 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5107,14 +5107,14 @@ Checking test 164 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.976472
-The maximum resident set size (KB)                   = 2814856
+The total amount of wall time                        = 238.891082
+The maximum resident set size (KB)                   = 2818764
 
 Test 164 atmaero_control_p8_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/atmaero_control_p8_rad_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/atmaero_control_p8_rad_intel
 Checking test 165 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5158,14 +5158,14 @@ Checking test 165 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 282.023904
-The maximum resident set size (KB)                   = 2877568
+The total amount of wall time                        = 280.607705
+The maximum resident set size (KB)                   = 2876624
 
 Test 165 atmaero_control_p8_rad_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_micro_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/atmaero_control_p8_rad_micro_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/atmaero_control_p8_rad_micro_intel
 Checking test 166 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5209,14 +5209,14 @@ Checking test 166 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 288.257279
-The maximum resident set size (KB)                   = 2885664
+The total amount of wall time                        = 286.706982
+The maximum resident set size (KB)                   = 2887948
 
 Test 166 atmaero_control_p8_rad_micro_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_atmaq_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_atmaq_intel
 Checking test 167 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5232,14 +5232,14 @@ Checking test 167 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 681.512862
-The maximum resident set size (KB)                   = 1249040
+The total amount of wall time                        = 710.408116
+The maximum resident set size (KB)                   = 1260196
 
 Test 167 regional_atmaq_intel PASS
 
 
 baseline dir = /lfs/h1/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_25875/regional_atmaq_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_210308/regional_atmaq_debug_intel
 Checking test 168 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5253,12 +5253,12 @@ Checking test 168 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1313.219702
-The maximum resident set size (KB)                   = 1291096
+The total amount of wall time                        = 1338.527352
+The maximum resident set size (KB)                   = 1289292
 
 Test 168 regional_atmaq_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Jun 26 15:56:09 UTC 2023
-Elapsed time: 01h:51m:03s. Have a nice day!
+Wed Jun 28 15:20:36 UTC 2023
+Elapsed time: 01h:34m:45s. Have a nice day!

--- a/tests/logs/RegressionTests_cheyenne.log
+++ b/tests/logs/RegressionTests_cheyenne.log
@@ -1,71 +1,71 @@
-Sat Jun 24 09:09:51 MDT 2023
+Tue Jun 27 17:23:20 MDT 2023
 Start Regression test
 
-Testing UFSWM Hash: bb0a41dd8ee19115327ebcc6db1442f5617ad752
+Testing UFSWM Hash: 2e508553d6cc8463a0244285d542f54fc083ed31
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
+ 596f540cff635a802d07cacf652d49b30d62ea6e ../FV3 (remotes/origin/unused_ccpp_suites)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 1559 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 1537 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 1397 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 459 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 409 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1124 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1111 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 1422 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 410 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 011 elapsed time 1138 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1021 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 975 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 855 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 1227 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 451 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 281 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 912 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 886 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 309 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 301 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 1170 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 363 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 1551 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 1158 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 446 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 205 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 444 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 112 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 1014 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 1035 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 1021 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 949 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 914 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 037 elapsed time 979 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 038 elapsed time 403 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1368 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1511 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1412 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 437 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 419 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1129 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 1155 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 1448 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 432 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 011 elapsed time 1122 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 1010 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 928 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 846 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 942 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 439 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 283 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 889 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 888 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 298 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 288 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 1165 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 339 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 1128 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 1149 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 435 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 028 elapsed time 207 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 443 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 116 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 976 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 1028 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 1072 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 940 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 919 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 037 elapsed time 996 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 038 elapsed time 398 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile 039 elapsed time 414 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 040 elapsed time 894 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 041 elapsed time 177 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 042 elapsed time 394 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 043 elapsed time 1160 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 044 elapsed time 893 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 045 elapsed time 899 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 046 elapsed time 626 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 047 elapsed time 573 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 048 elapsed time 334 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 049 elapsed time 572 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 050 elapsed time 285 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 051 elapsed time 295 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 040 elapsed time 405 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 041 elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 042 elapsed time 391 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 043 elapsed time 639 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 044 elapsed time 413 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 045 elapsed time 414 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 046 elapsed time 617 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 047 elapsed time 528 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 048 elapsed time 329 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 049 elapsed time 568 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 050 elapsed time 292 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 051 elapsed time 299 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_mixedmode_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_p8_mixedmode_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -130,14 +130,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 323.380891
-0:The maximum resident set size (KB)                   = 2698836
+0:The total amount of wall time                        = 309.209868
+0:The maximum resident set size (KB)                   = 2698224
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_gfsv17_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_gfsv17_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -201,14 +201,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 271.265633
-0:The maximum resident set size (KB)                   = 1427212
+0:The total amount of wall time                        = 271.554944
+0:The maximum resident set size (KB)                   = 1426936
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -273,14 +273,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 325.445881
-0:The maximum resident set size (KB)                   = 2715468
+0:The total amount of wall time                        = 312.886424
+0:The maximum resident set size (KB)                   = 2715540
 
 Test 003 cpld_control_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_restart_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -333,14 +333,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 192.544290
-0:The maximum resident set size (KB)                   = 2575620
+0:The total amount of wall time                        = 189.778228
+0:The maximum resident set size (KB)                   = 2575672
 
 Test 004 cpld_restart_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_qr_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -405,14 +405,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 327.747780
-0:The maximum resident set size (KB)                   = 2719228
+0:The total amount of wall time                        = 316.523102
+0:The maximum resident set size (KB)                   = 2719328
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_restart_qr_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -465,14 +465,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 205.621462
-0:The maximum resident set size (KB)                   = 2591828
+0:The total amount of wall time                        = 201.441992
+0:The maximum resident set size (KB)                   = 2591832
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_2threads_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -525,14 +525,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 253.039049
-0:The maximum resident set size (KB)                   = 3177888
+0:The total amount of wall time                        = 243.556050
+0:The maximum resident set size (KB)                   = 3176968
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_decomp_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -585,14 +585,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 324.643510
-0:The maximum resident set size (KB)                   = 2720372
+0:The total amount of wall time                        = 317.119700
+0:The maximum resident set size (KB)                   = 2720320
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_mpi_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -645,14 +645,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 277.813369
-0:The maximum resident set size (KB)                   = 2680036
+0:The total amount of wall time                        = 271.392030
+0:The maximum resident set size (KB)                   = 2679908
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_ciceC_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_ciceC_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -717,14 +717,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 325.617005
-0:The maximum resident set size (KB)                   = 2715672
+0:The total amount of wall time                        = 313.383667
+0:The maximum resident set size (KB)                   = 2715388
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_c192_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_c192_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_c192_p8_intel
 Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -777,14 +777,14 @@ Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 623.737748
-0:The maximum resident set size (KB)                   = 3350720
+0:The total amount of wall time                        = 613.999496
+0:The maximum resident set size (KB)                   = 3350656
 
 Test 011 cpld_control_c192_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_c192_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_restart_c192_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_restart_c192_p8_intel
 Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -837,14 +837,14 @@ Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 385.102010
-0:The maximum resident set size (KB)                   = 3272384
+0:The total amount of wall time                        = 386.854169
+0:The maximum resident set size (KB)                   = 3271912
 
 Test 012 cpld_restart_c192_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_noaero_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_noaero_p8_intel
 Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -908,14 +908,14 @@ Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 283.449523
-0:The maximum resident set size (KB)                   = 1436100
+0:The total amount of wall time                        = 286.882009
+0:The maximum resident set size (KB)                   = 1436000
 
 Test 013 cpld_control_noaero_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_nowave_noaero_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_nowave_noaero_p8_intel
 Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -977,14 +977,14 @@ Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 195.723555
-0:The maximum resident set size (KB)                   = 1451788
+0:The total amount of wall time                        = 192.289793
+0:The maximum resident set size (KB)                   = 1451772
 
 Test 014 cpld_control_nowave_noaero_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_debug_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_debug_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_debug_p8_intel
 Checking test 015 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1037,14 +1037,14 @@ Checking test 015 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 350.933651
-0:The maximum resident set size (KB)                   = 2779408
+0:The total amount of wall time                        = 350.589919
+0:The maximum resident set size (KB)                   = 2779328
 
 Test 015 cpld_debug_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_debug_noaero_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_debug_noaero_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_debug_noaero_p8_intel
 Checking test 016 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1096,14 +1096,14 @@ Checking test 016 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 300.973936
-0:The maximum resident set size (KB)                   = 1454228
+0:The total amount of wall time                        = 300.478556
+0:The maximum resident set size (KB)                   = 1454412
 
 Test 016 cpld_debug_noaero_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_agrid_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_noaero_p8_agrid_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_noaero_p8_agrid_intel
 Checking test 017 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1165,14 +1165,14 @@ Checking test 017 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 255.736000
-0:The maximum resident set size (KB)                   = 1455564
+0:The total amount of wall time                        = 253.468603
+0:The maximum resident set size (KB)                   = 1455536
 
 Test 017 cpld_control_noaero_p8_agrid_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_c48_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_c48_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_c48_intel
 Checking test 018 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1222,14 +1222,14 @@ Checking test 018 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 605.145511
-0:The maximum resident set size (KB)                   = 2584152
+0:The total amount of wall time                        = 602.905636
+0:The maximum resident set size (KB)                   = 2584604
 
 Test 018 cpld_control_c48_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_warmstart_c48_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_warmstart_c48_intel
 Checking test 019 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1279,14 +1279,14 @@ Checking test 019 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 162.698920
-0:The maximum resident set size (KB)                   = 2590296
+0:The total amount of wall time                        = 162.446194
+0:The maximum resident set size (KB)                   = 2589760
 
 Test 019 cpld_warmstart_c48_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_restart_c48_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_restart_c48_intel
 Checking test 020 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1336,14 +1336,14 @@ Checking test 020 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-0:The total amount of wall time                        = 84.455480
-0:The maximum resident set size (KB)                   = 2013836
+0:The total amount of wall time                        = 84.474602
+0:The maximum resident set size (KB)                   = 2014316
 
 Test 020 cpld_restart_c48_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_pdlib_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_pdlib_p8_intel
 Checking test 021 cpld_control_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1407,14 +1407,14 @@ Checking test 021 cpld_control_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1187.180916
-0:The maximum resident set size (KB)                   = 1497224
+0:The total amount of wall time                        = 1188.712712
+0:The maximum resident set size (KB)                   = 1497504
 
 Test 021 cpld_control_pdlib_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_restart_pdlib_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_restart_pdlib_p8_intel
 Checking test 022 cpld_restart_pdlib_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1466,14 +1466,14 @@ Checking test 022 cpld_restart_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 559.047979
-0:The maximum resident set size (KB)                   = 676776
+0:The total amount of wall time                        = 559.729480
+0:The maximum resident set size (KB)                   = 676560
 
 Test 022 cpld_restart_pdlib_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_mpi_pdlib_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_mpi_pdlib_p8_intel
 Checking test 023 cpld_mpi_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1537,14 +1537,14 @@ Checking test 023 cpld_mpi_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1073.224682
-0:The maximum resident set size (KB)                   = 1472372
+0:The total amount of wall time                        = 1076.356405
+0:The maximum resident set size (KB)                   = 1472264
 
 Test 023 cpld_mpi_pdlib_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_debug_pdlib_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_debug_pdlib_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_debug_pdlib_p8_intel
 Checking test 024 cpld_debug_pdlib_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1596,14 +1596,14 @@ Checking test 024 cpld_debug_pdlib_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1488.818191
-0:The maximum resident set size (KB)                   = 1514856
+0:The total amount of wall time                        = 1489.828769
+0:The maximum resident set size (KB)                   = 1514772
 
 Test 024 cpld_debug_pdlib_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_flake_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_flake_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_flake_intel
 Checking test 025 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1614,14 +1614,14 @@ Checking test 025 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 217.605044
-0:The maximum resident set size (KB)                   = 503344
+0:The total amount of wall time                        = 209.821711
+0:The maximum resident set size (KB)                   = 503284
 
 Test 025 control_flake_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_CubedSphereGrid_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_CubedSphereGrid_intel
 Checking test 026 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1648,28 +1648,28 @@ Checking test 026 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-0:The total amount of wall time                        = 143.273285
-0:The maximum resident set size (KB)                   = 454080
+0:The total amount of wall time                        = 139.631037
+0:The maximum resident set size (KB)                   = 453956
 
 Test 026 control_CubedSphereGrid_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_parallel_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_CubedSphereGrid_parallel_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_CubedSphereGrid_parallel_intel
 Checking test 027 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 140.067141
-0:The maximum resident set size (KB)                   = 454184
+0:The total amount of wall time                        = 137.159823
+0:The maximum resident set size (KB)                   = 454176
 
 Test 027 control_CubedSphereGrid_parallel_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_latlon_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_latlon_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_latlon_intel
 Checking test 028 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1680,14 +1680,14 @@ Checking test 028 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 147.868289
-0:The maximum resident set size (KB)                   = 455184
+0:The total amount of wall time                        = 143.235073
+0:The maximum resident set size (KB)                   = 455052
 
 Test 028 control_latlon_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_wrtGauss_netcdf_parallel_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_wrtGauss_netcdf_parallel_intel
 Checking test 029 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
@@ -1698,14 +1698,14 @@ Checking test 029 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 150.346419
-0:The maximum resident set size (KB)                   = 455024
+0:The total amount of wall time                        = 148.322340
+0:The maximum resident set size (KB)                   = 455128
 
 Test 029 control_wrtGauss_netcdf_parallel_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_c48_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_c48_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_c48_intel
 Checking test 030 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1744,14 +1744,14 @@ Checking test 030 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 442.874444
-0:The maximum resident set size (KB)                   = 632528
+0:The total amount of wall time                        = 445.903192
+0:The maximum resident set size (KB)                   = 632480
 
 Test 030 control_c48_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_c192_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_c192_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_c192_intel
 Checking test 031 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1762,14 +1762,14 @@ Checking test 031 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 591.792495
-0:The maximum resident set size (KB)                   = 560700
+0:The total amount of wall time                        = 575.449292
+0:The maximum resident set size (KB)                   = 560868
 
 Test 031 control_c192_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_c384_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_c384_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_c384_intel
 Checking test 032 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1780,14 +1780,14 @@ Checking test 032 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 584.494871
-0:The maximum resident set size (KB)                   = 898848
+0:The total amount of wall time                        = 566.077414
+0:The maximum resident set size (KB)                   = 898788
 
 Test 032 control_c384_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_c384gdas_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_c384gdas_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_c384gdas_intel
 Checking test 033 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1830,14 +1830,14 @@ Checking test 033 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 513.284069
-0:The maximum resident set size (KB)                   = 1027532
+0:The total amount of wall time                        = 525.529772
+0:The maximum resident set size (KB)                   = 1027496
 
 Test 033 control_c384gdas_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_stochy_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_stochy_intel
 Checking test 034 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1848,28 +1848,28 @@ Checking test 034 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 98.388457
-0:The maximum resident set size (KB)                   = 456820
+0:The total amount of wall time                        = 96.774796
+0:The maximum resident set size (KB)                   = 456532
 
 Test 034 control_stochy_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_stochy_restart_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_stochy_restart_intel
 Checking test 035 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 52.678635
-0:The maximum resident set size (KB)                   = 226368
+0:The total amount of wall time                        = 53.362763
+0:The maximum resident set size (KB)                   = 226356
 
 Test 035 control_stochy_restart_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_lndp_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_lndp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_lndp_intel
 Checking test 036 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1880,14 +1880,14 @@ Checking test 036 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 91.384508
-0:The maximum resident set size (KB)                   = 458420
+0:The total amount of wall time                        = 88.543188
+0:The maximum resident set size (KB)                   = 458264
 
 Test 036 control_lndp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_iovr4_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_iovr4_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_iovr4_intel
 Checking test 037 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1902,14 +1902,14 @@ Checking test 037 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 150.068843
-0:The maximum resident set size (KB)                   = 454920
+0:The total amount of wall time                        = 145.276696
+0:The maximum resident set size (KB)                   = 455016
 
 Test 037 control_iovr4_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_iovr5_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_iovr5_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_iovr5_intel
 Checking test 038 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1924,14 +1924,14 @@ Checking test 038 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 148.209724
-0:The maximum resident set size (KB)                   = 455044
+0:The total amount of wall time                        = 145.278453
+0:The maximum resident set size (KB)                   = 454972
 
 Test 038 control_iovr5_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_p8_intel
 Checking test 039 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1978,14 +1978,14 @@ Checking test 039 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 180.062623
-0:The maximum resident set size (KB)                   = 1425652
+0:The total amount of wall time                        = 180.368379
+0:The maximum resident set size (KB)                   = 1425600
 
 Test 039 control_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_restart_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_restart_p8_intel
 Checking test 040 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2024,14 +2024,14 @@ Checking test 040 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 95.285603
-0:The maximum resident set size (KB)                   = 583080
+0:The total amount of wall time                        = 96.288769
+0:The maximum resident set size (KB)                   = 582972
 
 Test 040 control_restart_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_qr_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_qr_p8_intel
 Checking test 041 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2078,14 +2078,14 @@ Checking test 041 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 182.932037
-0:The maximum resident set size (KB)                   = 1429332
+0:The total amount of wall time                        = 176.395676
+0:The maximum resident set size (KB)                   = 1429244
 
 Test 041 control_qr_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_restart_qr_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_restart_qr_p8_intel
 Checking test 042 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2124,14 +2124,14 @@ Checking test 042 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 97.987357
-0:The maximum resident set size (KB)                   = 596504
+0:The total amount of wall time                        = 97.775706
+0:The maximum resident set size (KB)                   = 596528
 
 Test 042 control_restart_qr_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_decomp_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_decomp_p8_intel
 Checking test 043 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2174,14 +2174,14 @@ Checking test 043 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 190.618738
-0:The maximum resident set size (KB)                   = 1419576
+0:The total amount of wall time                        = 186.874967
+0:The maximum resident set size (KB)                   = 1419512
 
 Test 043 control_decomp_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_2threads_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_2threads_p8_intel
 Checking test 044 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2224,14 +2224,14 @@ Checking test 044 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 168.281510
-0:The maximum resident set size (KB)                   = 1505776
+0:The total amount of wall time                        = 167.224223
+0:The maximum resident set size (KB)                   = 1510008
 
 Test 044 control_2threads_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_lndp_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_p8_lndp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_p8_lndp_intel
 Checking test 045 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2250,14 +2250,14 @@ Checking test 045 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-0:The total amount of wall time                        = 334.244473
-0:The maximum resident set size (KB)                   = 1426196
+0:The total amount of wall time                        = 328.122146
+0:The maximum resident set size (KB)                   = 1426148
 
 Test 045 control_p8_lndp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_rrtmgp_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_p8_rrtmgp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_p8_rrtmgp_intel
 Checking test 046 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2304,14 +2304,14 @@ Checking test 046 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 246.698689
-0:The maximum resident set size (KB)                   = 1479300
+0:The total amount of wall time                        = 238.068498
+0:The maximum resident set size (KB)                   = 1479272
 
 Test 046 control_p8_rrtmgp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_mynn_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_p8_mynn_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_p8_mynn_intel
 Checking test 047 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2358,14 +2358,14 @@ Checking test 047 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 183.637842
-0:The maximum resident set size (KB)                   = 1429984
+0:The total amount of wall time                        = 184.734182
+0:The maximum resident set size (KB)                   = 1429920
 
 Test 047 control_p8_mynn_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/merra2_thompson_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/merra2_thompson_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/merra2_thompson_intel
 Checking test 048 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2412,14 +2412,14 @@ Checking test 048 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 207.755283
-0:The maximum resident set size (KB)                   = 1429572
+0:The total amount of wall time                        = 203.975397
+0:The maximum resident set size (KB)                   = 1429556
 
 Test 048 merra2_thompson_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_control_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_control_intel
 Checking test 049 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2430,28 +2430,28 @@ Checking test 049 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 338.959536
-0:The maximum resident set size (KB)                   = 604348
+0:The total amount of wall time                        = 322.612985
+0:The maximum resident set size (KB)                   = 604252
 
 Test 049 regional_control_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_restart_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_restart_intel
 Checking test 050 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 165.331815
-0:The maximum resident set size (KB)                   = 596744
+0:The total amount of wall time                        = 170.939019
+0:The maximum resident set size (KB)                   = 596640
 
 Test 050 regional_restart_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_control_qr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_control_qr_intel
 Checking test 051 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2462,28 +2462,28 @@ Checking test 051 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 338.488255
-0:The maximum resident set size (KB)                   = 604424
+0:The total amount of wall time                        = 321.100370
+0:The maximum resident set size (KB)                   = 604356
 
 Test 051 regional_control_qr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_restart_qr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_restart_qr_intel
 Checking test 052 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 172.025108
-0:The maximum resident set size (KB)                   = 596716
+0:The total amount of wall time                        = 171.509797
+0:The maximum resident set size (KB)                   = 596732
 
 Test 052 regional_restart_qr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_decomp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_decomp_intel
 Checking test 053 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2494,14 +2494,14 @@ Checking test 053 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 352.908913
-0:The maximum resident set size (KB)                   = 597768
+0:The total amount of wall time                        = 353.990076
+0:The maximum resident set size (KB)                   = 597688
 
 Test 053 regional_decomp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_2threads_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_2threads_intel
 Checking test 054 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2512,14 +2512,14 @@ Checking test 054 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 191.136901
-0:The maximum resident set size (KB)                   = 610812
+0:The total amount of wall time                        = 194.816343
+0:The maximum resident set size (KB)                   = 610664
 
 Test 054 regional_2threads_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_noquilt_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_noquilt_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_noquilt_intel
 Checking test 055 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2527,28 +2527,28 @@ Checking test 055 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-0:The total amount of wall time                        = 330.905133
-0:The maximum resident set size (KB)                   = 599204
+0:The total amount of wall time                        = 321.159532
+0:The maximum resident set size (KB)                   = 599200
 
 Test 055 regional_noquilt_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_netcdf_parallel_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_netcdf_parallel_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_netcdf_parallel_intel
 Checking test 056 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc ............ALT CHECK......OK
  Comparing dynf006.nc ............ALT CHECK......OK
- Comparing phyf000.nc .........OK
- Comparing phyf006.nc .........OK
+ Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf006.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 332.961910
-0:The maximum resident set size (KB)                   = 596624
+0:The total amount of wall time                        = 334.453553
+0:The maximum resident set size (KB)                   = 596516
 
 Test 056 regional_netcdf_parallel_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_2dwrtdecomp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_2dwrtdecomp_intel
 Checking test 057 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2559,14 +2559,14 @@ Checking test 057 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 333.880563
-0:The maximum resident set size (KB)                   = 604404
+0:The total amount of wall time                        = 330.187328
+0:The maximum resident set size (KB)                   = 604336
 
 Test 057 regional_2dwrtdecomp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/fv3_regional_wofs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_wofs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_wofs_intel
 Checking test 058 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2577,14 +2577,14 @@ Checking test 058 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 420.681502
-0:The maximum resident set size (KB)                   = 276248
+0:The total amount of wall time                        = 409.028410
+0:The maximum resident set size (KB)                   = 276224
 
 Test 058 regional_wofs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_intel
 Checking test 059 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2631,14 +2631,14 @@ Checking test 059 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 466.233614
-0:The maximum resident set size (KB)                   = 822240
+0:The total amount of wall time                        = 460.346823
+0:The maximum resident set size (KB)                   = 822200
 
 Test 059 rap_control_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_spp_sppt_shum_skeb_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_spp_sppt_shum_skeb_intel
 Checking test 060 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2649,14 +2649,14 @@ Checking test 060 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 257.243068
-0:The maximum resident set size (KB)                   = 954628
+0:The total amount of wall time                        = 256.080434
+0:The maximum resident set size (KB)                   = 954552
 
 Test 060 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_decomp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_decomp_intel
 Checking test 061 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2703,14 +2703,14 @@ Checking test 061 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 497.825971
-0:The maximum resident set size (KB)                   = 821884
+0:The total amount of wall time                        = 481.410166
+0:The maximum resident set size (KB)                   = 821872
 
 Test 061 rap_decomp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_2threads_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_2threads_intel
 Checking test 062 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2757,14 +2757,14 @@ Checking test 062 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 441.973653
-0:The maximum resident set size (KB)                   = 901356
+0:The total amount of wall time                        = 438.675092
+0:The maximum resident set size (KB)                   = 897620
 
 Test 062 rap_2threads_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_restart_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_restart_intel
 Checking test 063 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2803,14 +2803,14 @@ Checking test 063 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 236.508863
-0:The maximum resident set size (KB)                   = 564788
+0:The total amount of wall time                        = 235.852233
+0:The maximum resident set size (KB)                   = 564880
 
 Test 063 rap_restart_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_sfcdiff_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_sfcdiff_intel
 Checking test 064 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2857,14 +2857,14 @@ Checking test 064 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 468.781854
-0:The maximum resident set size (KB)                   = 822184
+0:The total amount of wall time                        = 466.807192
+0:The maximum resident set size (KB)                   = 822160
 
 Test 064 rap_sfcdiff_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_sfcdiff_decomp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_sfcdiff_decomp_intel
 Checking test 065 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2911,14 +2911,14 @@ Checking test 065 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 491.382819
-0:The maximum resident set size (KB)                   = 821896
+0:The total amount of wall time                        = 489.732154
+0:The maximum resident set size (KB)                   = 821676
 
 Test 065 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_sfcdiff_restart_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_sfcdiff_restart_intel
 Checking test 066 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2957,14 +2957,14 @@ Checking test 066 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 346.095561
-0:The maximum resident set size (KB)                   = 569716
+0:The total amount of wall time                        = 340.499662
+0:The maximum resident set size (KB)                   = 569576
 
 Test 066 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_intel
 Checking test 067 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3011,14 +3011,14 @@ Checking test 067 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 448.533531
-0:The maximum resident set size (KB)                   = 819968
+0:The total amount of wall time                        = 444.717413
+0:The maximum resident set size (KB)                   = 820512
 
 Test 067 hrrr_control_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_qr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_qr_intel
 Checking test 068 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3065,14 +3065,14 @@ Checking test 068 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0:The total amount of wall time                        = 449.303052
-0:The maximum resident set size (KB)                   = 829864
+0:The total amount of wall time                        = 439.353204
+0:The maximum resident set size (KB)                   = 830096
 
 Test 068 hrrr_control_qr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_decomp_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_decomp_intel
 Checking test 069 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3119,14 +3119,14 @@ Checking test 069 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 460.329211
-0:The maximum resident set size (KB)                   = 819108
+0:The total amount of wall time                        = 464.844652
+0:The maximum resident set size (KB)                   = 819068
 
 Test 069 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_2threads_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_2threads_intel
 Checking test 070 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3173,42 +3173,42 @@ Checking test 070 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 503.613769
-0:The maximum resident set size (KB)                   = 887048
+0:The total amount of wall time                        = 506.820718
+0:The maximum resident set size (KB)                   = 887120
 
 Test 070 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_restart_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_intel
 Checking test 071 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 331.655924
-0:The maximum resident set size (KB)                   = 565272
+0:The total amount of wall time                        = 332.134997
+0:The maximum resident set size (KB)                   = 565384
 
 Test 071 hrrr_control_restart_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_restart_qr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_qr_intel
 Checking test 072 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 339.858161
-0:The maximum resident set size (KB)                   = 597388
+0:The total amount of wall time                        = 333.577948
+0:The maximum resident set size (KB)                   = 597424
 
 Test 072 hrrr_control_restart_qr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_v1beta_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_v1beta_intel
 Checking test 073 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3255,14 +3255,14 @@ Checking test 073 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 461.734996
-0:The maximum resident set size (KB)                   = 820408
+0:The total amount of wall time                        = 458.126296
+0:The maximum resident set size (KB)                   = 820312
 
 Test 073 rrfs_v1beta_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_v1nssl_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_v1nssl_intel
 Checking test 074 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3277,14 +3277,14 @@ Checking test 074 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 570.331701
-0:The maximum resident set size (KB)                   = 508892
+0:The total amount of wall time                        = 568.070895
+0:The maximum resident set size (KB)                   = 508820
 
 Test 074 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_v1nssl_nohailnoccn_intel
 Checking test 075 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3299,14 +3299,14 @@ Checking test 075 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 556.366380
-0:The maximum resident set size (KB)                   = 502312
+0:The total amount of wall time                        = 542.733844
+0:The maximum resident set size (KB)                   = 502348
 
 Test 075 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 076 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3322,14 +3322,14 @@ Checking test 076 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 156.195755
-0:The maximum resident set size (KB)                   = 666904
+0:The total amount of wall time                        = 154.173014
+0:The maximum resident set size (KB)                   = 666912
 
 Test 076 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
 Checking test 077 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3338,14 +3338,14 @@ Checking test 077 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 94.654515
-0:The maximum resident set size (KB)                   = 690624
+0:The total amount of wall time                        = 94.982708
+0:The maximum resident set size (KB)                   = 690536
 
 Test 077 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_conus13km_hrrr_warm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_conus13km_hrrr_warm_intel
 Checking test 078 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3361,14 +3361,14 @@ Checking test 078 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 140.807557
-0:The maximum resident set size (KB)                   = 656076
+0:The total amount of wall time                        = 137.001673
+0:The maximum resident set size (KB)                   = 656032
 
 Test 078 rrfs_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_radar_tten_warm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_radar_tten_warm_intel
 Checking test 079 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3377,26 +3377,26 @@ Checking test 079 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 157.382631
-0:The maximum resident set size (KB)                   = 668968
+0:The total amount of wall time                        = 153.692816
+0:The maximum resident set size (KB)                   = 668900
 
 Test 079 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
 Checking test 080 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 85.927958
-0:The maximum resident set size (KB)                   = 661224
+0:The total amount of wall time                        = 87.597821
+0:The maximum resident set size (KB)                   = 661148
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_csawmg_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_csawmg_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_csawmg_intel
 Checking test 081 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3407,14 +3407,14 @@ Checking test 081 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 386.932093
-0:The maximum resident set size (KB)                   = 528480
+0:The total amount of wall time                        = 386.959694
+0:The maximum resident set size (KB)                   = 528492
 
 Test 081 control_csawmg_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_csawmgt_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_csawmgt_intel
 Checking test 082 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3425,14 +3425,14 @@ Checking test 082 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 383.031227
-0:The maximum resident set size (KB)                   = 528692
+0:The total amount of wall time                        = 386.341499
+0:The maximum resident set size (KB)                   = 528740
 
 Test 082 control_csawmgt_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_ras_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_ras_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_ras_intel
 Checking test 083 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3443,26 +3443,26 @@ Checking test 083 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 207.103959
-0:The maximum resident set size (KB)                   = 489628
+0:The total amount of wall time                        = 206.863386
+0:The maximum resident set size (KB)                   = 489568
 
 Test 083 control_ras_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_wam_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_wam_intel
 Checking test 084 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-0:The total amount of wall time                        = 128.602037
-0:The maximum resident set size (KB)                   = 206692
+0:The total amount of wall time                        = 122.801971
+0:The maximum resident set size (KB)                   = 206768
 
 Test 084 control_wam_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_faster_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_p8_faster_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_p8_faster_intel
 Checking test 085 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3509,14 +3509,14 @@ Checking test 085 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 173.445103
-0:The maximum resident set size (KB)                   = 1425468
+0:The total amount of wall time                        = 165.555024
+0:The maximum resident set size (KB)                   = 1425408
 
 Test 085 control_p8_faster_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_control_faster_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_control_faster_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_control_faster_intel
 Checking test 086 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3527,56 +3527,56 @@ Checking test 086 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-0:The total amount of wall time                        = 313.757734
-0:The maximum resident set size (KB)                   = 604232
+0:The total amount of wall time                        = 314.896484
+0:The maximum resident set size (KB)                   = 604116
 
 Test 086 regional_control_faster_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_debug_intel
 Checking test 087 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 884.197258
-0:The maximum resident set size (KB)                   = 697864
+0:The total amount of wall time                        = 875.332323
+0:The maximum resident set size (KB)                   = 697836
 
 Test 087 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
 Checking test 088 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 504.831233
-0:The maximum resident set size (KB)                   = 722096
+0:The total amount of wall time                        = 498.381895
+0:The maximum resident set size (KB)                   = 722000
 
 Test 088 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_conus13km_hrrr_warm_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_conus13km_hrrr_warm_debug_intel
 Checking test 089 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 784.775840
-0:The maximum resident set size (KB)                   = 683792
+0:The total amount of wall time                        = 784.817881
+0:The maximum resident set size (KB)                   = 683800
 
 Test 089 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_CubedSphereGrid_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_CubedSphereGrid_debug_intel
 Checking test 090 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3603,348 +3603,348 @@ Checking test 090 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-0:The total amount of wall time                        = 154.844352
-0:The maximum resident set size (KB)                   = 617728
+0:The total amount of wall time                        = 154.348279
+0:The maximum resident set size (KB)                   = 617604
 
 Test 090 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 091 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 155.572218
-0:The maximum resident set size (KB)                   = 613864
+0:The total amount of wall time                        = 155.171181
+0:The maximum resident set size (KB)                   = 613720
 
 Test 091 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_stochy_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_stochy_debug_intel
 Checking test 092 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 174.690084
-0:The maximum resident set size (KB)                   = 621052
+0:The total amount of wall time                        = 175.585591
+0:The maximum resident set size (KB)                   = 621112
 
 Test 092 control_stochy_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_lndp_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_lndp_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_lndp_debug_intel
 Checking test 093 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 157.362839
-0:The maximum resident set size (KB)                   = 621456
+0:The total amount of wall time                        = 157.858227
+0:The maximum resident set size (KB)                   = 621488
 
 Test 093 control_lndp_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_csawmg_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_csawmg_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_csawmg_debug_intel
 Checking test 094 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 247.726967
-0:The maximum resident set size (KB)                   = 663464
+0:The total amount of wall time                        = 247.745191
+0:The maximum resident set size (KB)                   = 663456
 
 Test 094 control_csawmg_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_csawmgt_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_csawmgt_debug_intel
 Checking test 095 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 244.110281
-0:The maximum resident set size (KB)                   = 663700
+0:The total amount of wall time                        = 243.109375
+0:The maximum resident set size (KB)                   = 663696
 
 Test 095 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_ras_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_ras_debug_intel
 Checking test 096 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 158.845186
+0:The total amount of wall time                        = 159.211419
 0:The maximum resident set size (KB)                   = 628380
 
 Test 096 control_ras_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_diag_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_diag_debug_intel
 Checking test 097 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 160.209508
-0:The maximum resident set size (KB)                   = 671980
+0:The total amount of wall time                        = 159.099908
+0:The maximum resident set size (KB)                   = 671904
 
 Test 097 control_diag_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_debug_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_debug_p8_intel
 Checking test 098 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 175.556525
-0:The maximum resident set size (KB)                   = 1442832
+0:The total amount of wall time                        = 174.074841
+0:The maximum resident set size (KB)                   = 1442840
 
 Test 098 control_debug_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_debug_intel
 Checking test 099 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 1033.827193
-0:The maximum resident set size (KB)                   = 625816
+0:The total amount of wall time                        = 1034.140926
+0:The maximum resident set size (KB)                   = 625888
 
 Test 099 regional_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_debug_intel
 Checking test 100 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.229720
-0:The maximum resident set size (KB)                   = 986524
+0:The total amount of wall time                        = 287.247232
+0:The maximum resident set size (KB)                   = 986444
 
 Test 100 rap_control_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_debug_intel
 Checking test 101 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 285.529446
-0:The maximum resident set size (KB)                   = 983332
+0:The total amount of wall time                        = 285.259182
+0:The maximum resident set size (KB)                   = 983180
 
 Test 101 hrrr_control_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_unified_drag_suite_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_unified_drag_suite_debug_intel
 Checking test 102 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.344651
-0:The maximum resident set size (KB)                   = 986488
+0:The total amount of wall time                        = 287.260779
+0:The maximum resident set size (KB)                   = 986452
 
 Test 102 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_diag_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_diag_debug_intel
 Checking test 103 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 297.280210
-0:The maximum resident set size (KB)                   = 1069016
+0:The total amount of wall time                        = 298.381127
+0:The maximum resident set size (KB)                   = 1068840
 
 Test 103 rap_diag_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_cires_ugwp_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_cires_ugwp_debug_intel
 Checking test 104 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 291.806961
-0:The maximum resident set size (KB)                   = 986296
+0:The total amount of wall time                        = 291.260277
+0:The maximum resident set size (KB)                   = 986376
 
 Test 104 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_unified_ugwp_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_unified_ugwp_debug_intel
 Checking test 105 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 294.573601
-0:The maximum resident set size (KB)                   = 986568
+0:The total amount of wall time                        = 300.015315
+0:The maximum resident set size (KB)                   = 986744
 
 Test 105 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_lndp_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_lndp_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_lndp_debug_intel
 Checking test 106 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 288.814064
-0:The maximum resident set size (KB)                   = 987364
+0:The total amount of wall time                        = 289.230074
+0:The maximum resident set size (KB)                   = 987284
 
 Test 106 rap_lndp_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_progcld_thompson_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_progcld_thompson_debug_intel
 Checking test 107 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.546235
-0:The maximum resident set size (KB)                   = 986444
+0:The total amount of wall time                        = 287.465570
+0:The maximum resident set size (KB)                   = 986504
 
 Test 107 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_noah_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_noah_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_noah_debug_intel
 Checking test 108 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 280.485754
-0:The maximum resident set size (KB)                   = 985136
+0:The total amount of wall time                        = 280.713335
+0:The maximum resident set size (KB)                   = 985100
 
 Test 108 rap_noah_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_sfcdiff_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_sfcdiff_debug_intel
 Checking test 109 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 289.649782
-0:The maximum resident set size (KB)                   = 986488
+0:The total amount of wall time                        = 286.392434
+0:The maximum resident set size (KB)                   = 986380
 
 Test 109 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 110 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 470.431164
-0:The maximum resident set size (KB)                   = 984884
+0:The total amount of wall time                        = 471.065154
+0:The maximum resident set size (KB)                   = 984852
 
 Test 110 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_v1beta_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_v1beta_debug_intel
 Checking test 111 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 282.144196
-0:The maximum resident set size (KB)                   = 983368
+0:The total amount of wall time                        = 282.292676
+0:The maximum resident set size (KB)                   = 983068
 
 Test 111 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_clm_lake_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_clm_lake_debug_intel
 Checking test 112 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 354.063283
-0:The maximum resident set size (KB)                   = 989088
+0:The total amount of wall time                        = 349.126881
+0:The maximum resident set size (KB)                   = 988968
 
 Test 112 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_flake_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_flake_debug_intel
 Checking test 113 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 286.536477
-0:The maximum resident set size (KB)                   = 986636
+0:The total amount of wall time                        = 285.539277
+0:The maximum resident set size (KB)                   = 986744
 
 Test 113 rap_flake_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_wam_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_wam_debug_intel
 Checking test 114 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 291.178242
+0:The total amount of wall time                        = 290.143619
 0:The maximum resident set size (KB)                   = 236092
 
 Test 114 control_wam_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 115 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3955,14 +3955,14 @@ Checking test 115 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-0:The total amount of wall time                        = 240.832950
-0:The maximum resident set size (KB)                   = 851820
+0:The total amount of wall time                        = 241.371960
+0:The maximum resident set size (KB)                   = 851888
 
 Test 115 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_dyn32_phy32_intel
 Checking test 116 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4009,14 +4009,14 @@ Checking test 116 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 385.711592
-0:The maximum resident set size (KB)                   = 706580
+0:The total amount of wall time                        = 384.346448
+0:The maximum resident set size (KB)                   = 706532
 
 Test 116 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_dyn32_phy32_intel
 Checking test 117 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4063,68 +4063,68 @@ Checking test 117 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 200.115433
-0:The maximum resident set size (KB)                   = 705700
+0:The total amount of wall time                        = 197.092322
+0:The maximum resident set size (KB)                   = 705732
 
 Test 117 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_qr_dyn32_phy32_intel
 Checking test 118 hrrr_control_qr_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......NOT OK
- Comparing sfcf009.nc ............ALT CHECK......NOT OK
- Comparing sfcf012.nc ............ALT CHECK......NOT OK
- Comparing atmf000.nc ............ALT CHECK......NOT OK
- Comparing atmf009.nc ............ALT CHECK......NOT OK
- Comparing atmf012.nc ............ALT CHECK......NOT OK
- Comparing GFSFLX.GrbF00 .........NOT OK
- Comparing GFSFLX.GrbF09 .........NOT OK
- Comparing GFSFLX.GrbF12 .........NOT OK
- Comparing GFSPRS.GrbF00 .........NOT OK
- Comparing GFSPRS.GrbF09 .........NOT OK
- Comparing GFSPRS.GrbF12 .........NOT OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 199.969137
-0:The maximum resident set size (KB)                   = 712876
+0:The total amount of wall time                        = 200.673189
+0:The maximum resident set size (KB)                   = 712520
 
-Test 118 hrrr_control_qr_dyn32_phy32_intel FAIL Tries: 2
+Test 118 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_2threads_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_2threads_dyn32_phy32_intel
 Checking test 119 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4171,14 +4171,14 @@ Checking test 119 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 365.086015
-0:The maximum resident set size (KB)                   = 756564
+0:The total amount of wall time                        = 364.029549
+0:The maximum resident set size (KB)                   = 756508
 
 Test 119 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 120 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4225,14 +4225,14 @@ Checking test 120 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 275.439945
-0:The maximum resident set size (KB)                   = 752932
+0:The total amount of wall time                        = 273.435728
+0:The maximum resident set size (KB)                   = 752980
 
 Test 120 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 121 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4279,14 +4279,14 @@ Checking test 121 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 209.712508
-0:The maximum resident set size (KB)                   = 705008
+0:The total amount of wall time                        = 210.064313
+0:The maximum resident set size (KB)                   = 705076
 
 Test 121 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_restart_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_restart_dyn32_phy32_intel
 Checking test 122 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4325,28 +4325,42 @@ Checking test 122 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 285.513885
-0:The maximum resident set size (KB)                   = 540140
+0:The total amount of wall time                        = 284.527918
+0:The maximum resident set size (KB)                   = 540032
 
 Test 122 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_dyn32_phy32_intel
 Checking test 123 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 103.371845
-0:The maximum resident set size (KB)                   = 534032
+0:The total amount of wall time                        = 104.503560
+0:The maximum resident set size (KB)                   = 533892
 
 Test 123 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_qr_dyn32_phy32_intel
+Checking test 124 hrrr_control_restart_qr_dyn32_phy32_intel results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+0:The total amount of wall time                        = 106.183614
+0:The maximum resident set size (KB)                   = 559152
+
+Test 124 hrrr_control_restart_qr_dyn32_phy32_intel PASS
+
+
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_dyn64_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_dyn64_phy32_intel
 Checking test 125 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4393,81 +4407,81 @@ Checking test 125 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 263.962289
-0:The maximum resident set size (KB)                   = 726312
+0:The total amount of wall time                        = 255.165532
+0:The maximum resident set size (KB)                   = 726264
 
 Test 125 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_debug_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_debug_dyn32_phy32_intel
 Checking test 126 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 284.480818
-0:The maximum resident set size (KB)                   = 871908
+0:The total amount of wall time                        = 281.913355
+0:The maximum resident set size (KB)                   = 871952
 
 Test 126 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_debug_dyn32_phy32_intel
 Checking test 127 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 275.749369
-0:The maximum resident set size (KB)                   = 870156
+0:The total amount of wall time                        = 276.184845
+0:The maximum resident set size (KB)                   = 870104
 
 Test 127 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_dyn64_phy32_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_dyn64_phy32_debug_intel
 Checking test 128 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 287.384075
-0:The maximum resident set size (KB)                   = 889544
+0:The total amount of wall time                        = 288.508127
+0:The maximum resident set size (KB)                   = 889588
 
 Test 128 rap_control_dyn64_phy32_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_atm_intel
 Checking test 129 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-0:The total amount of wall time                        = 249.333205
-0:The maximum resident set size (KB)                   = 741108
+0:The total amount of wall time                        = 243.790989
+0:The maximum resident set size (KB)                   = 740880
 
 Test 129 hafs_regional_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 130 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-0:The total amount of wall time                        = 272.212669
-0:The maximum resident set size (KB)                   = 1099744
+0:The total amount of wall time                        = 285.449572
+0:The maximum resident set size (KB)                   = 1100128
 
 Test 130 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_atm_ocn_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_atm_ocn_intel
 Checking test 131 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4476,14 +4490,14 @@ Checking test 131 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 451.231465
-0:The maximum resident set size (KB)                   = 743032
+0:The total amount of wall time                        = 421.227096
+0:The maximum resident set size (KB)                   = 742880
 
 Test 131 hafs_regional_atm_ocn_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_wav_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_atm_wav_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_atm_wav_intel
 Checking test 132 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4492,14 +4506,14 @@ Checking test 132 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1060.060288
-0:The maximum resident set size (KB)                   = 769924
+0:The total amount of wall time                        = 1080.635696
+0:The maximum resident set size (KB)                   = 770540
 
 Test 132 hafs_regional_atm_wav_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_wav_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_atm_ocn_wav_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_atm_ocn_wav_intel
 Checking test 133 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4510,14 +4524,14 @@ Checking test 133 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 1092.756780
-0:The maximum resident set size (KB)                   = 792512
+0:The total amount of wall time                        = 1123.328288
+0:The maximum resident set size (KB)                   = 792340
 
 Test 133 hafs_regional_atm_ocn_wav_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_1nest_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_1nest_atm_intel
 Checking test 134 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4539,14 +4553,14 @@ Checking test 134 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-0:The total amount of wall time                        = 349.957688
-0:The maximum resident set size (KB)                   = 300796
+0:The total amount of wall time                        = 349.736773
+0:The maximum resident set size (KB)                   = 300816
 
 Test 134 hafs_regional_1nest_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_telescopic_2nests_atm_intel
 Checking test 135 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4555,14 +4569,14 @@ Checking test 135 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-0:The total amount of wall time                        = 398.008408
-0:The maximum resident set size (KB)                   = 318296
+0:The total amount of wall time                        = 397.576939
+0:The maximum resident set size (KB)                   = 318248
 
 Test 135 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_global_1nest_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_global_1nest_atm_intel
 Checking test 136 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4609,14 +4623,14 @@ Checking test 136 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-0:The total amount of wall time                        = 160.431926
-0:The maximum resident set size (KB)                   = 214640
+0:The total amount of wall time                        = 161.148847
+0:The maximum resident set size (KB)                   = 214704
 
 Test 136 hafs_global_1nest_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_global_multiple_4nests_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_global_multiple_4nests_atm_intel
 Checking test 137 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4698,14 +4712,14 @@ Checking test 137 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-0:The total amount of wall time                        = 453.120385
-0:The maximum resident set size (KB)                   = 301656
+0:The total amount of wall time                        = 444.203126
+0:The maximum resident set size (KB)                   = 302020
 
 Test 137 hafs_global_multiple_4nests_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_specified_moving_1nest_atm_intel
 Checking test 138 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4714,14 +4728,14 @@ Checking test 138 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-0:The total amount of wall time                        = 228.815068
-0:The maximum resident set size (KB)                   = 317604
+0:The total amount of wall time                        = 228.893958
+0:The maximum resident set size (KB)                   = 318124
 
 Test 138 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_storm_following_1nest_atm_intel
 Checking test 139 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4743,14 +4757,14 @@ Checking test 139 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-0:The total amount of wall time                        = 213.425826
-0:The maximum resident set size (KB)                   = 318440
+0:The total amount of wall time                        = 215.007968
+0:The maximum resident set size (KB)                   = 317396
 
 Test 139 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_storm_following_1nest_atm_ocn_intel
 Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4759,42 +4773,42 @@ Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-0:The total amount of wall time                        = 277.906865
-0:The maximum resident set size (KB)                   = 376160
+0:The total amount of wall time                        = 277.911569
+0:The maximum resident set size (KB)                   = 376144
 
 Test 140 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_global_storm_following_1nest_atm_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_global_storm_following_1nest_atm_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_global_storm_following_1nest_atm_intel
 Checking test 141 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-0:The total amount of wall time                        = 63.299240
-0:The maximum resident set size (KB)                   = 233236
+0:The total amount of wall time                        = 63.329505
+0:The maximum resident set size (KB)                   = 232984
 
 Test 141 hafs_global_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
 Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-0:The total amount of wall time                        = 764.720384
-0:The maximum resident set size (KB)                   = 403144
+0:The total amount of wall time                        = 766.463082
+0:The maximum resident set size (KB)                   = 403268
 
 Test 142 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
 Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4805,14 +4819,14 @@ Checking test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-0:The total amount of wall time                        = 723.148323
-0:The maximum resident set size (KB)                   = 427560
+0:The total amount of wall time                        = 713.159298
+0:The maximum resident set size (KB)                   = 427712
 
 Test 143 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_docn_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_docn_intel
 Checking test 144 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4820,14 +4834,14 @@ Checking test 144 hafs_regional_docn_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 378.961112
-0:The maximum resident set size (KB)                   = 756092
+0:The total amount of wall time                        = 361.970152
+0:The maximum resident set size (KB)                   = 756108
 
 Test 144 hafs_regional_docn_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_oisst_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_docn_oisst_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_docn_oisst_intel
 Checking test 145 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4835,131 +4849,131 @@ Checking test 145 hafs_regional_docn_oisst_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-0:The total amount of wall time                        = 375.310399
-0:The maximum resident set size (KB)                   = 739068
+0:The total amount of wall time                        = 361.269186
+0:The maximum resident set size (KB)                   = 739260
 
 Test 145 hafs_regional_docn_oisst_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hafs_regional_datm_cdeps_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hafs_regional_datm_cdeps_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hafs_regional_datm_cdeps_intel
 Checking test 146 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-0:The total amount of wall time                        = 1278.448519
-0:The maximum resident set size (KB)                   = 887820
+0:The total amount of wall time                        = 1276.221450
+0:The maximum resident set size (KB)                   = 887824
 
 Test 146 hafs_regional_datm_cdeps_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_control_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_control_cfsr_intel
 Checking test 147 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.919987
-0:The maximum resident set size (KB)                   = 727848
+0:The total amount of wall time                        = 159.333655
+0:The maximum resident set size (KB)                   = 716748
 
 Test 147 datm_cdeps_control_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_restart_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_restart_cfsr_intel
 Checking test 148 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 100.789104
-0:The maximum resident set size (KB)                   = 704880
+0:The total amount of wall time                        = 100.201606
+0:The maximum resident set size (KB)                   = 715964
 
 Test 148 datm_cdeps_restart_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_gefs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_control_gefs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_control_gefs_intel
 Checking test 149 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 157.866953
-0:The maximum resident set size (KB)                   = 607484
+0:The total amount of wall time                        = 153.617257
+0:The maximum resident set size (KB)                   = 607536
 
 Test 149 datm_cdeps_control_gefs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_iau_gefs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_iau_gefs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_iau_gefs_intel
 Checking test 150 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 162.559359
-0:The maximum resident set size (KB)                   = 607508
+0:The total amount of wall time                        = 155.923502
+0:The maximum resident set size (KB)                   = 607520
 
 Test 150 datm_cdeps_iau_gefs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_stochy_gefs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_stochy_gefs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_stochy_gefs_intel
 Checking test 151 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 161.977604
-0:The maximum resident set size (KB)                   = 607492
+0:The total amount of wall time                        = 160.941902
+0:The maximum resident set size (KB)                   = 607528
 
 Test 151 datm_cdeps_stochy_gefs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_ciceC_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_ciceC_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_ciceC_cfsr_intel
 Checking test 152 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 166.569255
-0:The maximum resident set size (KB)                   = 716724
+0:The total amount of wall time                        = 167.434330
+0:The maximum resident set size (KB)                   = 716780
 
 Test 152 datm_cdeps_ciceC_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_bulk_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_bulk_cfsr_intel
 Checking test 153 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 167.114469
-0:The maximum resident set size (KB)                   = 716728
+0:The total amount of wall time                        = 166.738546
+0:The maximum resident set size (KB)                   = 727836
 
 Test 153 datm_cdeps_bulk_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_gefs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_bulk_gefs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_bulk_gefs_intel
 Checking test 154 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 158.823194
-0:The maximum resident set size (KB)                   = 607484
+0:The total amount of wall time                        = 158.037340
+0:The maximum resident set size (KB)                   = 607512
 
 Test 154 datm_cdeps_bulk_gefs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_mx025_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_mx025_cfsr_intel
 Checking test 155 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4968,14 +4982,14 @@ Checking test 155 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 429.359524
-0:The maximum resident set size (KB)                   = 514388
+0:The total amount of wall time                        = 429.219851
+0:The maximum resident set size (KB)                   = 514416
 
 Test 155 datm_cdeps_mx025_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_gefs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_mx025_gefs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_mx025_gefs_intel
 Checking test 156 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4984,77 +4998,77 @@ Checking test 156 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-0:The total amount of wall time                        = 419.049500
-0:The maximum resident set size (KB)                   = 494844
+0:The total amount of wall time                        = 423.932181
+0:The maximum resident set size (KB)                   = 494776
 
 Test 156 datm_cdeps_mx025_gefs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_multiple_files_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_multiple_files_cfsr_intel
 Checking test 157 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.412494
-0:The maximum resident set size (KB)                   = 716768
+0:The total amount of wall time                        = 166.749502
+0:The maximum resident set size (KB)                   = 716760
 
 Test 157 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_3072x1536_cfsr_intel
 Checking test 158 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 256.638214
-0:The maximum resident set size (KB)                   = 1942044
+0:The total amount of wall time                        = 237.912634
+0:The maximum resident set size (KB)                   = 1910080
 
 Test 158 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_gfs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_gfs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_gfs_intel
 Checking test 159 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 269.330270
-0:The maximum resident set size (KB)                   = 1941144
+0:The total amount of wall time                        = 259.577300
+0:The maximum resident set size (KB)                   = 1940312
 
 Test 159 datm_cdeps_gfs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_debug_cfsr_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_debug_cfsr_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_debug_cfsr_intel
 Checking test 160 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
-0:The total amount of wall time                        = 371.879213
-0:The maximum resident set size (KB)                   = 712060
+0:The total amount of wall time                        = 374.315009
+0:The maximum resident set size (KB)                   = 711796
 
 Test 160 datm_cdeps_debug_cfsr_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_faster_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_control_cfsr_faster_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_control_cfsr_faster_intel
 Checking test 161 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 165.815337
-0:The maximum resident set size (KB)                   = 716748
+0:The total amount of wall time                        = 159.943314
+0:The maximum resident set size (KB)                   = 727808
 
 Test 161 datm_cdeps_control_cfsr_faster_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_lnd_gswp3_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_lnd_gswp3_intel
 Checking test 162 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5063,14 +5077,14 @@ Checking test 162 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 10.324764
-0:The maximum resident set size (KB)                   = 208272
+0:The total amount of wall time                        = 11.181925
+0:The maximum resident set size (KB)                   = 208200
 
 Test 162 datm_cdeps_lnd_gswp3_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_lnd_gswp3_rst_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_lnd_gswp3_rst_intel
 Checking test 163 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5079,14 +5093,14 @@ Checking test 163 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-0:The total amount of wall time                        = 15.664733
-0:The maximum resident set size (KB)                   = 204540
+0:The total amount of wall time                        = 15.470435
+0:The maximum resident set size (KB)                   = 204568
 
 Test 163 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_atmlnd_sbs_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_p8_atmlnd_sbs_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_p8_atmlnd_sbs_intel
 Checking test 164 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -5171,14 +5185,14 @@ Checking test 164 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-0:The total amount of wall time                        = 231.557884
-0:The maximum resident set size (KB)                   = 1464000
+0:The total amount of wall time                        = 232.130515
+0:The maximum resident set size (KB)                   = 1464112
 
 Test 164 control_p8_atmlnd_sbs_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/atmwav_control_noaero_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/atmwav_control_noaero_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/atmwav_control_noaero_p8_intel
 Checking test 165 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5221,14 +5235,14 @@ Checking test 165 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-0:The total amount of wall time                        = 100.084997
-0:The maximum resident set size (KB)                   = 1437300
+0:The total amount of wall time                        = 100.063381
+0:The maximum resident set size (KB)                   = 1437332
 
 Test 165 atmwav_control_noaero_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_atmwav_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_atmwav_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_atmwav_intel
 Checking test 166 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5272,14 +5286,14 @@ Checking test 166 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-0:The total amount of wall time                        = 100.763810
-0:The maximum resident set size (KB)                   = 475116
+0:The total amount of wall time                        = 101.013840
+0:The maximum resident set size (KB)                   = 475024
 
 Test 166 control_atmwav_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/atmaero_control_p8_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/atmaero_control_p8_intel
 Checking test 167 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5323,14 +5337,14 @@ Checking test 167 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 249.883910
-0:The maximum resident set size (KB)                   = 2703952
+0:The total amount of wall time                        = 251.543722
+0:The maximum resident set size (KB)                   = 2703956
 
 Test 167 atmaero_control_p8_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/atmaero_control_p8_rad_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/atmaero_control_p8_rad_intel
 Checking test 168 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5374,14 +5388,14 @@ Checking test 168 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 301.451905
-0:The maximum resident set size (KB)                   = 2757972
+0:The total amount of wall time                        = 302.153371
+0:The maximum resident set size (KB)                   = 2757884
 
 Test 168 atmaero_control_p8_rad_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_micro_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/atmaero_control_p8_rad_micro_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/atmaero_control_p8_rad_micro_intel
 Checking test 169 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5425,14 +5439,14 @@ Checking test 169 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 307.411911
-0:The maximum resident set size (KB)                   = 2764192
+0:The total amount of wall time                        = 308.837764
+0:The maximum resident set size (KB)                   = 2764228
 
 Test 169 atmaero_control_p8_rad_micro_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_atmaq_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_atmaq_intel
 Checking test 170 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5448,14 +5462,14 @@ Checking test 170 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 721.259423
-0:The maximum resident set size (KB)                   = 999476
+0:The total amount of wall time                        = 750.621967
+0:The maximum resident set size (KB)                   = 999468
 
 Test 170 regional_atmaq_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_faster_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_atmaq_faster_intel
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_atmaq_faster_intel
 Checking test 171 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5471,14 +5485,14 @@ Checking test 171 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 954.452099
-0:The maximum resident set size (KB)                   = 999308
+0:The total amount of wall time                        = 1003.113886
+0:The maximum resident set size (KB)                   = 999312
 
 Test 171 regional_atmaq_faster_intel PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_c48_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_c48_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_c48_gnu
 Checking test 172 control_c48_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5517,14 +5531,14 @@ Checking test 172 control_c48_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 817.433579
-0:The maximum resident set size (KB)                   = 678644
+0:The total amount of wall time                        = 819.169541
+0:The maximum resident set size (KB)                   = 678720
 
 Test 172 control_c48_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_stochy_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_stochy_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_stochy_gnu
 Checking test 173 control_stochy_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5535,14 +5549,14 @@ Checking test 173 control_stochy_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 176.194653
-0:The maximum resident set size (KB)                   = 443140
+0:The total amount of wall time                        = 177.828207
+0:The maximum resident set size (KB)                   = 443276
 
 Test 173 control_stochy_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_ras_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_ras_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_ras_gnu
 Checking test 174 control_ras_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5553,14 +5567,14 @@ Checking test 174 control_ras_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 294.791716
-0:The maximum resident set size (KB)                   = 452372
+0:The total amount of wall time                        = 290.048702
+0:The maximum resident set size (KB)                   = 451860
 
 Test 174 control_ras_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_p8_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_p8_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_p8_gnu
 Checking test 175 control_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -5607,14 +5621,14 @@ Checking test 175 control_p8_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 312.426890
-0:The maximum resident set size (KB)                   = 1225536
+0:The total amount of wall time                        = 304.311866
+0:The maximum resident set size (KB)                   = 1225584
 
 Test 175 control_p8_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_flake_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_flake_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_flake_gnu
 Checking test 176 control_flake_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5625,14 +5639,14 @@ Checking test 176 control_flake_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-0:The total amount of wall time                        = 352.106758
-0:The maximum resident set size (KB)                   = 490320
+0:The total amount of wall time                        = 341.755341
+0:The maximum resident set size (KB)                   = 489912
 
 Test 176 control_flake_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_gnu
 Checking test 177 rap_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -5679,14 +5693,14 @@ Checking test 177 rap_control_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 712.539873
-0:The maximum resident set size (KB)                   = 791856
+0:The total amount of wall time                        = 708.247564
+0:The maximum resident set size (KB)                   = 791920
 
 Test 177 rap_control_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_decomp_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_decomp_gnu
 Checking test 178 rap_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -5733,14 +5747,14 @@ Checking test 178 rap_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 716.083797
-0:The maximum resident set size (KB)                   = 791176
+0:The total amount of wall time                        = 709.575891
+0:The maximum resident set size (KB)                   = 791688
 
 Test 178 rap_decomp_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_2threads_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_2threads_gnu
 Checking test 179 rap_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -5787,14 +5801,14 @@ Checking test 179 rap_2threads_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 650.080949
-0:The maximum resident set size (KB)                   = 865032
+0:The total amount of wall time                        = 647.528264
+0:The maximum resident set size (KB)                   = 865388
 
 Test 179 rap_2threads_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_restart_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_restart_gnu
 Checking test 180 rap_restart_gnu results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -5833,14 +5847,14 @@ Checking test 180 rap_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 355.669314
-0:The maximum resident set size (KB)                   = 537156
+0:The total amount of wall time                        = 352.994737
+0:The maximum resident set size (KB)                   = 537532
 
 Test 180 rap_restart_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_sfcdiff_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_sfcdiff_gnu
 Checking test 181 rap_sfcdiff_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -5887,14 +5901,14 @@ Checking test 181 rap_sfcdiff_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 712.833984
-0:The maximum resident set size (KB)                   = 792100
+0:The total amount of wall time                        = 707.240947
+0:The maximum resident set size (KB)                   = 792096
 
 Test 181 rap_sfcdiff_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_sfcdiff_decomp_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_sfcdiff_decomp_gnu
 Checking test 182 rap_sfcdiff_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -5941,14 +5955,14 @@ Checking test 182 rap_sfcdiff_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 725.808987
-0:The maximum resident set size (KB)                   = 790760
+0:The total amount of wall time                        = 724.629049
+0:The maximum resident set size (KB)                   = 791380
 
 Test 182 rap_sfcdiff_decomp_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_sfcdiff_restart_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_sfcdiff_restart_gnu
 Checking test 183 rap_sfcdiff_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -5987,61 +6001,15 @@ Checking test 183 rap_sfcdiff_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 527.309041
-0:The maximum resident set size (KB)                   = 543944
+0:The total amount of wall time                        = 521.880255
+0:The maximum resident set size (KB)                   = 544272
 
 Test 183 rap_sfcdiff_restart_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_gnu
 Checking test 184 hrrr_control_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......ERROR
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_qr_gnu
-Checking test 185 hrrr_control_qr_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -6083,10 +6051,72 @@ Checking test 185 hrrr_control_qr_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......ERROR
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+0:The total amount of wall time                        = 689.718421
+0:The maximum resident set size (KB)                   = 788588
+
+Test 184 hrrr_control_gnu PASS
+
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_2threads_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_qr_gnu
+Checking test 185 hrrr_control_qr_gnu results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF00 .........OK
+ Comparing GFSFLX.GrbF09 .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
+
+0:The total amount of wall time                        = 681.764735
+0:The maximum resident set size (KB)                   = 802172
+
+Test 185 hrrr_control_qr_gnu PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_2threads_gnu
 Checking test 186 hrrr_control_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6102,37 +6132,45 @@ Checking test 186 hrrr_control_2threads_gnu results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......ERROR
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+0:The total amount of wall time                        = 709.899703
+0:The maximum resident set size (KB)                   = 854600
+
+Test 186 hrrr_control_2threads_gnu PASS
+
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_decomp_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_decomp_gnu
 Checking test 187 hrrr_control_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6148,37 +6186,73 @@ Checking test 187 hrrr_control_decomp_gnu results ....
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210322.120000.coupler.res .........OK
  Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......ERROR
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
+
+0:The total amount of wall time                        = 682.326686
+0:The maximum resident set size (KB)                   = 788404
+
+Test 187 hrrr_control_decomp_gnu PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_gnu
+Checking test 188 hrrr_control_restart_gnu results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+0:The total amount of wall time                        = 505.423272
+0:The maximum resident set size (KB)                   = 539428
+
+Test 188 hrrr_control_restart_gnu PASS
+
+
+baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_qr_gnu
+Checking test 189 hrrr_control_restart_qr_gnu results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+0:The total amount of wall time                        = 518.914375
+0:The maximum resident set size (KB)                   = 569344
+
+Test 189 hrrr_control_restart_qr_gnu PASS
+
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_v1beta_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_v1beta_gnu
 Checking test 190 rrfs_v1beta_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6225,14 +6299,14 @@ Checking test 190 rrfs_v1beta_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 699.552137
-0:The maximum resident set size (KB)                   = 788480
+0:The total amount of wall time                        = 698.565903
+0:The maximum resident set size (KB)                   = 788528
 
 Test 190 rrfs_v1beta_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_gnu
 Checking test 191 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6248,14 +6322,14 @@ Checking test 191 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 238.980273
-0:The maximum resident set size (KB)                   = 638352
+0:The total amount of wall time                        = 239.707579
+0:The maximum resident set size (KB)                   = 638788
 
 Test 191 rrfs_smoke_conus13km_hrrr_warm_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
 Checking test 192 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6264,14 +6338,14 @@ Checking test 192 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 148.794396
-0:The maximum resident set size (KB)                   = 663012
+0:The total amount of wall time                        = 150.806557
+0:The maximum resident set size (KB)                   = 657116
 
 Test 192 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_radar_tten_warm_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_radar_tten_warm_gnu
 Checking test 193 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6280,14 +6354,14 @@ Checking test 193 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 239.777487
-0:The maximum resident set size (KB)                   = 641112
+0:The total amount of wall time                        = 239.699318
+0:The maximum resident set size (KB)                   = 641512
 
 Test 193 rrfs_smoke_conus13km_radar_tten_warm_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_conus13km_hrrr_warm_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_conus13km_hrrr_warm_gnu
 Checking test 194 rrfs_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6303,262 +6377,262 @@ Checking test 194 rrfs_conus13km_hrrr_warm_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-0:The total amount of wall time                        = 219.358899
-0:The maximum resident set size (KB)                   = 612964
+0:The total amount of wall time                        = 220.119678
+0:The maximum resident set size (KB)                   = 613372
 
 Test 194 rrfs_conus13km_hrrr_warm_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
 Checking test 195 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-0:The total amount of wall time                        = 132.243656
-0:The maximum resident set size (KB)                   = 613280
+0:The total amount of wall time                        = 131.797635
+0:The maximum resident set size (KB)                   = 613668
 
 Test 195 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_diag_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_diag_debug_gnu
 Checking test 196 control_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 81.888478
-0:The maximum resident set size (KB)                   = 491780
+0:The total amount of wall time                        = 82.358511
+0:The maximum resident set size (KB)                   = 493036
 
 Test 196 control_diag_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/regional_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/regional_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/regional_debug_gnu
 Checking test 197 regional_debug_gnu results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-0:The total amount of wall time                        = 474.373761
-0:The maximum resident set size (KB)                   = 566916
+0:The total amount of wall time                        = 477.170187
+0:The maximum resident set size (KB)                   = 564272
 
 Test 197 regional_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_debug_gnu
 Checking test 198 rap_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.849494
-0:The maximum resident set size (KB)                   = 805832
+0:The total amount of wall time                        = 146.407312
+0:The maximum resident set size (KB)                   = 806216
 
 Test 198 rap_control_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_debug_gnu
 Checking test 199 hrrr_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 142.224865
-0:The maximum resident set size (KB)                   = 801228
+0:The total amount of wall time                        = 141.787550
+0:The maximum resident set size (KB)                   = 801788
 
 Test 199 hrrr_control_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_diag_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_diag_debug_gnu
 Checking test 200 rap_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 152.375362
-0:The maximum resident set size (KB)                   = 888992
+0:The total amount of wall time                        = 152.375056
+0:The maximum resident set size (KB)                   = 889216
 
 Test 200 rap_diag_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_noah_sfcdiff_cires_ugwp_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_noah_sfcdiff_cires_ugwp_debug_gnu
 Checking test 201 rap_noah_sfcdiff_cires_ugwp_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 233.333198
-0:The maximum resident set size (KB)                   = 804152
+0:The total amount of wall time                        = 234.836218
+0:The maximum resident set size (KB)                   = 804452
 
 Test 201 rap_noah_sfcdiff_cires_ugwp_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_progcld_thompson_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_progcld_thompson_debug_gnu
 Checking test 202 rap_progcld_thompson_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 145.014306
-0:The maximum resident set size (KB)                   = 805896
+0:The total amount of wall time                        = 146.107680
+0:The maximum resident set size (KB)                   = 806276
 
 Test 202 rap_progcld_thompson_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_v1beta_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_v1beta_debug_gnu
 Checking test 203 rrfs_v1beta_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 143.719143
-0:The maximum resident set size (KB)                   = 801008
+0:The total amount of wall time                        = 144.062075
+0:The maximum resident set size (KB)                   = 801476
 
 Test 203 rrfs_v1beta_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_ras_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_ras_debug_gnu
 Checking test 204 control_ras_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 80.054740
-0:The maximum resident set size (KB)                   = 446452
+0:The total amount of wall time                        = 80.650918
+0:The maximum resident set size (KB)                   = 446752
 
 Test 204 control_ras_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_stochy_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_stochy_debug_gnu
 Checking test 205 control_stochy_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 87.957238
-0:The maximum resident set size (KB)                   = 438996
+0:The total amount of wall time                        = 89.002860
+0:The maximum resident set size (KB)                   = 438472
 
 Test 205 control_stochy_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_debug_p8_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_debug_p8_gnu
 Checking test 206 control_debug_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 90.714775
-0:The maximum resident set size (KB)                   = 1221328
+0:The total amount of wall time                        = 91.298670
+0:The maximum resident set size (KB)                   = 1221040
 
 Test 206 control_debug_p8_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
 Checking test 207 rrfs_smoke_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 442.439653
-0:The maximum resident set size (KB)                   = 643984
+0:The total amount of wall time                        = 444.349825
+0:The maximum resident set size (KB)                   = 644476
 
 Test 207 rrfs_smoke_conus13km_hrrr_warm_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
 Checking test 208 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 259.358380
-0:The maximum resident set size (KB)                   = 663104
+0:The total amount of wall time                        = 260.742203
+0:The maximum resident set size (KB)                   = 668332
 
 Test 208 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rrfs_conus13km_hrrr_warm_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rrfs_conus13km_hrrr_warm_debug_gnu
 Checking test 209 rrfs_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 403.564144
-0:The maximum resident set size (KB)                   = 618036
+0:The total amount of wall time                        = 402.709873
+0:The maximum resident set size (KB)                   = 618520
 
 Test 209 rrfs_conus13km_hrrr_warm_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_flake_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_flake_debug_gnu
 Checking test 210 rap_flake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 146.232332
-0:The maximum resident set size (KB)                   = 805768
+0:The total amount of wall time                        = 145.388339
+0:The maximum resident set size (KB)                   = 806392
 
 Test 210 rap_flake_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_clm_lake_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_clm_lake_debug_gnu
 Checking test 211 rap_clm_lake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 164.581766
-0:The maximum resident set size (KB)                   = 807320
+0:The total amount of wall time                        = 164.604335
+0:The maximum resident set size (KB)                   = 808060
 
 Test 211 rap_clm_lake_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/control_wam_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/control_wam_debug_gnu
 Checking test 212 control_wam_debug_gnu results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-0:The total amount of wall time                        = 140.489357
-0:The maximum resident set size (KB)                   = 182396
+0:The total amount of wall time                        = 139.359752
+0:The maximum resident set size (KB)                   = 182660
 
 Test 212 control_wam_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_dyn32_phy32_gnu
 Checking test 213 rap_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6605,14 +6679,14 @@ Checking test 213 rap_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 701.870458
-0:The maximum resident set size (KB)                   = 672332
+0:The total amount of wall time                        = 703.274858
+0:The maximum resident set size (KB)                   = 672788
 
 Test 213 rap_control_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_dyn32_phy32_gnu
 Checking test 214 hrrr_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6659,14 +6733,14 @@ Checking test 214 hrrr_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 353.714640
-0:The maximum resident set size (KB)                   = 670860
+0:The total amount of wall time                        = 353.980302
+0:The maximum resident set size (KB)                   = 671224
 
 Test 214 hrrr_control_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_qr_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_qr_dyn32_phy32_gnu
 Checking test 215 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6713,14 +6787,14 @@ Checking test 215 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 354.008911
-0:The maximum resident set size (KB)                   = 681252
+0:The total amount of wall time                        = 352.819248
+0:The maximum resident set size (KB)                   = 681736
 
 Test 215 hrrr_control_qr_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_2threads_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_2threads_dyn32_phy32_gnu
 Checking test 216 rap_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6767,14 +6841,14 @@ Checking test 216 rap_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 640.768223
-0:The maximum resident set size (KB)                   = 719208
+0:The total amount of wall time                        = 640.817219
+0:The maximum resident set size (KB)                   = 719584
 
 Test 216 rap_2threads_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_2threads_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_2threads_dyn32_phy32_gnu
 Checking test 217 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6821,14 +6895,14 @@ Checking test 217 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 405.211814
+0:The total amount of wall time                        = 404.284442
 0:The maximum resident set size (KB)                   = 710828
 
 Test 217 hrrr_control_2threads_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_decomp_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_decomp_dyn32_phy32_gnu
 Checking test 218 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6875,14 +6949,14 @@ Checking test 218 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 353.254589
-0:The maximum resident set size (KB)                   = 669640
+0:The total amount of wall time                        = 353.101034
+0:The maximum resident set size (KB)                   = 670052
 
 Test 218 hrrr_control_decomp_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_restart_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_restart_dyn32_phy32_gnu
 Checking test 219 rap_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -6921,42 +6995,42 @@ Checking test 219 rap_restart_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 520.268384
-0:The maximum resident set size (KB)                   = 508964
+0:The total amount of wall time                        = 524.148646
+0:The maximum resident set size (KB)                   = 509024
 
 Test 219 rap_restart_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_restart_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_dyn32_phy32_gnu
 Checking test 220 hrrr_control_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 178.451162
-0:The maximum resident set size (KB)                   = 504672
+0:The total amount of wall time                        = 180.063689
+0:The maximum resident set size (KB)                   = 504032
 
 Test 220 hrrr_control_restart_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_restart_qr_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_restart_qr_dyn32_phy32_gnu
 Checking test 221 hrrr_control_restart_qr_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-0:The total amount of wall time                        = 182.001060
-0:The maximum resident set size (KB)                   = 531192
+0:The total amount of wall time                        = 183.347904
+0:The maximum resident set size (KB)                   = 531512
 
 Test 221 hrrr_control_restart_qr_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_dyn64_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_dyn64_phy32_gnu
 Checking test 222 rap_control_dyn64_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7003,56 +7077,56 @@ Checking test 222 rap_control_dyn64_phy32_gnu results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-0:The total amount of wall time                        = 404.897478
-0:The maximum resident set size (KB)                   = 692604
+0:The total amount of wall time                        = 411.451731
+0:The maximum resident set size (KB)                   = 693868
 
 Test 222 rap_control_dyn64_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_debug_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_debug_dyn32_phy32_gnu
 Checking test 223 rap_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 144.827433
-0:The maximum resident set size (KB)                   = 687976
+0:The total amount of wall time                        = 143.476431
+0:The maximum resident set size (KB)                   = 687876
 
 Test 223 rap_control_debug_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/hrrr_control_debug_dyn32_phy32_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/hrrr_control_debug_dyn32_phy32_gnu
 Checking test 224 hrrr_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 139.159736
-0:The maximum resident set size (KB)                   = 684188
+0:The total amount of wall time                        = 140.718637
+0:The maximum resident set size (KB)                   = 684668
 
 Test 224 hrrr_control_debug_dyn32_phy32_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/rap_control_dyn64_phy32_debug_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/rap_control_dyn64_phy32_debug_gnu
 Checking test 225 rap_control_dyn64_phy32_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-0:The total amount of wall time                        = 148.638589
-0:The maximum resident set size (KB)                   = 707808
+0:The total amount of wall time                        = 147.166547
+0:The maximum resident set size (KB)                   = 707224
 
 Test 225 rap_control_dyn64_phy32_debug_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_p8_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_p8_gnu
 Checking test 226 cpld_control_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7117,14 +7191,14 @@ Checking test 226 cpld_control_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 501.849874
-0:The maximum resident set size (KB)                   = 3158808
+0:The total amount of wall time                        = 501.047836
+0:The maximum resident set size (KB)                   = 3158524
 
 Test 226 cpld_control_p8_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_nowave_noaero_p8_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_nowave_noaero_p8_gnu
 Checking test 227 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7186,14 +7260,14 @@ Checking test 227 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-0:The total amount of wall time                        = 249.442824
-0:The maximum resident set size (KB)                   = 1240160
+0:The total amount of wall time                        = 251.230461
+0:The maximum resident set size (KB)                   = 1241280
 
 Test 227 cpld_control_nowave_noaero_p8_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_debug_p8_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_debug_p8_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_debug_p8_gnu
 Checking test 228 cpld_debug_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -7246,14 +7320,14 @@ Checking test 228 cpld_debug_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 199.556709
-0:The maximum resident set size (KB)                   = 3172712
+0:The total amount of wall time                        = 199.249987
+0:The maximum resident set size (KB)                   = 3177492
 
 Test 228 cpld_debug_p8_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_control_pdlib_p8_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_control_pdlib_p8_gnu
 Checking test 229 cpld_control_pdlib_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7317,14 +7391,14 @@ Checking test 229 cpld_control_pdlib_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 1391.402553
-0:The maximum resident set size (KB)                   = 1288444
+0:The total amount of wall time                        = 1388.197346
+0:The maximum resident set size (KB)                   = 1285012
 
 Test 229 cpld_control_pdlib_p8_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/cpld_debug_pdlib_p8_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/cpld_debug_pdlib_p8_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/cpld_debug_pdlib_p8_gnu
 Checking test 230 cpld_debug_pdlib_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -7376,325 +7450,25 @@ Checking test 230 cpld_debug_pdlib_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-0:The total amount of wall time                        = 693.814941
-0:The maximum resident set size (KB)                   = 1298572
+0:The total amount of wall time                        = 692.573473
+0:The maximum resident set size (KB)                   = 1299136
 
 Test 230 cpld_debug_pdlib_p8_gnu PASS
 
 
 baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_22734/datm_cdeps_control_cfsr_gnu
+working dir  = /glade/scratch/epicufsrt/FV3_RT/rt_13437/datm_cdeps_control_cfsr_gnu
 Checking test 231 datm_cdeps_control_cfsr_gnu results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
-0:The total amount of wall time                        = 183.697423
-0:The maximum resident set size (KB)                   = 671216
+0:The total amount of wall time                        = 174.096782
+0:The maximum resident set size (KB)                   = 672532
 
 Test 231 datm_cdeps_control_cfsr_gnu PASS
 
-FAILED TESTS: 
-118 hrrr_control_qr_dyn32_phy32_intel failed in check_result
-hrrr_control_qr_dyn32_phy32_intel 118 failed in run_test
-hrrr_control_gnu 184 failed in run_test
-hrrr_control_qr_gnu 185 failed in run_test
-hrrr_control_2threads_gnu 186 failed in run_test
-hrrr_control_decomp_gnu 187 failed in run_test
-
-REGRESSION TEST FAILED
-Sat Jun 24 10:41:34 MDT 2023
-Elapsed time: 01h:31m:44s. Have a nice day!
-Sat Jun 24 17:09:50 MDT 2023
-Start Regression test
-
-Testing UFSWM Hash: bb0a41dd8ee19115327ebcc6db1442f5617ad752
-Testing With Submodule Hashes:
- 37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
- 2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
- 5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
- cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
- cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
- b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
- 24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
- fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
- e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
- c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
- 3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 897 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 410 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_14393/hrrr_control_qr_dyn32_phy32_intel
-Checking test 001 hrrr_control_qr_dyn32_phy32_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-0:The total amount of wall time                        = 201.290044
-0:The maximum resident set size (KB)                   = 712836
-
-Test 001 hrrr_control_qr_dyn32_phy32_intel PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_14393/hrrr_control_gnu
-Checking test 002 hrrr_control_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-0:The total amount of wall time                        = 690.362695
-0:The maximum resident set size (KB)                   = 788452
-
-Test 002 hrrr_control_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_14393/hrrr_control_qr_gnu
-Checking test 003 hrrr_control_qr_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
-
-0:The total amount of wall time                        = 688.731344
-0:The maximum resident set size (KB)                   = 801860
-
-Test 003 hrrr_control_qr_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_14393/hrrr_control_2threads_gnu
-Checking test 004 hrrr_control_2threads_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-0:The total amount of wall time                        = 708.672396
-0:The maximum resident set size (KB)                   = 854676
-
-Test 004 hrrr_control_2threads_gnu PASS
-
-
-baseline dir = /glade/scratch/epicufsrt/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /glade/scratch/jongkim/rt-1795/jongkim/FV3_RT/rt_14393/hrrr_control_decomp_gnu
-Checking test 005 hrrr_control_decomp_gnu results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-0:The total amount of wall time                        = 685.385208
-0:The maximum resident set size (KB)                   = 787992
-
-Test 005 hrrr_control_decomp_gnu PASS
-
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 24 17:31:20 MDT 2023
-Elapsed time: 00h:21m:30s. Have a nice day!
+Tue Jun 27 19:03:49 MDT 2023
+Elapsed time: 01h:40m:30s. Have a nice day!

--- a/tests/logs/RegressionTests_gaea.log
+++ b/tests/logs/RegressionTests_gaea.log
@@ -1,56 +1,56 @@
-Sat 24 Jun 2023 11:10:33 AM EDT
+Tue 27 Jun 2023 03:59:59 PM EDT
 Start Regression test
 
-Testing UFSWM Hash: bb0a41dd8ee19115327ebcc6db1442f5617ad752
+Testing UFSWM Hash: 2e508553d6cc8463a0244285d542f54fc083ed31
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
+ 596f540cff635a802d07cacf652d49b30d62ea6e ../FV3 (remotes/origin/unused_ccpp_suites)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 937 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 937 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 857 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 347 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 322 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 823 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 787 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 992 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 821 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 778 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 699 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 638 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 815 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 260 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 672 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 665 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 232 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 753 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 246 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 841 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 719 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 260 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 160 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 246 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 96 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 705 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 701 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 681 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 719 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 686 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 037 elapsed time 701 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1027 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1064 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 993 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 488 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 432 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 913 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 946 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 1089 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 887 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 886 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 707 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 688 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 839 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 403 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 301 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 758 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 770 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 249 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 245 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 806 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 394 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 961 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 946 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 423 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 028 elapsed time 321 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 405 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 226 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 851 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 851 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 834 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 854 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 808 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 037 elapsed time 864 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_mixedmode_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_p8_mixedmode_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -115,14 +115,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 314.562162
-  0: The maximum resident set size (KB)                   = 1531980
+  0: The total amount of wall time                        = 331.662322
+  0: The maximum resident set size (KB)                   = 1531652
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_gfsv17_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_gfsv17_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -186,14 +186,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 228.917330
-  0: The maximum resident set size (KB)                   = 1449268
+  0: The total amount of wall time                        = 241.339143
+  0: The maximum resident set size (KB)                   = 1448748
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -258,14 +258,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 357.143765
-  0: The maximum resident set size (KB)                   = 1566668
+  0: The total amount of wall time                        = 370.072703
+  0: The maximum resident set size (KB)                   = 1565888
 
 Test 003 cpld_control_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_restart_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -318,14 +318,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 224.891132
-  0: The maximum resident set size (KB)                   = 1282260
+  0: The total amount of wall time                        = 223.075432
+  0: The maximum resident set size (KB)                   = 1282156
 
 Test 004 cpld_restart_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_qr_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -390,14 +390,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 356.787819
-  0: The maximum resident set size (KB)                   = 1578028
+  0: The total amount of wall time                        = 371.234553
+  0: The maximum resident set size (KB)                   = 1576712
 
-Test 005 cpld_control_qr_p8_intel PASS Tries: 2
+Test 005 cpld_control_qr_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_restart_qr_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -450,14 +450,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 204.490056
-  0: The maximum resident set size (KB)                   = 1295156
+  0: The total amount of wall time                        = 218.282406
+  0: The maximum resident set size (KB)                   = 1295180
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_2threads_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -510,14 +510,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 409.064737
-  0: The maximum resident set size (KB)                   = 1756588
+  0: The total amount of wall time                        = 384.797018
+  0: The maximum resident set size (KB)                   = 1759272
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_decomp_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -570,14 +570,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 357.318398
-  0: The maximum resident set size (KB)                   = 1559532
+  0: The total amount of wall time                        = 374.548767
+  0: The maximum resident set size (KB)                   = 1559812
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_mpi_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -630,14 +630,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 294.232097
-  0: The maximum resident set size (KB)                   = 1523700
+  0: The total amount of wall time                        = 308.398919
+  0: The maximum resident set size (KB)                   = 1523096
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_bmark_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_bmark_p8_intel
 Checking test 010 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -685,14 +685,14 @@ Checking test 010 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 717.262681
-   0: The maximum resident set size (KB)                   = 2498628
+   0: The total amount of wall time                        = 818.155215
+   0: The maximum resident set size (KB)                   = 2497204
 
 Test 010 cpld_bmark_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_restart_bmark_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_restart_bmark_p8_intel
 Checking test 011 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -740,14 +740,14 @@ Checking test 011 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 429.416945
-   0: The maximum resident set size (KB)                   = 2329336
+   0: The total amount of wall time                        = 458.568759
+   0: The maximum resident set size (KB)                   = 2327876
 
 Test 011 cpld_restart_bmark_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_noaero_p8_intel
 Checking test 012 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -811,14 +811,14 @@ Checking test 012 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 270.175144
-  0: The maximum resident set size (KB)                   = 1464240
+  0: The total amount of wall time                        = 285.669934
+  0: The maximum resident set size (KB)                   = 1464204
 
 Test 012 cpld_control_noaero_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_nowave_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_nowave_noaero_p8_intel
 Checking test 013 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -880,14 +880,14 @@ Checking test 013 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 278.401435
-  0: The maximum resident set size (KB)                   = 1502156
+  0: The total amount of wall time                        = 292.582597
+  0: The maximum resident set size (KB)                   = 1502436
 
 Test 013 cpld_control_nowave_noaero_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_debug_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_debug_p8_intel
 Checking test 014 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -940,14 +940,14 @@ Checking test 014 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 690.530565
-  0: The maximum resident set size (KB)                   = 1594816
+  0: The total amount of wall time                        = 545.508624
+  0: The maximum resident set size (KB)                   = 1595132
 
 Test 014 cpld_debug_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_debug_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_debug_noaero_p8_intel
 Checking test 015 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -999,14 +999,14 @@ Checking test 015 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 376.254987
-  0: The maximum resident set size (KB)                   = 1483004
+  0: The total amount of wall time                        = 377.366006
+  0: The maximum resident set size (KB)                   = 1483296
 
 Test 015 cpld_debug_noaero_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_agrid_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_noaero_p8_agrid_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_noaero_p8_agrid_intel
 Checking test 016 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1068,14 +1068,14 @@ Checking test 016 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 285.971351
-  0: The maximum resident set size (KB)                   = 1503416
+  0: The total amount of wall time                        = 298.786962
+  0: The maximum resident set size (KB)                   = 1503460
 
 Test 016 cpld_control_noaero_p8_agrid_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c48_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_control_c48_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_c48_intel
 Checking test 017 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1125,14 +1125,14 @@ Checking test 017 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 596.018329
- 0: The maximum resident set size (KB)                   = 2560288
+ 0: The total amount of wall time                        = 597.393582
+ 0: The maximum resident set size (KB)                   = 2560252
 
 Test 017 cpld_control_c48_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_warmstart_c48_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_warmstart_c48_intel
 Checking test 018 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1182,14 +1182,14 @@ Checking test 018 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 157.371243
- 0: The maximum resident set size (KB)                   = 2563952
+ 0: The total amount of wall time                        = 166.189035
+ 0: The maximum resident set size (KB)                   = 2563564
 
 Test 018 cpld_warmstart_c48_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/cpld_restart_c48_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_restart_c48_intel
 Checking test 019 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1239,18 +1239,86 @@ Checking test 019 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 82.783991
- 0: The maximum resident set size (KB)                   = 1982324
+ 0: The total amount of wall time                        = 90.083104
+ 0: The maximum resident set size (KB)                   = 1982712
 
 Test 019 cpld_restart_c48_intel PASS
 
-Test 020 cpld_control_p8_faster_intel FAIL
 
-Test 020 cpld_control_p8_faster_intel FAIL
+baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_faster_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/cpld_control_p8_faster_intel
+Checking test 020 cpld_control_p8_faster_intel results ....
+ Comparing sfcf021.tile1.nc .........OK
+ Comparing sfcf021.tile2.nc .........OK
+ Comparing sfcf021.tile3.nc .........OK
+ Comparing sfcf021.tile4.nc .........OK
+ Comparing sfcf021.tile5.nc .........OK
+ Comparing sfcf021.tile6.nc .........OK
+ Comparing atmf021.tile1.nc .........OK
+ Comparing atmf021.tile2.nc .........OK
+ Comparing atmf021.tile3.nc .........OK
+ Comparing atmf021.tile4.nc .........OK
+ Comparing atmf021.tile5.nc .........OK
+ Comparing atmf021.tile6.nc .........OK
+ Comparing sfcf024.tile1.nc .........OK
+ Comparing sfcf024.tile2.nc .........OK
+ Comparing sfcf024.tile3.nc .........OK
+ Comparing sfcf024.tile4.nc .........OK
+ Comparing sfcf024.tile5.nc .........OK
+ Comparing sfcf024.tile6.nc .........OK
+ Comparing atmf024.tile1.nc .........OK
+ Comparing atmf024.tile2.nc .........OK
+ Comparing atmf024.tile3.nc .........OK
+ Comparing atmf024.tile4.nc .........OK
+ Comparing atmf024.tile5.nc .........OK
+ Comparing atmf024.tile6.nc .........OK
+ Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
+ Comparing RESTART/20210323.060000.coupler.res .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20210323.060000.MOM.res.nc .........OK
+ Comparing RESTART/iced.2021-03-23-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
+ Comparing 20210323.060000.out_pnt.ww3 .........OK
+ Comparing 20210323.060000.out_grd.ww3 .........OK
+
+  0: The total amount of wall time                        = 356.466222
+  0: The maximum resident set size (KB)                   = 1566176
+
+Test 020 cpld_control_p8_faster_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_flake_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_flake_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_flake_intel
 Checking test 021 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1261,14 +1329,14 @@ Checking test 021 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 207.587094
-  0: The maximum resident set size (KB)                   = 483484
+  0: The total amount of wall time                        = 212.830143
+  0: The maximum resident set size (KB)                   = 483368
 
 Test 021 control_flake_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_CubedSphereGrid_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_CubedSphereGrid_intel
 Checking test 022 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1295,28 +1363,28 @@ Checking test 022 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 134.344263
-  0: The maximum resident set size (KB)                   = 434952
+  0: The total amount of wall time                        = 137.287487
+  0: The maximum resident set size (KB)                   = 434924
 
-Test 022 control_CubedSphereGrid_intel PASS Tries: 2
+Test 022 control_CubedSphereGrid_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_parallel_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_CubedSphereGrid_parallel_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_CubedSphereGrid_parallel_intel
 Checking test 023 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 135.160416
-  0: The maximum resident set size (KB)                   = 434964
+  0: The total amount of wall time                        = 155.312965
+  0: The maximum resident set size (KB)                   = 434900
 
 Test 023 control_CubedSphereGrid_parallel_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_latlon_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_latlon_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_latlon_intel
 Checking test 024 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1327,14 +1395,14 @@ Checking test 024 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.159498
-  0: The maximum resident set size (KB)                   = 434816
+  0: The total amount of wall time                        = 159.337938
+  0: The maximum resident set size (KB)                   = 434924
 
 Test 024 control_latlon_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_wrtGauss_netcdf_parallel_intel
 Checking test 025 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1345,14 +1413,14 @@ Checking test 025 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 143.922988
-  0: The maximum resident set size (KB)                   = 434936
+  0: The total amount of wall time                        = 160.111382
+  0: The maximum resident set size (KB)                   = 435000
 
 Test 025 control_wrtGauss_netcdf_parallel_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c48_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_c48_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_c48_intel
 Checking test 026 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1391,14 +1459,14 @@ Checking test 026 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 418.710220
-0: The maximum resident set size (KB)                   = 632784
+0: The total amount of wall time                        = 418.223385
+0: The maximum resident set size (KB)                   = 632728
 
 Test 026 control_c48_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c192_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_c192_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_c192_intel
 Checking test 027 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1409,14 +1477,14 @@ Checking test 027 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 566.774475
-  0: The maximum resident set size (KB)                   = 542028
+  0: The total amount of wall time                        = 573.395732
+  0: The maximum resident set size (KB)                   = 541872
 
 Test 027 control_c192_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c384_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_c384_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_c384_intel
 Checking test 028 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1427,14 +1495,14 @@ Checking test 028 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1091.468502
-  0: The maximum resident set size (KB)                   = 821788
+  0: The total amount of wall time                        = 1098.641691
+  0: The maximum resident set size (KB)                   = 821880
 
 Test 028 control_c384_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c384gdas_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_c384gdas_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_c384gdas_intel
 Checking test 029 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1477,14 +1545,14 @@ Checking test 029 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 897.677408
-  0: The maximum resident set size (KB)                   = 954596
+  0: The total amount of wall time                        = 917.502128
+  0: The maximum resident set size (KB)                   = 954492
 
 Test 029 control_c384gdas_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_stochy_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_stochy_intel
 Checking test 030 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1495,28 +1563,28 @@ Checking test 030 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 92.009705
-  0: The maximum resident set size (KB)                   = 439376
+  0: The total amount of wall time                        = 91.975786
+  0: The maximum resident set size (KB)                   = 439276
 
 Test 030 control_stochy_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_stochy_restart_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_stochy_restart_intel
 Checking test 031 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.962739
-  0: The maximum resident set size (KB)                   = 193256
+  0: The total amount of wall time                        = 51.465649
+  0: The maximum resident set size (KB)                   = 193156
 
 Test 031 control_stochy_restart_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_lndp_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_lndp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_lndp_intel
 Checking test 032 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1527,14 +1595,14 @@ Checking test 032 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 85.407597
-  0: The maximum resident set size (KB)                   = 441624
+  0: The total amount of wall time                        = 85.187908
+  0: The maximum resident set size (KB)                   = 441608
 
 Test 032 control_lndp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_iovr4_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_iovr4_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_iovr4_intel
 Checking test 033 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1549,14 +1617,14 @@ Checking test 033 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 140.687295
-  0: The maximum resident set size (KB)                   = 435032
+  0: The total amount of wall time                        = 166.306179
+  0: The maximum resident set size (KB)                   = 434920
 
 Test 033 control_iovr4_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_iovr5_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_iovr5_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_iovr5_intel
 Checking test 034 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1571,14 +1639,14 @@ Checking test 034 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 140.511313
-  0: The maximum resident set size (KB)                   = 434872
+  0: The total amount of wall time                        = 158.797307
+  0: The maximum resident set size (KB)                   = 434956
 
 Test 034 control_iovr5_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_p8_intel
 Checking test 035 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1625,14 +1693,14 @@ Checking test 035 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.530912
-  0: The maximum resident set size (KB)                   = 1404224
+  0: The total amount of wall time                        = 176.616786
+  0: The maximum resident set size (KB)                   = 1404160
 
 Test 035 control_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_restart_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_restart_p8_intel
 Checking test 036 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1671,14 +1739,14 @@ Checking test 036 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 88.930595
-  0: The maximum resident set size (KB)                   = 564596
+  0: The total amount of wall time                        = 94.648234
+  0: The maximum resident set size (KB)                   = 564548
 
 Test 036 control_restart_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_qr_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_qr_p8_intel
 Checking test 037 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1725,14 +1793,14 @@ Checking test 037 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 169.890549
-  0: The maximum resident set size (KB)                   = 1408008
+  0: The total amount of wall time                        = 179.314584
+  0: The maximum resident set size (KB)                   = 1407908
 
 Test 037 control_qr_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_restart_qr_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_restart_qr_p8_intel
 Checking test 038 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1771,14 +1839,14 @@ Checking test 038 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 91.063563
-  0: The maximum resident set size (KB)                   = 579284
+  0: The total amount of wall time                        = 97.586751
+  0: The maximum resident set size (KB)                   = 579264
 
 Test 038 control_restart_qr_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_decomp_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_decomp_p8_intel
 Checking test 039 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1821,14 +1889,14 @@ Checking test 039 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.970250
-  0: The maximum resident set size (KB)                   = 1397744
+  0: The total amount of wall time                        = 184.143040
+  0: The maximum resident set size (KB)                   = 1397688
 
 Test 039 control_decomp_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_2threads_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_2threads_p8_intel
 Checking test 040 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1871,14 +1939,14 @@ Checking test 040 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 158.091974
-  0: The maximum resident set size (KB)                   = 1485052
+  0: The total amount of wall time                        = 168.194501
+  0: The maximum resident set size (KB)                   = 1485224
 
 Test 040 control_2threads_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_lndp_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_p8_lndp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_p8_lndp_intel
 Checking test 041 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1897,14 +1965,14 @@ Checking test 041 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 316.514454
-  0: The maximum resident set size (KB)                   = 1405100
+  0: The total amount of wall time                        = 328.079509
+  0: The maximum resident set size (KB)                   = 1404952
 
 Test 041 control_p8_lndp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_rrtmgp_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_p8_rrtmgp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_p8_rrtmgp_intel
 Checking test 042 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1951,14 +2019,14 @@ Checking test 042 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.307932
-  0: The maximum resident set size (KB)                   = 1457936
+  0: The total amount of wall time                        = 241.284277
+  0: The maximum resident set size (KB)                   = 1457868
 
 Test 042 control_p8_rrtmgp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_mynn_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_p8_mynn_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_p8_mynn_intel
 Checking test 043 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2005,14 +2073,14 @@ Checking test 043 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.885969
-  0: The maximum resident set size (KB)                   = 1409160
+  0: The total amount of wall time                        = 183.541988
+  0: The maximum resident set size (KB)                   = 1409092
 
 Test 043 control_p8_mynn_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/merra2_thompson_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/merra2_thompson_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/merra2_thompson_intel
 Checking test 044 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2059,14 +2127,14 @@ Checking test 044 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.584020
-  0: The maximum resident set size (KB)                   = 1407868
+  0: The total amount of wall time                        = 201.625996
+  0: The maximum resident set size (KB)                   = 1407832
 
 Test 044 merra2_thompson_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_control_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_control_intel
 Checking test 045 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2077,28 +2145,28 @@ Checking test 045 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 317.507443
-  0: The maximum resident set size (KB)                   = 574584
+  0: The total amount of wall time                        = 324.137147
+  0: The maximum resident set size (KB)                   = 574480
 
 Test 045 regional_control_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_restart_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_restart_intel
 Checking test 046 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 162.796887
-  0: The maximum resident set size (KB)                   = 576124
+  0: The total amount of wall time                        = 163.377622
+  0: The maximum resident set size (KB)                   = 576036
 
 Test 046 regional_restart_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_control_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_control_qr_intel
 Checking test 047 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2109,28 +2177,28 @@ Checking test 047 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 317.548276
-  0: The maximum resident set size (KB)                   = 574508
+  0: The total amount of wall time                        = 322.667869
+  0: The maximum resident set size (KB)                   = 574512
 
 Test 047 regional_control_qr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_restart_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_restart_qr_intel
 Checking test 048 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 161.958080
-  0: The maximum resident set size (KB)                   = 576128
+  0: The total amount of wall time                        = 163.238357
+  0: The maximum resident set size (KB)                   = 576080
 
 Test 048 regional_restart_qr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_decomp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_decomp_intel
 Checking test 049 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2141,14 +2209,14 @@ Checking test 049 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 339.888388
-  0: The maximum resident set size (KB)                   = 575764
+  0: The total amount of wall time                        = 339.071026
+  0: The maximum resident set size (KB)                   = 575616
 
 Test 049 regional_decomp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_2threads_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_2threads_intel
 Checking test 050 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2159,14 +2227,14 @@ Checking test 050 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 182.266452
-  0: The maximum resident set size (KB)                   = 583052
+  0: The total amount of wall time                        = 194.440731
+  0: The maximum resident set size (KB)                   = 582876
 
 Test 050 regional_2threads_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_noquilt_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_noquilt_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_noquilt_intel
 Checking test 051 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2174,28 +2242,28 @@ Checking test 051 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 316.444333
-  0: The maximum resident set size (KB)                   = 568172
+  0: The total amount of wall time                        = 321.671738
+  0: The maximum resident set size (KB)                   = 568116
 
-Test 051 regional_noquilt_intel PASS Tries: 2
+Test 051 regional_noquilt_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_netcdf_parallel_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_netcdf_parallel_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_netcdf_parallel_intel
 Checking test 052 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 325.118195
-  0: The maximum resident set size (KB)                   = 574436
+  0: The total amount of wall time                        = 318.506198
+  0: The maximum resident set size (KB)                   = 574416
 
 Test 052 regional_netcdf_parallel_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_2dwrtdecomp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_2dwrtdecomp_intel
 Checking test 053 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2206,14 +2274,14 @@ Checking test 053 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 319.516440
-  0: The maximum resident set size (KB)                   = 577840
+  0: The total amount of wall time                        = 325.716863
+  0: The maximum resident set size (KB)                   = 577644
 
 Test 053 regional_2dwrtdecomp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/fv3_regional_wofs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_wofs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_wofs_intel
 Checking test 054 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2224,14 +2292,14 @@ Checking test 054 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 406.386316
-  0: The maximum resident set size (KB)                   = 259272
+  0: The total amount of wall time                        = 406.903287
+  0: The maximum resident set size (KB)                   = 259316
 
 Test 054 regional_wofs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_control_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_control_intel
 Checking test 055 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2278,14 +2346,14 @@ Checking test 055 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 457.403724
-  0: The maximum resident set size (KB)                   = 804788
+  0: The total amount of wall time                        = 466.021913
+  0: The maximum resident set size (KB)                   = 804928
 
 Test 055 rap_control_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_spp_sppt_shum_skeb_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_spp_sppt_shum_skeb_intel
 Checking test 056 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2296,14 +2364,14 @@ Checking test 056 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 251.764078
-  0: The maximum resident set size (KB)                   = 896872
+  0: The total amount of wall time                        = 257.022601
+  0: The maximum resident set size (KB)                   = 897308
 
 Test 056 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_decomp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_decomp_intel
 Checking test 057 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2350,14 +2418,14 @@ Checking test 057 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 466.102628
-  0: The maximum resident set size (KB)                   = 805072
+  0: The total amount of wall time                        = 475.603743
+  0: The maximum resident set size (KB)                   = 805036
 
 Test 057 rap_decomp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_2threads_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_2threads_intel
 Checking test 058 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2404,14 +2472,14 @@ Checking test 058 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 426.577595
-  0: The maximum resident set size (KB)                   = 878928
+  0: The total amount of wall time                        = 434.902780
+  0: The maximum resident set size (KB)                   = 880304
 
 Test 058 rap_2threads_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_restart_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_restart_intel
 Checking test 059 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2450,14 +2518,14 @@ Checking test 059 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.449320
-  0: The maximum resident set size (KB)                   = 545156
+  0: The total amount of wall time                        = 228.668492
+  0: The maximum resident set size (KB)                   = 545332
 
 Test 059 rap_restart_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_sfcdiff_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_sfcdiff_intel
 Checking test 060 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2504,14 +2572,14 @@ Checking test 060 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 453.272834
-  0: The maximum resident set size (KB)                   = 804724
+  0: The total amount of wall time                        = 461.601506
+  0: The maximum resident set size (KB)                   = 804616
 
 Test 060 rap_sfcdiff_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_sfcdiff_decomp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_sfcdiff_decomp_intel
 Checking test 061 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2558,14 +2626,14 @@ Checking test 061 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 467.697118
-  0: The maximum resident set size (KB)                   = 804828
+  0: The total amount of wall time                        = 474.393493
+  0: The maximum resident set size (KB)                   = 805048
 
 Test 061 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_sfcdiff_restart_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_sfcdiff_restart_intel
 Checking test 062 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2604,14 +2672,14 @@ Checking test 062 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 336.442595
-  0: The maximum resident set size (KB)                   = 549564
+  0: The total amount of wall time                        = 338.249681
+  0: The maximum resident set size (KB)                   = 549484
 
 Test 062 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_intel
 Checking test 063 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2658,14 +2726,14 @@ Checking test 063 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 431.307925
-  0: The maximum resident set size (KB)                   = 802820
+  0: The total amount of wall time                        = 438.846375
+  0: The maximum resident set size (KB)                   = 802804
 
 Test 063 hrrr_control_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_qr_intel
 Checking test 064 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2712,14 +2780,14 @@ Checking test 064 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 431.230937
-  0: The maximum resident set size (KB)                   = 813592
+  0: The total amount of wall time                        = 439.764843
+  0: The maximum resident set size (KB)                   = 813556
 
 Test 064 hrrr_control_qr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_decomp_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_decomp_intel
 Checking test 065 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2766,14 +2834,14 @@ Checking test 065 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 447.482830
-  0: The maximum resident set size (KB)                   = 802180
+  0: The total amount of wall time                        = 453.810055
+  0: The maximum resident set size (KB)                   = 802032
 
 Test 065 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_2threads_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_2threads_intel
 Checking test 066 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2820,42 +2888,42 @@ Checking test 066 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 397.697000
-  0: The maximum resident set size (KB)                   = 876116
+  0: The total amount of wall time                        = 403.613809
+  0: The maximum resident set size (KB)                   = 876244
 
 Test 066 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_restart_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_restart_intel
 Checking test 067 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 322.104199
-  0: The maximum resident set size (KB)                   = 544284
+  0: The total amount of wall time                        = 321.887922
+  0: The maximum resident set size (KB)                   = 544336
 
 Test 067 hrrr_control_restart_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_restart_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_restart_qr_intel
 Checking test 068 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 323.729937
-  0: The maximum resident set size (KB)                   = 565528
+  0: The total amount of wall time                        = 324.443979
+  0: The maximum resident set size (KB)                   = 565524
 
 Test 068 hrrr_control_restart_qr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_v1beta_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_v1beta_intel
 Checking test 069 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2902,14 +2970,14 @@ Checking test 069 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 443.607349
-  0: The maximum resident set size (KB)                   = 801564
+  0: The total amount of wall time                        = 455.043137
+  0: The maximum resident set size (KB)                   = 801592
 
 Test 069 rrfs_v1beta_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_v1nssl_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_v1nssl_intel
 Checking test 070 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2924,14 +2992,14 @@ Checking test 070 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 547.321685
-  0: The maximum resident set size (KB)                   = 490640
+  0: The total amount of wall time                        = 552.566880
+  0: The maximum resident set size (KB)                   = 490936
 
 Test 070 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_v1nssl_nohailnoccn_intel
 Checking test 071 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2946,14 +3014,14 @@ Checking test 071 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 529.684020
-  0: The maximum resident set size (KB)                   = 484816
+  0: The total amount of wall time                        = 535.991567
+  0: The maximum resident set size (KB)                   = 484864
 
 Test 071 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 072 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2969,14 +3037,14 @@ Checking test 072 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 149.310423
-  0: The maximum resident set size (KB)                   = 647392
+  0: The total amount of wall time                        = 167.338708
+  0: The maximum resident set size (KB)                   = 647416
 
 Test 072 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
 Checking test 073 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2985,14 +3053,14 @@ Checking test 073 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 92.435519
-  0: The maximum resident set size (KB)                   = 662700
+  0: The total amount of wall time                        = 96.304574
+  0: The maximum resident set size (KB)                   = 662644
 
 Test 073 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_conus13km_hrrr_warm_intel
 Checking test 074 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3008,14 +3076,14 @@ Checking test 074 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 132.190325
-  0: The maximum resident set size (KB)                   = 632360
+  0: The total amount of wall time                        = 135.664130
+  0: The maximum resident set size (KB)                   = 632444
 
 Test 074 rrfs_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_smoke_conus13km_radar_tten_warm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_smoke_conus13km_radar_tten_warm_intel
 Checking test 075 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3024,26 +3092,26 @@ Checking test 075 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 154.927823
-  0: The maximum resident set size (KB)                   = 650084
+  0: The total amount of wall time                        = 151.205277
+  0: The maximum resident set size (KB)                   = 650132
 
 Test 075 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
 Checking test 076 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 89.106802
-  0: The maximum resident set size (KB)                   = 639684
+  0: The total amount of wall time                        = 84.186912
+  0: The maximum resident set size (KB)                   = 639772
 
 Test 076 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_csawmgt_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_csawmgt_intel
 Checking test 077 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3054,14 +3122,14 @@ Checking test 077 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 358.058461
-  0: The maximum resident set size (KB)                   = 501048
+  0: The total amount of wall time                        = 360.263297
+  0: The maximum resident set size (KB)                   = 501044
 
 Test 077 control_csawmgt_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_ras_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_ras_intel
 Checking test 078 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3072,26 +3140,26 @@ Checking test 078 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.799490
-  0: The maximum resident set size (KB)                   = 470572
+  0: The total amount of wall time                        = 194.547212
+  0: The maximum resident set size (KB)                   = 470472
 
 Test 078 control_ras_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_wam_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_wam_intel
 Checking test 079 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 121.419157
-  0: The maximum resident set size (KB)                   = 186376
+  0: The total amount of wall time                        = 121.121058
+  0: The maximum resident set size (KB)                   = 186540
 
 Test 079 control_wam_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_faster_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_p8_faster_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_p8_faster_intel
 Checking test 080 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3138,14 +3206,14 @@ Checking test 080 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 161.006027
-  0: The maximum resident set size (KB)                   = 1403972
+  0: The total amount of wall time                        = 161.891305
+  0: The maximum resident set size (KB)                   = 1403900
 
 Test 080 control_p8_faster_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_faster_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_control_faster_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_control_faster_intel
 Checking test 081 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3156,56 +3224,56 @@ Checking test 081 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 295.414202
-  0: The maximum resident set size (KB)                   = 574284
+  0: The total amount of wall time                        = 301.559357
+  0: The maximum resident set size (KB)                   = 574124
 
 Test 081 regional_control_faster_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_smoke_conus13km_hrrr_warm_debug_intel
 Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 870.021463
-  0: The maximum resident set size (KB)                   = 679324
+  0: The total amount of wall time                        = 871.572097
+  0: The maximum resident set size (KB)                   = 679384
 
 Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
 Checking test 083 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 494.908024
-  0: The maximum resident set size (KB)                   = 695872
+  0: The total amount of wall time                        = 496.515769
+  0: The maximum resident set size (KB)                   = 695920
 
 Test 083 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_conus13km_hrrr_warm_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_conus13km_hrrr_warm_debug_intel
 Checking test 084 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 778.323986
-  0: The maximum resident set size (KB)                   = 663508
+  0: The total amount of wall time                        = 779.883554
+  0: The maximum resident set size (KB)                   = 663628
 
 Test 084 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_CubedSphereGrid_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_CubedSphereGrid_debug_intel
 Checking test 085 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3232,348 +3300,348 @@ Checking test 085 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 150.569432
-  0: The maximum resident set size (KB)                   = 599124
+  0: The total amount of wall time                        = 151.141922
+  0: The maximum resident set size (KB)                   = 599036
 
 Test 085 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 086 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.050278
-  0: The maximum resident set size (KB)                   = 598812
+  0: The total amount of wall time                        = 163.855135
+  0: The maximum resident set size (KB)                   = 598872
 
 Test 086 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_stochy_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_stochy_debug_intel
 Checking test 087 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 170.880992
-  0: The maximum resident set size (KB)                   = 603324
+  0: The total amount of wall time                        = 171.865781
+  0: The maximum resident set size (KB)                   = 603240
 
 Test 087 control_stochy_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_lndp_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_lndp_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_lndp_debug_intel
 Checking test 088 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.836185
-  0: The maximum resident set size (KB)                   = 605524
+  0: The total amount of wall time                        = 153.594420
+  0: The maximum resident set size (KB)                   = 605448
 
 Test 088 control_lndp_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmg_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_csawmg_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_csawmg_debug_intel
 Checking test 089 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 243.332558
-  0: The maximum resident set size (KB)                   = 639056
+  0: The total amount of wall time                        = 243.127015
+  0: The maximum resident set size (KB)                   = 639008
 
 Test 089 control_csawmg_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_csawmgt_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_csawmgt_debug_intel
 Checking test 090 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 238.561718
-  0: The maximum resident set size (KB)                   = 639104
+  0: The total amount of wall time                        = 238.800329
+  0: The maximum resident set size (KB)                   = 639120
 
 Test 090 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_ras_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_ras_debug_intel
 Checking test 091 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.604004
-  0: The maximum resident set size (KB)                   = 612044
+  0: The total amount of wall time                        = 155.487869
+  0: The maximum resident set size (KB)                   = 612216
 
 Test 091 control_ras_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_diag_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_diag_debug_intel
 Checking test 092 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.922763
-  0: The maximum resident set size (KB)                   = 657120
+  0: The total amount of wall time                        = 157.573779
+  0: The maximum resident set size (KB)                   = 656980
 
 Test 092 control_diag_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_debug_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_debug_p8_intel
 Checking test 093 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 215.850131
-  0: The maximum resident set size (KB)                   = 1421548
+  0: The total amount of wall time                        = 172.793990
+  0: The maximum resident set size (KB)                   = 1421744
 
 Test 093 control_debug_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_debug_intel
 Checking test 094 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1033.895422
-  0: The maximum resident set size (KB)                   = 602444
+  0: The total amount of wall time                        = 1034.816611
+  0: The maximum resident set size (KB)                   = 602412
 
 Test 094 regional_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_control_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_control_debug_intel
 Checking test 095 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.574386
-  0: The maximum resident set size (KB)                   = 969008
+  0: The total amount of wall time                        = 282.506891
+  0: The maximum resident set size (KB)                   = 969296
 
 Test 095 rap_control_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_debug_intel
 Checking test 096 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.678358
-  0: The maximum resident set size (KB)                   = 966028
+  0: The total amount of wall time                        = 275.697647
+  0: The maximum resident set size (KB)                   = 966200
 
 Test 096 hrrr_control_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_unified_drag_suite_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_unified_drag_suite_debug_intel
 Checking test 097 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.740171
-  0: The maximum resident set size (KB)                   = 969188
+  0: The total amount of wall time                        = 282.605186
+  0: The maximum resident set size (KB)                   = 969360
 
 Test 097 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_diag_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_diag_debug_intel
 Checking test 098 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 295.710835
-  0: The maximum resident set size (KB)                   = 1051340
+  0: The total amount of wall time                        = 296.197460
+  0: The maximum resident set size (KB)                   = 1051556
 
 Test 098 rap_diag_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_cires_ugwp_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_cires_ugwp_debug_intel
 Checking test 099 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.224196
-  0: The maximum resident set size (KB)                   = 969372
+  0: The total amount of wall time                        = 288.231763
+  0: The maximum resident set size (KB)                   = 969264
 
 Test 099 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_unified_ugwp_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_unified_ugwp_debug_intel
 Checking test 100 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.433878
-  0: The maximum resident set size (KB)                   = 969820
+  0: The total amount of wall time                        = 288.070181
+  0: The maximum resident set size (KB)                   = 969752
 
 Test 100 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_lndp_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_lndp_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_lndp_debug_intel
 Checking test 101 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.746359
-  0: The maximum resident set size (KB)                   = 970204
+  0: The total amount of wall time                        = 285.022296
+  0: The maximum resident set size (KB)                   = 970408
 
 Test 101 rap_lndp_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_progcld_thompson_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_progcld_thompson_debug_intel
 Checking test 102 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.998218
-  0: The maximum resident set size (KB)                   = 969256
+  0: The total amount of wall time                        = 282.598509
+  0: The maximum resident set size (KB)                   = 969376
 
 Test 102 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_noah_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_noah_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_noah_debug_intel
 Checking test 103 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.019552
-  0: The maximum resident set size (KB)                   = 967320
+  0: The total amount of wall time                        = 276.058091
+  0: The maximum resident set size (KB)                   = 967164
 
 Test 103 rap_noah_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_sfcdiff_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_sfcdiff_debug_intel
 Checking test 104 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.638183
-  0: The maximum resident set size (KB)                   = 968520
+  0: The total amount of wall time                        = 282.859772
+  0: The maximum resident set size (KB)                   = 968460
 
 Test 104 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 466.588881
-  0: The maximum resident set size (KB)                   = 966916
+  0: The total amount of wall time                        = 466.967055
+  0: The maximum resident set size (KB)                   = 967120
 
 Test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rrfs_v1beta_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rrfs_v1beta_debug_intel
 Checking test 106 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.862312
-  0: The maximum resident set size (KB)                   = 965164
+  0: The total amount of wall time                        = 277.440621
+  0: The maximum resident set size (KB)                   = 965284
 
 Test 106 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_clm_lake_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_clm_lake_debug_intel
 Checking test 107 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 348.887156
-  0: The maximum resident set size (KB)                   = 970820
+  0: The total amount of wall time                        = 345.673992
+  0: The maximum resident set size (KB)                   = 970624
 
 Test 107 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_flake_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_flake_debug_intel
 Checking test 108 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.420199
-  0: The maximum resident set size (KB)                   = 969380
+  0: The total amount of wall time                        = 282.492539
+  0: The maximum resident set size (KB)                   = 969516
 
 Test 108 rap_flake_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_wam_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_wam_debug_intel
 Checking test 109 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 286.449811
-  0: The maximum resident set size (KB)                   = 215868
+  0: The total amount of wall time                        = 286.866334
+  0: The maximum resident set size (KB)                   = 215984
 
 Test 109 control_wam_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3584,14 +3652,14 @@ Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 247.581932
-  0: The maximum resident set size (KB)                   = 808208
+  0: The total amount of wall time                        = 237.111853
+  0: The maximum resident set size (KB)                   = 807536
 
 Test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_control_dyn32_phy32_intel
 Checking test 111 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3638,14 +3706,14 @@ Checking test 111 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 368.925879
-  0: The maximum resident set size (KB)                   = 689448
+  0: The total amount of wall time                        = 369.712965
+  0: The maximum resident set size (KB)                   = 689484
 
 Test 111 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_dyn32_phy32_intel
 Checking test 112 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3692,14 +3760,14 @@ Checking test 112 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.601605
-  0: The maximum resident set size (KB)                   = 688220
+  0: The total amount of wall time                        = 206.040515
+  0: The maximum resident set size (KB)                   = 688336
 
 Test 112 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_qr_dyn32_phy32_intel
 Checking test 113 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3746,14 +3814,14 @@ Checking test 113 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.417537
-  0: The maximum resident set size (KB)                   = 694748
+  0: The total amount of wall time                        = 190.729397
+  0: The maximum resident set size (KB)                   = 694784
 
 Test 113 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_2threads_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_2threads_dyn32_phy32_intel
 Checking test 114 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3800,14 +3868,14 @@ Checking test 114 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 348.862556
-  0: The maximum resident set size (KB)                   = 739844
+  0: The total amount of wall time                        = 350.133273
+  0: The maximum resident set size (KB)                   = 740032
 
 Test 114 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 115 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3854,14 +3922,14 @@ Checking test 115 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.725462
-  0: The maximum resident set size (KB)                   = 739760
+  0: The total amount of wall time                        = 176.692797
+  0: The maximum resident set size (KB)                   = 739732
 
 Test 115 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 116 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3908,14 +3976,14 @@ Checking test 116 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.807470
-  0: The maximum resident set size (KB)                   = 687616
+  0: The total amount of wall time                        = 200.462062
+  0: The maximum resident set size (KB)                   = 687668
 
 Test 116 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_restart_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_restart_dyn32_phy32_intel
 Checking test 117 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3954,42 +4022,42 @@ Checking test 117 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 275.790603
-  0: The maximum resident set size (KB)                   = 519288
+  0: The total amount of wall time                        = 294.497979
+  0: The maximum resident set size (KB)                   = 519316
 
 Test 117 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_restart_dyn32_phy32_intel
 Checking test 118 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 98.480431
-  0: The maximum resident set size (KB)                   = 513940
+  0: The total amount of wall time                        = 99.899603
+  0: The maximum resident set size (KB)                   = 514048
 
 Test 118 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_restart_qr_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_restart_qr_dyn32_phy32_intel
 Checking test 119 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 100.902690
-  0: The maximum resident set size (KB)                   = 540976
+  0: The total amount of wall time                        = 102.993322
+  0: The maximum resident set size (KB)                   = 541032
 
 Test 119 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_control_dyn64_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_control_dyn64_phy32_intel
 Checking test 120 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4036,81 +4104,81 @@ Checking test 120 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 249.398619
-  0: The maximum resident set size (KB)                   = 708216
+  0: The total amount of wall time                        = 249.652269
+  0: The maximum resident set size (KB)                   = 707972
 
 Test 120 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_control_debug_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_control_debug_dyn32_phy32_intel
 Checking test 121 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.755183
-  0: The maximum resident set size (KB)                   = 852336
+  0: The total amount of wall time                        = 277.870694
+  0: The maximum resident set size (KB)                   = 852304
 
 Test 121 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hrrr_control_debug_dyn32_phy32_intel
 Checking test 122 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.815986
-  0: The maximum resident set size (KB)                   = 851220
+  0: The total amount of wall time                        = 271.851470
+  0: The maximum resident set size (KB)                   = 851168
 
 Test 122 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/rap_control_dyn64_phy32_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/rap_control_dyn64_phy32_debug_intel
 Checking test 123 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.318379
-  0: The maximum resident set size (KB)                   = 870844
+  0: The total amount of wall time                        = 282.577066
+  0: The maximum resident set size (KB)                   = 870864
 
 Test 123 rap_control_dyn64_phy32_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_atm_intel
 Checking test 124 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 239.245058
-  0: The maximum resident set size (KB)                   = 684528
+  0: The total amount of wall time                        = 239.403031
+  0: The maximum resident set size (KB)                   = 684900
 
 Test 124 hafs_regional_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 125 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 275.853270
-  0: The maximum resident set size (KB)                   = 1039916
+  0: The total amount of wall time                        = 275.932676
+  0: The maximum resident set size (KB)                   = 1039812
 
 Test 125 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_atm_ocn_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_atm_ocn_intel
 Checking test 126 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4119,14 +4187,14 @@ Checking test 126 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 420.261163
-  0: The maximum resident set size (KB)                   = 715208
+  0: The total amount of wall time                        = 420.710315
+  0: The maximum resident set size (KB)                   = 714992
 
 Test 126 hafs_regional_atm_ocn_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_wav_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_atm_wav_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_atm_wav_intel
 Checking test 127 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4135,14 +4203,14 @@ Checking test 127 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 906.186312
-  0: The maximum resident set size (KB)                   = 745404
+  0: The total amount of wall time                        = 907.262216
+  0: The maximum resident set size (KB)                   = 746208
 
 Test 127 hafs_regional_atm_wav_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_wav_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_atm_ocn_wav_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_atm_ocn_wav_intel
 Checking test 128 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4153,14 +4221,14 @@ Checking test 128 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1012.796757
-  0: The maximum resident set size (KB)                   = 763716
+  0: The total amount of wall time                        = 1011.643237
+  0: The maximum resident set size (KB)                   = 764384
 
 Test 128 hafs_regional_atm_ocn_wav_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_1nest_atm_intel
 Checking test 129 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4182,14 +4250,14 @@ Checking test 129 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 335.597551
-  0: The maximum resident set size (KB)                   = 275360
+  0: The total amount of wall time                        = 336.315609
+  0: The maximum resident set size (KB)                   = 276096
 
 Test 129 hafs_regional_1nest_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_1nest_atm_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_1nest_atm_qr_intel
 Checking test 130 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4211,14 +4279,14 @@ Checking test 130 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 358.207954
-  0: The maximum resident set size (KB)                   = 273400
+  0: The total amount of wall time                        = 901.047738
+  0: The maximum resident set size (KB)                   = 269856
 
 Test 130 hafs_regional_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_telescopic_2nests_atm_intel
 Checking test 131 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4227,14 +4295,14 @@ Checking test 131 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 385.179865
-  0: The maximum resident set size (KB)                   = 285184
+  0: The total amount of wall time                        = 385.056549
+  0: The maximum resident set size (KB)                   = 284064
 
 Test 131 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_global_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_global_1nest_atm_intel
 Checking test 132 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4281,14 +4349,14 @@ Checking test 132 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 152.181010
-  0: The maximum resident set size (KB)                   = 181896
+  0: The total amount of wall time                        = 153.532558
+  0: The maximum resident set size (KB)                   = 181964
 
 Test 132 hafs_global_1nest_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_global_1nest_atm_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_global_1nest_atm_qr_intel
 Checking test 133 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4335,14 +4403,14 @@ Checking test 133 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 181.981661
-  0: The maximum resident set size (KB)                   = 190176
+  0: The total amount of wall time                        = 205.617392
+  0: The maximum resident set size (KB)                   = 189864
 
 Test 133 hafs_global_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_global_multiple_4nests_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_global_multiple_4nests_atm_intel
 Checking test 134 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4424,14 +4492,14 @@ Checking test 134 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 437.090460
-  0: The maximum resident set size (KB)                   = 212768
+  0: The total amount of wall time                        = 439.969223
+  0: The maximum resident set size (KB)                   = 212604
 
 Test 134 hafs_global_multiple_4nests_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_global_multiple_4nests_atm_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_global_multiple_4nests_atm_qr_intel
 Checking test 135 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4513,14 +4581,14 @@ Checking test 135 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 705.648698
-  0: The maximum resident set size (KB)                   = 255792
+  0: The total amount of wall time                        = 1724.939409
+  0: The maximum resident set size (KB)                   = 254268
 
-Test 135 hafs_global_multiple_4nests_atm_qr_intel PASS
+Test 135 hafs_global_multiple_4nests_atm_qr_intel PASS Tries: 2
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_specified_moving_1nest_atm_intel
 Checking test 136 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4529,14 +4597,14 @@ Checking test 136 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 215.663813
-  0: The maximum resident set size (KB)                   = 292708
+  0: The total amount of wall time                        = 216.213065
+  0: The maximum resident set size (KB)                   = 292636
 
 Test 136 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_storm_following_1nest_atm_intel
 Checking test 137 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4558,14 +4626,14 @@ Checking test 137 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 200.560422
-  0: The maximum resident set size (KB)                   = 290572
+  0: The total amount of wall time                        = 200.445644
+  0: The maximum resident set size (KB)                   = 290964
 
 Test 137 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_storm_following_1nest_atm_qr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_storm_following_1nest_atm_qr_intel
 Checking test 138 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4587,14 +4655,14 @@ Checking test 138 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 227.769820
-  0: The maximum resident set size (KB)                   = 300448
+  0: The total amount of wall time                        = 249.140377
+  0: The maximum resident set size (KB)                   = 300236
 
 Test 138 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_storm_following_1nest_atm_ocn_intel
 Checking test 139 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4603,42 +4671,42 @@ Checking test 139 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 248.022521
-  0: The maximum resident set size (KB)                   = 318808
+  0: The total amount of wall time                        = 249.069854
+  0: The maximum resident set size (KB)                   = 319188
 
 Test 139 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_storm_following_1nest_atm_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_global_storm_following_1nest_atm_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_global_storm_following_1nest_atm_intel
 Checking test 140 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 59.231715
-  0: The maximum resident set size (KB)                   = 200700
+  0: The total amount of wall time                        = 59.843745
+  0: The maximum resident set size (KB)                   = 200460
 
 Test 140 hafs_global_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
 Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 756.768772
-  0: The maximum resident set size (KB)                   = 345432
+  0: The total amount of wall time                        = 757.418270
+  0: The maximum resident set size (KB)                   = 345384
 
 Test 141 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
 Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4649,14 +4717,14 @@ Checking test 142 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 644.428997
-  0: The maximum resident set size (KB)                   = 368072
+  0: The total amount of wall time                        = 643.103511
+  0: The maximum resident set size (KB)                   = 367788
 
 Test 142 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_docn_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_docn_intel
 Checking test 143 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4664,14 +4732,14 @@ Checking test 143 hafs_regional_docn_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 362.082131
-  0: The maximum resident set size (KB)                   = 722356
+  0: The total amount of wall time                        = 384.340830
+  0: The maximum resident set size (KB)                   = 722600
 
 Test 143 hafs_regional_docn_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_oisst_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_docn_oisst_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_docn_oisst_intel
 Checking test 144 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4679,131 +4747,131 @@ Checking test 144 hafs_regional_docn_oisst_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 359.063621
-  0: The maximum resident set size (KB)                   = 712188
+  0: The total amount of wall time                        = 370.932774
+  0: The maximum resident set size (KB)                   = 711976
 
 Test 144 hafs_regional_docn_oisst_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_datm_cdeps_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/hafs_regional_datm_cdeps_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/hafs_regional_datm_cdeps_intel
 Checking test 145 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1188.694470
-  0: The maximum resident set size (KB)                   = 805300
+  0: The total amount of wall time                        = 1187.993889
+  0: The maximum resident set size (KB)                   = 820004
 
 Test 145 hafs_regional_datm_cdeps_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_control_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_control_cfsr_intel
 Checking test 146 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 161.760252
- 0: The maximum resident set size (KB)                   = 716180
+ 0: The total amount of wall time                        = 163.814796
+ 0: The maximum resident set size (KB)                   = 716116
 
 Test 146 datm_cdeps_control_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_restart_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_restart_cfsr_intel
 Checking test 147 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 93.657413
- 0: The maximum resident set size (KB)                   = 711360
+ 0: The total amount of wall time                        = 95.362257
+ 0: The maximum resident set size (KB)                   = 711372
 
 Test 147 datm_cdeps_restart_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_gefs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_control_gefs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_control_gefs_intel
 Checking test 148 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.346083
- 0: The maximum resident set size (KB)                   = 599968
+ 0: The total amount of wall time                        = 156.447010
+ 0: The maximum resident set size (KB)                   = 600032
 
 Test 148 datm_cdeps_control_gefs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_iau_gefs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_iau_gefs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_iau_gefs_intel
 Checking test 149 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.085754
- 0: The maximum resident set size (KB)                   = 599992
+ 0: The total amount of wall time                        = 161.055970
+ 0: The maximum resident set size (KB)                   = 597992
 
 Test 149 datm_cdeps_iau_gefs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_stochy_gefs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_stochy_gefs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_stochy_gefs_intel
 Checking test 150 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.632095
- 0: The maximum resident set size (KB)                   = 595968
+ 0: The total amount of wall time                        = 157.628432
+ 0: The maximum resident set size (KB)                   = 605756
 
 Test 150 datm_cdeps_stochy_gefs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_ciceC_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_ciceC_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_ciceC_cfsr_intel
 Checking test 151 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 160.419602
- 0: The maximum resident set size (KB)                   = 716128
+ 0: The total amount of wall time                        = 161.976181
+ 0: The maximum resident set size (KB)                   = 716184
 
 Test 151 datm_cdeps_ciceC_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_bulk_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_bulk_cfsr_intel
 Checking test 152 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 159.946837
- 0: The maximum resident set size (KB)                   = 716124
+ 0: The total amount of wall time                        = 161.683934
+ 0: The maximum resident set size (KB)                   = 716172
 
 Test 152 datm_cdeps_bulk_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_gefs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_bulk_gefs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_bulk_gefs_intel
 Checking test 153 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.196876
- 0: The maximum resident set size (KB)                   = 596028
+ 0: The total amount of wall time                        = 154.241622
+ 0: The maximum resident set size (KB)                   = 595816
 
 Test 153 datm_cdeps_bulk_gefs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_mx025_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_mx025_cfsr_intel
 Checking test 154 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4812,14 +4880,14 @@ Checking test 154 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 390.448705
-  0: The maximum resident set size (KB)                   = 495384
+  0: The total amount of wall time                        = 389.863608
+  0: The maximum resident set size (KB)                   = 493700
 
 Test 154 datm_cdeps_mx025_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_gefs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_mx025_gefs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_mx025_gefs_intel
 Checking test 155 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4828,77 +4896,77 @@ Checking test 155 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 386.634909
-  0: The maximum resident set size (KB)                   = 473832
+  0: The total amount of wall time                        = 388.566375
+  0: The maximum resident set size (KB)                   = 473544
 
 Test 155 datm_cdeps_mx025_gefs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_multiple_files_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_multiple_files_cfsr_intel
 Checking test 156 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 182.412962
- 0: The maximum resident set size (KB)                   = 716168
+ 0: The total amount of wall time                        = 161.055781
+ 0: The maximum resident set size (KB)                   = 716204
 
 Test 156 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_3072x1536_cfsr_intel
 Checking test 157 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 246.027112
- 0: The maximum resident set size (KB)                   = 1941624
+ 0: The total amount of wall time                        = 246.724699
+ 0: The maximum resident set size (KB)                   = 1958736
 
 Test 157 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_gfs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_gfs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_gfs_intel
 Checking test 158 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 245.004408
- 0: The maximum resident set size (KB)                   = 1943416
+ 0: The total amount of wall time                        = 250.650208
+ 0: The maximum resident set size (KB)                   = 1940516
 
 Test 158 datm_cdeps_gfs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_debug_cfsr_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_debug_cfsr_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_debug_cfsr_intel
 Checking test 159 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 367.565202
- 0: The maximum resident set size (KB)                   = 699696
+ 0: The total amount of wall time                        = 367.843997
+ 0: The maximum resident set size (KB)                   = 707084
 
 Test 159 datm_cdeps_debug_cfsr_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_faster_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_control_cfsr_faster_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_control_cfsr_faster_intel
 Checking test 160 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 159.584245
- 0: The maximum resident set size (KB)                   = 716184
+ 0: The total amount of wall time                        = 162.668621
+ 0: The maximum resident set size (KB)                   = 716284
 
 Test 160 datm_cdeps_control_cfsr_faster_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_lnd_gswp3_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_lnd_gswp3_intel
 Checking test 161 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4907,14 +4975,14 @@ Checking test 161 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 7.307657
-  0: The maximum resident set size (KB)                   = 153400
+  0: The total amount of wall time                        = 7.773388
+  0: The maximum resident set size (KB)                   = 153260
 
-Test 161 datm_cdeps_lnd_gswp3_intel PASS Tries: 2
+Test 161 datm_cdeps_lnd_gswp3_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/datm_cdeps_lnd_gswp3_rst_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/datm_cdeps_lnd_gswp3_rst_intel
 Checking test 162 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4923,14 +4991,14 @@ Checking test 162 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 13.788920
-  0: The maximum resident set size (KB)                   = 148364
+  0: The total amount of wall time                        = 13.704248
+  0: The maximum resident set size (KB)                   = 148248
 
-Test 162 datm_cdeps_lnd_gswp3_rst_intel PASS Tries: 2
+Test 162 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_atmlnd_sbs_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_p8_atmlnd_sbs_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_p8_atmlnd_sbs_intel
 Checking test 163 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -5015,14 +5083,14 @@ Checking test 163 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 214.083313
-  0: The maximum resident set size (KB)                   = 1436396
+  0: The total amount of wall time                        = 215.995448
+  0: The maximum resident set size (KB)                   = 1436296
 
 Test 163 control_p8_atmlnd_sbs_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmwav_control_noaero_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/atmwav_control_noaero_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/atmwav_control_noaero_p8_intel
 Checking test 164 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5065,14 +5133,14 @@ Checking test 164 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 92.306027
-  0: The maximum resident set size (KB)                   = 1421300
+  0: The total amount of wall time                        = 93.591552
+  0: The maximum resident set size (KB)                   = 1421240
 
 Test 164 atmwav_control_noaero_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_atmwav_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/control_atmwav_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/control_atmwav_intel
 Checking test 165 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5116,14 +5184,14 @@ Checking test 165 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 90.009479
-  0: The maximum resident set size (KB)                   = 452732
+  0: The total amount of wall time                        = 90.548838
+  0: The maximum resident set size (KB)                   = 452744
 
 Test 165 control_atmwav_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/atmaero_control_p8_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/atmaero_control_p8_intel
 Checking test 166 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5167,14 +5235,14 @@ Checking test 166 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 233.926252
-  0: The maximum resident set size (KB)                   = 1446704
+  0: The total amount of wall time                        = 239.736802
+  0: The maximum resident set size (KB)                   = 1446216
 
 Test 166 atmaero_control_p8_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/atmaero_control_p8_rad_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/atmaero_control_p8_rad_intel
 Checking test 167 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5218,14 +5286,14 @@ Checking test 167 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 287.698382
-  0: The maximum resident set size (KB)                   = 1497248
+  0: The total amount of wall time                        = 288.638555
+  0: The maximum resident set size (KB)                   = 1496972
 
 Test 167 atmaero_control_p8_rad_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_micro_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/atmaero_control_p8_rad_micro_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/atmaero_control_p8_rad_micro_intel
 Checking test 168 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5269,14 +5337,14 @@ Checking test 168 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 294.965362
-  0: The maximum resident set size (KB)                   = 1502576
+  0: The total amount of wall time                        = 292.936602
+  0: The maximum resident set size (KB)                   = 1502796
 
 Test 168 atmaero_control_p8_rad_micro_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_atmaq_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_atmaq_intel
 Checking test 169 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5292,14 +5360,14 @@ Checking test 169 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 628.600953
-  0: The maximum resident set size (KB)                   = 965424
+  0: The total amount of wall time                        = 635.094902
+  0: The maximum resident set size (KB)                   = 967008
 
 Test 169 regional_atmaq_intel PASS
 
 
 baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_faster_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_5424/regional_atmaq_faster_intel
+working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_47431/regional_atmaq_faster_intel
 Checking test 170 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5315,108 +5383,12 @@ Checking test 170 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 579.228447
-  0: The maximum resident set size (KB)                   = 965532
+  0: The total amount of wall time                        = 584.088445
+  0: The maximum resident set size (KB)                   = 967264
 
 Test 170 regional_atmaq_faster_intel PASS
 
-FAILED TESTS: 
-cpld_control_p8_faster_intel 020 failed in run_test
-
-REGRESSION TEST FAILED
-Sat 24 Jun 2023 12:22:23 PM EDT
-Elapsed time: 01h:11m:58s. Have a nice day!
-Sat 24 Jun 2023 05:23:17 PM EDT
-Start Regression test
-
-Testing UFSWM Hash: bb0a41dd8ee19115327ebcc6db1442f5617ad752
-Testing With Submodule Hashes:
- 37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
- 2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
- 5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
- cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
- cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
- b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
- 24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
- fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
- e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
- c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
- 3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 955 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-
-baseline dir = /lustre/f2/pdata/ncep_shared/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_faster_intel
-working dir  = /lustre/f2/scratch/Jong.Kim/FV3_RT/rt_10842/cpld_control_p8_faster_intel
-Checking test 001 cpld_control_p8_faster_intel results ....
- Comparing sfcf021.tile1.nc .........OK
- Comparing sfcf021.tile2.nc .........OK
- Comparing sfcf021.tile3.nc .........OK
- Comparing sfcf021.tile4.nc .........OK
- Comparing sfcf021.tile5.nc .........OK
- Comparing sfcf021.tile6.nc .........OK
- Comparing atmf021.tile1.nc .........OK
- Comparing atmf021.tile2.nc .........OK
- Comparing atmf021.tile3.nc .........OK
- Comparing atmf021.tile4.nc .........OK
- Comparing atmf021.tile5.nc .........OK
- Comparing atmf021.tile6.nc .........OK
- Comparing sfcf024.tile1.nc .........OK
- Comparing sfcf024.tile2.nc .........OK
- Comparing sfcf024.tile3.nc .........OK
- Comparing sfcf024.tile4.nc .........OK
- Comparing sfcf024.tile5.nc .........OK
- Comparing sfcf024.tile6.nc .........OK
- Comparing atmf024.tile1.nc .........OK
- Comparing atmf024.tile2.nc .........OK
- Comparing atmf024.tile3.nc .........OK
- Comparing atmf024.tile4.nc .........OK
- Comparing atmf024.tile5.nc .........OK
- Comparing atmf024.tile6.nc .........OK
- Comparing gocart.inst_aod.20210323_0600z.nc4 .........OK
- Comparing RESTART/20210323.060000.coupler.res .........OK
- Comparing RESTART/20210323.060000.fv_core.res.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210323.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
- Comparing RESTART/20210323.060000.MOM.res.nc .........OK
- Comparing RESTART/iced.2021-03-23-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
- Comparing 20210323.060000.out_pnt.ww3 .........OK
- Comparing 20210323.060000.out_grd.ww3 .........OK
-
-  0: The total amount of wall time                        = 349.052830
-  0: The maximum resident set size (KB)                   = 1565860
-
-Test 001 cpld_control_p8_faster_intel PASS
-
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat 24 Jun 2023 05:51:37 PM EDT
-Elapsed time: 00h:28m:33s. Have a nice day!
+Tue 27 Jun 2023 06:30:13 PM EDT
+Elapsed time: 02h:30m:23s. Have a nice day!

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,73 +1,73 @@
-Sat Jun 24 19:53:05 UTC 2023
+Wed Jun 28 12:19:45 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: bb0a41dd8ee19115327ebcc6db1442f5617ad752
+Testing UFSWM Hash: 7b494db0ae614ad51f7df85848c8c0e4678be16a
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-1401-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
+ 596f540cff635a802d07cacf652d49b30d62ea6e ../FV3 (remotes/origin/unused_ccpp_suites)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 661 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 676 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 623 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 256 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 210 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 588 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 580 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 695 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 907 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 646 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 652 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 648 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 235 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 220 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 591 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 582 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 699 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 899 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile 010 elapsed time 225 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 011 elapsed time 604 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 547 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 539 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 493 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 588 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 240 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 169 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 517 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 521 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 180 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 178 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 566 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 207 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 652 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 595 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 186 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 113 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 185 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 64 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 545 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 570 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 588 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 522 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 516 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 183 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 037 elapsed time 545 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 038 elapsed time 204 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 039 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 040 elapsed time 349 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 041 elapsed time 103 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 042 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 043 elapsed time 432 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 044 elapsed time 353 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 045 elapsed time 350 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 046 elapsed time 273 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 047 elapsed time 244 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 048 elapsed time 151 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 049 elapsed time 254 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 050 elapsed time 133 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 011 elapsed time 587 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 543 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 526 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 507 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 566 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 241 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 183 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 511 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 529 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 182 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 182 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 588 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 199 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 599 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 584 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 199 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 028 elapsed time 115 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 213 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 59 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 567 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 606 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 596 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 544 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 527 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 184 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 037 elapsed time 549 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 038 elapsed time 202 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 039 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 040 elapsed time 176 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 041 elapsed time 102 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 042 elapsed time 198 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 043 elapsed time 272 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 044 elapsed time 182 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 045 elapsed time 177 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 046 elapsed time 262 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 047 elapsed time 230 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 048 elapsed time 142 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 049 elapsed time 253 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 050 elapsed time 140 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 Compile 051 elapsed time 119 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_mixedmode_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_p8_mixedmode_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -132,14 +132,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 307.682994
-  0: The maximum resident set size (KB)                   = 3119552
+  0: The total amount of wall time                        = 310.664221
+  0: The maximum resident set size (KB)                   = 3125812
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_gfsv17_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_gfsv17_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -203,14 +203,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 218.757339
-  0: The maximum resident set size (KB)                   = 1650412
+  0: The total amount of wall time                        = 222.209355
+  0: The maximum resident set size (KB)                   = 1678112
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -275,14 +275,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 336.765008
-  0: The maximum resident set size (KB)                   = 3148824
+  0: The total amount of wall time                        = 343.670813
+  0: The maximum resident set size (KB)                   = 3162632
 
 Test 003 cpld_control_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_restart_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -335,14 +335,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 194.286989
-  0: The maximum resident set size (KB)                   = 3043768
+  0: The total amount of wall time                        = 198.408580
+  0: The maximum resident set size (KB)                   = 3040000
 
 Test 004 cpld_restart_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -407,14 +407,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 339.169741
-  0: The maximum resident set size (KB)                   = 3173644
+  0: The total amount of wall time                        = 345.788190
+  0: The maximum resident set size (KB)                   = 3182164
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_restart_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -467,14 +467,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 199.514489
-  0: The maximum resident set size (KB)                   = 3017564
+  0: The total amount of wall time                        = 207.379831
+  0: The maximum resident set size (KB)                   = 3036084
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_2threads_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -527,14 +527,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 346.789318
-  0: The maximum resident set size (KB)                   = 3503692
+  0: The total amount of wall time                        = 354.051796
+  0: The maximum resident set size (KB)                   = 3461740
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_decomp_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -587,14 +587,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 341.094843
-  0: The maximum resident set size (KB)                   = 3154884
+  0: The total amount of wall time                        = 342.508182
+  0: The maximum resident set size (KB)                   = 3170272
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_mpi_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -647,14 +647,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 280.348626
-  0: The maximum resident set size (KB)                   = 3015028
+  0: The total amount of wall time                        = 284.564137
+  0: The maximum resident set size (KB)                   = 3008196
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_ciceC_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_ciceC_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -719,14 +719,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 343.708521
-  0: The maximum resident set size (KB)                   = 3161376
+  0: The total amount of wall time                        = 343.272546
+  0: The maximum resident set size (KB)                   = 3166840
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c192_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_c192_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_c192_p8_intel
 Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -779,14 +779,14 @@ Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 588.284220
-  0: The maximum resident set size (KB)                   = 3257444
+  0: The total amount of wall time                        = 607.954397
+  0: The maximum resident set size (KB)                   = 3239044
 
 Test 011 cpld_control_c192_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c192_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_restart_c192_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_restart_c192_p8_intel
 Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -839,14 +839,14 @@ Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 385.043092
-  0: The maximum resident set size (KB)                   = 3158340
+  0: The total amount of wall time                        = 391.321982
+  0: The maximum resident set size (KB)                   = 3137576
 
 Test 012 cpld_restart_c192_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_bmark_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_bmark_p8_intel
 Checking test 013 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -894,14 +894,14 @@ Checking test 013 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 771.491299
-   0: The maximum resident set size (KB)                   = 4025740
+   0: The total amount of wall time                        = 732.556349
+   0: The maximum resident set size (KB)                   = 3983320
 
 Test 013 cpld_bmark_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_restart_bmark_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_restart_bmark_p8_intel
 Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -949,14 +949,14 @@ Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 468.959940
-   0: The maximum resident set size (KB)                   = 3953732
+   0: The total amount of wall time                        = 459.269312
+   0: The maximum resident set size (KB)                   = 3952416
 
 Test 014 cpld_restart_bmark_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_noaero_p8_intel
 Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1020,14 +1020,14 @@ Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 271.500851
-  0: The maximum resident set size (KB)                   = 1712596
+  0: The total amount of wall time                        = 268.145495
+  0: The maximum resident set size (KB)                   = 1691548
 
 Test 015 cpld_control_noaero_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_nowave_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_nowave_noaero_p8_intel
 Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1089,14 +1089,14 @@ Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 262.608687
-  0: The maximum resident set size (KB)                   = 1755972
+  0: The total amount of wall time                        = 265.155917
+  0: The maximum resident set size (KB)                   = 1756848
 
 Test 016 cpld_control_nowave_noaero_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_debug_p8_intel
 Checking test 017 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1149,14 +1149,14 @@ Checking test 017 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 528.230097
-  0: The maximum resident set size (KB)                   = 3222112
+  0: The total amount of wall time                        = 526.909155
+  0: The maximum resident set size (KB)                   = 3179276
 
 Test 017 cpld_debug_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_debug_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_debug_noaero_p8_intel
 Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1208,14 +1208,14 @@ Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 368.115023
-  0: The maximum resident set size (KB)                   = 1728132
+  0: The total amount of wall time                        = 366.593211
+  0: The maximum resident set size (KB)                   = 1704720
 
 Test 018 cpld_debug_noaero_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_agrid_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_noaero_p8_agrid_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_noaero_p8_agrid_intel
 Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1277,14 +1277,14 @@ Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 273.573669
-  0: The maximum resident set size (KB)                   = 1757164
+  0: The total amount of wall time                        = 284.641271
+  0: The maximum resident set size (KB)                   = 1710796
 
 Test 019 cpld_control_noaero_p8_agrid_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_c48_intel
 Checking test 020 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1334,14 +1334,14 @@ Checking test 020 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 580.705144
- 0: The maximum resident set size (KB)                   = 2798600
+ 0: The total amount of wall time                        = 580.627657
+ 0: The maximum resident set size (KB)                   = 2796544
 
 Test 020 cpld_control_c48_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_warmstart_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_warmstart_c48_intel
 Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1391,14 +1391,14 @@ Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 157.903620
- 0: The maximum resident set size (KB)                   = 2775496
+ 0: The total amount of wall time                        = 159.890756
+ 0: The maximum resident set size (KB)                   = 2782456
 
 Test 021 cpld_warmstart_c48_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_restart_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_restart_c48_intel
 Checking test 022 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1448,14 +1448,14 @@ Checking test 022 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 82.418819
- 0: The maximum resident set size (KB)                   = 2219896
+ 0: The total amount of wall time                        = 82.691717
+ 0: The maximum resident set size (KB)                   = 2218024
 
 Test 022 cpld_restart_c48_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_p8_faster_intel
 Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1520,14 +1520,14 @@ Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 322.300953
-  0: The maximum resident set size (KB)                   = 3150728
+  0: The total amount of wall time                        = 324.984147
+  0: The maximum resident set size (KB)                   = 3169312
 
 Test 023 cpld_control_p8_faster_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_pdlib_p8_intel
 Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1591,14 +1591,14 @@ Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1194.264269
-  0: The maximum resident set size (KB)                   = 1727760
+  0: The total amount of wall time                        = 1198.993888
+  0: The maximum resident set size (KB)                   = 1743356
 
 Test 024 cpld_control_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_restart_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_restart_pdlib_p8_intel
 Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1650,14 +1650,14 @@ Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 559.407885
-  0: The maximum resident set size (KB)                   = 1015324
+  0: The total amount of wall time                        = 560.616649
+  0: The maximum resident set size (KB)                   = 1015820
 
 Test 025 cpld_restart_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_mpi_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_mpi_pdlib_p8_intel
 Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1721,14 +1721,14 @@ Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1077.551051
-  0: The maximum resident set size (KB)                   = 1651972
+  0: The total amount of wall time                        = 1083.991636
+  0: The maximum resident set size (KB)                   = 1644848
 
 Test 026 cpld_mpi_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_debug_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_debug_pdlib_p8_intel
 Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1780,14 +1780,14 @@ Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1383.741645
-  0: The maximum resident set size (KB)                   = 1686528
+  0: The total amount of wall time                        = 1380.386472
+  0: The maximum resident set size (KB)                   = 1687704
 
 Test 027 cpld_debug_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_flake_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_flake_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_flake_intel
 Checking test 028 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1798,14 +1798,14 @@ Checking test 028 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 187.568816
-  0: The maximum resident set size (KB)                   = 644656
+  0: The total amount of wall time                        = 187.423887
+  0: The maximum resident set size (KB)                   = 675620
 
 Test 028 control_flake_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_CubedSphereGrid_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_CubedSphereGrid_intel
 Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1832,28 +1832,28 @@ Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.673412
-  0: The maximum resident set size (KB)                   = 623152
+  0: The total amount of wall time                        = 131.657760
+  0: The maximum resident set size (KB)                   = 622528
 
 Test 029 control_CubedSphereGrid_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_CubedSphereGrid_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_CubedSphereGrid_parallel_intel
 Checking test 030 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 127.180015
-  0: The maximum resident set size (KB)                   = 628252
+  0: The total amount of wall time                        = 129.584377
+  0: The maximum resident set size (KB)                   = 598560
 
 Test 030 control_CubedSphereGrid_parallel_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_latlon_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_latlon_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_latlon_intel
 Checking test 031 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1864,14 +1864,14 @@ Checking test 031 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.801498
-  0: The maximum resident set size (KB)                   = 621120
+  0: The total amount of wall time                        = 136.563469
+  0: The maximum resident set size (KB)                   = 627512
 
 Test 031 control_latlon_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_wrtGauss_netcdf_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_wrtGauss_netcdf_parallel_intel
 Checking test 032 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1882,14 +1882,14 @@ Checking test 032 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.642703
-  0: The maximum resident set size (KB)                   = 625144
+  0: The total amount of wall time                        = 138.897791
+  0: The maximum resident set size (KB)                   = 626228
 
 Test 032 control_wrtGauss_netcdf_parallel_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_c48_intel
 Checking test 033 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1928,14 +1928,14 @@ Checking test 033 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 370.652923
-0: The maximum resident set size (KB)                   = 817444
+0: The total amount of wall time                        = 369.668880
+0: The maximum resident set size (KB)                   = 818924
 
 Test 033 control_c48_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c192_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_c192_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_c192_intel
 Checking test 034 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1946,14 +1946,14 @@ Checking test 034 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 526.441672
-  0: The maximum resident set size (KB)                   = 760016
+  0: The total amount of wall time                        = 529.305155
+  0: The maximum resident set size (KB)                   = 737580
 
 Test 034 control_c192_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c384_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_c384_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_c384_intel
 Checking test 035 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1964,14 +1964,14 @@ Checking test 035 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 517.858514
-  0: The maximum resident set size (KB)                   = 1250824
+  0: The total amount of wall time                        = 529.793275
+  0: The maximum resident set size (KB)                   = 1264780
 
 Test 035 control_c384_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c384gdas_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_c384gdas_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_c384gdas_intel
 Checking test 036 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2014,14 +2014,14 @@ Checking test 036 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 458.435668
-  0: The maximum resident set size (KB)                   = 1381856
+  0: The total amount of wall time                        = 465.729544
+  0: The maximum resident set size (KB)                   = 1361224
 
 Test 036 control_c384gdas_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_stochy_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_stochy_intel
 Checking test 037 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2032,28 +2032,28 @@ Checking test 037 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 87.738380
-  0: The maximum resident set size (KB)                   = 629168
+  0: The total amount of wall time                        = 88.715678
+  0: The maximum resident set size (KB)                   = 626700
 
 Test 037 control_stochy_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_stochy_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_stochy_restart_intel
 Checking test 038 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.619447
-  0: The maximum resident set size (KB)                   = 461096
+  0: The total amount of wall time                        = 48.277030
+  0: The maximum resident set size (KB)                   = 481616
 
 Test 038 control_stochy_restart_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_lndp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_lndp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_lndp_intel
 Checking test 039 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2064,14 +2064,14 @@ Checking test 039 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 80.953963
-  0: The maximum resident set size (KB)                   = 633896
+  0: The total amount of wall time                        = 83.405529
+  0: The maximum resident set size (KB)                   = 631180
 
 Test 039 control_lndp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_iovr4_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_iovr4_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_iovr4_intel
 Checking test 040 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2086,14 +2086,14 @@ Checking test 040 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.421668
-  0: The maximum resident set size (KB)                   = 628096
+  0: The total amount of wall time                        = 136.163066
+  0: The maximum resident set size (KB)                   = 623508
 
 Test 040 control_iovr4_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_iovr5_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_iovr5_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_iovr5_intel
 Checking test 041 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2108,14 +2108,14 @@ Checking test 041 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.100277
-  0: The maximum resident set size (KB)                   = 623748
+  0: The total amount of wall time                        = 135.235839
+  0: The maximum resident set size (KB)                   = 620756
 
 Test 041 control_iovr5_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_p8_intel
 Checking test 042 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2162,14 +2162,14 @@ Checking test 042 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 169.138914
-  0: The maximum resident set size (KB)                   = 1593784
+  0: The total amount of wall time                        = 170.534160
+  0: The maximum resident set size (KB)                   = 1591028
 
 Test 042 control_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_restart_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_restart_p8_intel
 Checking test 043 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2208,14 +2208,14 @@ Checking test 043 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 87.957043
-  0: The maximum resident set size (KB)                   = 871312
+  0: The total amount of wall time                        = 102.889307
+  0: The maximum resident set size (KB)                   = 865904
 
 Test 043 control_restart_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_qr_p8_intel
 Checking test 044 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2262,14 +2262,14 @@ Checking test 044 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 167.479031
-  0: The maximum resident set size (KB)                   = 1600200
+  0: The total amount of wall time                        = 168.429634
+  0: The maximum resident set size (KB)                   = 1605884
 
 Test 044 control_qr_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_restart_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_restart_qr_p8_intel
 Checking test 045 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2308,14 +2308,14 @@ Checking test 045 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 90.246561
-  0: The maximum resident set size (KB)                   = 837272
+  0: The total amount of wall time                        = 95.898954
+  0: The maximum resident set size (KB)                   = 859900
 
 Test 045 control_restart_qr_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_decomp_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_decomp_p8_intel
 Checking test 046 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2358,14 +2358,14 @@ Checking test 046 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.891806
-  0: The maximum resident set size (KB)                   = 1577752
+  0: The total amount of wall time                        = 176.893156
+  0: The maximum resident set size (KB)                   = 1570800
 
 Test 046 control_decomp_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_2threads_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_2threads_p8_intel
 Checking test 047 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2408,14 +2408,14 @@ Checking test 047 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.568754
-  0: The maximum resident set size (KB)                   = 1676928
+  0: The total amount of wall time                        = 158.373942
+  0: The maximum resident set size (KB)                   = 1680652
 
 Test 047 control_2threads_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_lndp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_p8_lndp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_p8_lndp_intel
 Checking test 048 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2434,14 +2434,14 @@ Checking test 048 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 312.027112
-  0: The maximum resident set size (KB)                   = 1596276
+  0: The total amount of wall time                        = 319.826160
+  0: The maximum resident set size (KB)                   = 1595456
 
 Test 048 control_p8_lndp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_rrtmgp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_p8_rrtmgp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_p8_rrtmgp_intel
 Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2488,14 +2488,14 @@ Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 223.496641
-  0: The maximum resident set size (KB)                   = 1646144
+  0: The total amount of wall time                        = 226.372989
+  0: The maximum resident set size (KB)                   = 1656000
 
 Test 049 control_p8_rrtmgp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_mynn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_p8_mynn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_p8_mynn_intel
 Checking test 050 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2542,14 +2542,14 @@ Checking test 050 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 171.099802
-  0: The maximum resident set size (KB)                   = 1599064
+  0: The total amount of wall time                        = 175.833814
+  0: The maximum resident set size (KB)                   = 1580364
 
 Test 050 control_p8_mynn_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/merra2_thompson_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/merra2_thompson_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/merra2_thompson_intel
 Checking test 051 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2596,14 +2596,14 @@ Checking test 051 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.045753
-  0: The maximum resident set size (KB)                   = 1573136
+  0: The total amount of wall time                        = 192.918480
+  0: The maximum resident set size (KB)                   = 1598108
 
 Test 051 merra2_thompson_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_control_intel
 Checking test 052 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2614,28 +2614,28 @@ Checking test 052 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 291.632037
-  0: The maximum resident set size (KB)                   = 861556
+  0: The total amount of wall time                        = 293.833192
+  0: The maximum resident set size (KB)                   = 863520
 
 Test 052 regional_control_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_restart_intel
 Checking test 053 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 149.659433
-  0: The maximum resident set size (KB)                   = 860984
+  0: The total amount of wall time                        = 149.477448
+  0: The maximum resident set size (KB)                   = 857288
 
 Test 053 regional_restart_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_control_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_control_qr_intel
 Checking test 054 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2646,28 +2646,28 @@ Checking test 054 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 290.895037
-  0: The maximum resident set size (KB)                   = 872220
+  0: The total amount of wall time                        = 296.542254
+  0: The maximum resident set size (KB)                   = 864400
 
 Test 054 regional_control_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_restart_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_restart_qr_intel
 Checking test 055 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 149.936340
-  0: The maximum resident set size (KB)                   = 859628
+  0: The total amount of wall time                        = 150.794974
+  0: The maximum resident set size (KB)                   = 854368
 
 Test 055 regional_restart_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_decomp_intel
 Checking test 056 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2678,14 +2678,14 @@ Checking test 056 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 307.951481
-  0: The maximum resident set size (KB)                   = 833128
+  0: The total amount of wall time                        = 315.052879
+  0: The maximum resident set size (KB)                   = 852848
 
 Test 056 regional_decomp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_2threads_intel
 Checking test 057 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2696,14 +2696,14 @@ Checking test 057 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 175.472816
-  0: The maximum resident set size (KB)                   = 842068
+  0: The total amount of wall time                        = 180.429943
+  0: The maximum resident set size (KB)                   = 844904
 
 Test 057 regional_2threads_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_noquilt_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_noquilt_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_noquilt_intel
 Checking test 058 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2711,28 +2711,28 @@ Checking test 058 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 293.334788
-  0: The maximum resident set size (KB)                   = 834100
+  0: The total amount of wall time                        = 296.876150
+  0: The maximum resident set size (KB)                   = 853072
 
 Test 058 regional_noquilt_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_netcdf_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_netcdf_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_netcdf_parallel_intel
 Checking test 059 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 284.464293
-  0: The maximum resident set size (KB)                   = 856484
+  0: The total amount of wall time                        = 289.374412
+  0: The maximum resident set size (KB)                   = 858872
 
 Test 059 regional_netcdf_parallel_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_2dwrtdecomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_2dwrtdecomp_intel
 Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2743,14 +2743,14 @@ Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 293.742210
-  0: The maximum resident set size (KB)                   = 843072
+  0: The total amount of wall time                        = 294.149858
+  0: The maximum resident set size (KB)                   = 874980
 
 Test 060 regional_2dwrtdecomp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/fv3_regional_wofs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_wofs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_wofs_intel
 Checking test 061 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2761,14 +2761,14 @@ Checking test 061 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 371.687744
-  0: The maximum resident set size (KB)                   = 624700
+  0: The total amount of wall time                        = 377.100623
+  0: The maximum resident set size (KB)                   = 626480
 
 Test 061 regional_wofs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_intel
 Checking test 062 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2815,14 +2815,14 @@ Checking test 062 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 445.828653
-  0: The maximum resident set size (KB)                   = 1024108
+  0: The total amount of wall time                        = 453.822823
+  0: The maximum resident set size (KB)                   = 1050232
 
 Test 062 rap_control_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_spp_sppt_shum_skeb_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_spp_sppt_shum_skeb_intel
 Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2833,14 +2833,14 @@ Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 230.222504
-  0: The maximum resident set size (KB)                   = 1181168
+  0: The total amount of wall time                        = 245.385899
+  0: The maximum resident set size (KB)                   = 1184808
 
 Test 063 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_decomp_intel
 Checking test 064 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2887,14 +2887,14 @@ Checking test 064 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 465.038545
-  0: The maximum resident set size (KB)                   = 990928
+  0: The total amount of wall time                        = 474.653941
+  0: The maximum resident set size (KB)                   = 996768
 
 Test 064 rap_decomp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_2threads_intel
 Checking test 065 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2941,14 +2941,14 @@ Checking test 065 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 415.267428
-  0: The maximum resident set size (KB)                   = 1126040
+  0: The total amount of wall time                        = 432.098714
+  0: The maximum resident set size (KB)                   = 1139780
 
 Test 065 rap_2threads_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_restart_intel
 Checking test 066 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2987,14 +2987,14 @@ Checking test 066 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 227.434404
-  0: The maximum resident set size (KB)                   = 954988
+  0: The total amount of wall time                        = 228.270524
+  0: The maximum resident set size (KB)                   = 954456
 
 Test 066 rap_restart_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_sfcdiff_intel
 Checking test 067 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3041,14 +3041,14 @@ Checking test 067 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 447.745211
-  0: The maximum resident set size (KB)                   = 1042156
+  0: The total amount of wall time                        = 453.628445
+  0: The maximum resident set size (KB)                   = 1047948
 
 Test 067 rap_sfcdiff_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_sfcdiff_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_sfcdiff_decomp_intel
 Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3095,14 +3095,14 @@ Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 466.977485
-  0: The maximum resident set size (KB)                   = 994520
+  0: The total amount of wall time                        = 476.871297
+  0: The maximum resident set size (KB)                   = 996636
 
 Test 068 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_sfcdiff_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_sfcdiff_restart_intel
 Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3141,14 +3141,14 @@ Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 333.504678
-  0: The maximum resident set size (KB)                   = 988004
+  0: The total amount of wall time                        = 332.728656
+  0: The maximum resident set size (KB)                   = 985056
 
 Test 069 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_intel
 Checking test 070 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3195,14 +3195,14 @@ Checking test 070 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 427.689215
-  0: The maximum resident set size (KB)                   = 1055160
+  0: The total amount of wall time                        = 431.235238
+  0: The maximum resident set size (KB)                   = 1051456
 
 Test 070 hrrr_control_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_qr_intel
 Checking test 071 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3249,14 +3249,14 @@ Checking test 071 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 426.258096
-  0: The maximum resident set size (KB)                   = 1053496
+  0: The total amount of wall time                        = 429.578943
+  0: The maximum resident set size (KB)                   = 1057208
 
 Test 071 hrrr_control_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_decomp_intel
 Checking test 072 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3303,14 +3303,14 @@ Checking test 072 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 444.591218
-  0: The maximum resident set size (KB)                   = 991144
+  0: The total amount of wall time                        = 450.733472
+  0: The maximum resident set size (KB)                   = 1005484
 
 Test 072 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_2threads_intel
 Checking test 073 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3357,42 +3357,42 @@ Checking test 073 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 394.468968
-  0: The maximum resident set size (KB)                   = 1069568
+  0: The total amount of wall time                        = 399.340922
+  0: The maximum resident set size (KB)                   = 1073336
 
 Test 073 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_intel
 Checking test 074 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 318.876737
-  0: The maximum resident set size (KB)                   = 975724
+  0: The total amount of wall time                        = 321.914483
+  0: The maximum resident set size (KB)                   = 989792
 
 Test 074 hrrr_control_restart_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_qr_intel
 Checking test 075 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 321.019983
-  0: The maximum resident set size (KB)                   = 991744
+  0: The total amount of wall time                        = 325.437159
+  0: The maximum resident set size (KB)                   = 988764
 
 Test 075 hrrr_control_restart_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_v1beta_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_v1beta_intel
 Checking test 076 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3439,14 +3439,14 @@ Checking test 076 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 438.215104
-  0: The maximum resident set size (KB)                   = 1042992
+  0: The total amount of wall time                        = 444.687260
+  0: The maximum resident set size (KB)                   = 1051976
 
 Test 076 rrfs_v1beta_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_v1nssl_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_v1nssl_intel
 Checking test 077 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3461,14 +3461,14 @@ Checking test 077 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 521.058621
-  0: The maximum resident set size (KB)                   = 687000
+  0: The total amount of wall time                        = 524.656032
+  0: The maximum resident set size (KB)                   = 682852
 
 Test 077 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_v1nssl_nohailnoccn_intel
 Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3483,14 +3483,14 @@ Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 506.283606
-  0: The maximum resident set size (KB)                   = 752720
+  0: The total amount of wall time                        = 513.208627
+  0: The maximum resident set size (KB)                   = 755244
 
 Test 078 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3506,14 +3506,14 @@ Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 150.020382
-  0: The maximum resident set size (KB)                   = 998520
+  0: The total amount of wall time                        = 149.953019
+  0: The maximum resident set size (KB)                   = 1029588
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
 Checking test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3522,14 +3522,14 @@ Checking test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 91.534965
-  0: The maximum resident set size (KB)                   = 926256
+  0: The total amount of wall time                        = 92.575028
+  0: The maximum resident set size (KB)                   = 938256
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_conus13km_hrrr_warm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_conus13km_hrrr_warm_intel
 Checking test 081 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3545,14 +3545,14 @@ Checking test 081 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 131.286499
-  0: The maximum resident set size (KB)                   = 984364
+  0: The total amount of wall time                        = 131.237140
+  0: The maximum resident set size (KB)                   = 987024
 
 Test 081 rrfs_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_radar_tten_warm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_radar_tten_warm_intel
 Checking test 082 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3561,26 +3561,26 @@ Checking test 082 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 150.342732
-  0: The maximum resident set size (KB)                   = 1034828
+  0: The total amount of wall time                        = 150.178366
+  0: The maximum resident set size (KB)                   = 1036096
 
 Test 082 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
 Checking test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 84.545865
-  0: The maximum resident set size (KB)                   = 990616
+  0: The total amount of wall time                        = 82.671603
+  0: The maximum resident set size (KB)                   = 1020312
 
 Test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmg_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_csawmg_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_csawmg_intel
 Checking test 084 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3591,14 +3591,14 @@ Checking test 084 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 336.540234
-  0: The maximum resident set size (KB)                   = 708224
+  0: The total amount of wall time                        = 338.740524
+  0: The maximum resident set size (KB)                   = 721344
 
 Test 084 control_csawmg_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_csawmgt_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_csawmgt_intel
 Checking test 085 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3609,14 +3609,14 @@ Checking test 085 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 330.132046
-  0: The maximum resident set size (KB)                   = 720712
+  0: The total amount of wall time                        = 334.184474
+  0: The maximum resident set size (KB)                   = 718976
 
 Test 085 control_csawmgt_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_ras_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_ras_intel
 Checking test 086 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3627,26 +3627,26 @@ Checking test 086 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 183.003735
-  0: The maximum resident set size (KB)                   = 719796
+  0: The total amount of wall time                        = 184.489893
+  0: The maximum resident set size (KB)                   = 726152
 
 Test 086 control_ras_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_wam_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_wam_intel
 Checking test 087 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 113.111534
-  0: The maximum resident set size (KB)                   = 616992
+  0: The total amount of wall time                        = 111.706273
+  0: The maximum resident set size (KB)                   = 632888
 
 Test 087 control_wam_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_p8_faster_intel
 Checking test 088 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3693,14 +3693,14 @@ Checking test 088 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.834032
-  0: The maximum resident set size (KB)                   = 1565688
+  0: The total amount of wall time                        = 152.990406
+  0: The maximum resident set size (KB)                   = 1604660
 
 Test 088 control_p8_faster_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_control_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_control_faster_intel
 Checking test 089 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3711,56 +3711,56 @@ Checking test 089 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 267.756949
-  0: The maximum resident set size (KB)                   = 864168
+  0: The total amount of wall time                        = 270.130295
+  0: The maximum resident set size (KB)                   = 866532
 
 Test 089 regional_control_faster_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_debug_intel
 Checking test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 838.675256
-  0: The maximum resident set size (KB)                   = 1036772
+  0: The total amount of wall time                        = 835.289727
+  0: The maximum resident set size (KB)                   = 1059828
 
 Test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
 Checking test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 455.770715
-  0: The maximum resident set size (KB)                   = 970084
+  0: The total amount of wall time                        = 479.321234
+  0: The maximum resident set size (KB)                   = 967196
 
 Test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_conus13km_hrrr_warm_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_conus13km_hrrr_warm_debug_intel
 Checking test 092 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 751.361481
-  0: The maximum resident set size (KB)                   = 985692
+  0: The total amount of wall time                        = 744.119588
+  0: The maximum resident set size (KB)                   = 1016464
 
 Test 092 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_CubedSphereGrid_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_CubedSphereGrid_debug_intel
 Checking test 093 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3787,348 +3787,348 @@ Checking test 093 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 149.501818
-  0: The maximum resident set size (KB)                   = 789040
+  0: The total amount of wall time                        = 150.178795
+  0: The maximum resident set size (KB)                   = 801620
 
 Test 093 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 094 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.739810
-  0: The maximum resident set size (KB)                   = 780988
+  0: The total amount of wall time                        = 145.617734
+  0: The maximum resident set size (KB)                   = 792388
 
 Test 094 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_stochy_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_stochy_debug_intel
 Checking test 095 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.064784
-  0: The maximum resident set size (KB)                   = 777668
+  0: The total amount of wall time                        = 164.304798
+  0: The maximum resident set size (KB)                   = 797336
 
 Test 095 control_stochy_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_lndp_debug_intel
 Checking test 096 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 147.156951
-  0: The maximum resident set size (KB)                   = 793096
+  0: The total amount of wall time                        = 151.523501
+  0: The maximum resident set size (KB)                   = 772164
 
 Test 096 control_lndp_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmg_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_csawmg_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_csawmg_debug_intel
 Checking test 097 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 224.804556
-  0: The maximum resident set size (KB)                   = 838024
+  0: The total amount of wall time                        = 232.906831
+  0: The maximum resident set size (KB)                   = 837592
 
 Test 097 control_csawmg_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_csawmgt_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_csawmgt_debug_intel
 Checking test 098 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 226.622569
-  0: The maximum resident set size (KB)                   = 825448
+  0: The total amount of wall time                        = 226.020292
+  0: The maximum resident set size (KB)                   = 836152
 
 Test 098 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_ras_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_ras_debug_intel
 Checking test 099 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.630102
-  0: The maximum resident set size (KB)                   = 776880
+  0: The total amount of wall time                        = 152.966893
+  0: The maximum resident set size (KB)                   = 801232
 
 Test 099 control_ras_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_diag_debug_intel
 Checking test 100 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.393458
-  0: The maximum resident set size (KB)                   = 850424
+  0: The total amount of wall time                        = 155.772164
+  0: The maximum resident set size (KB)                   = 848496
 
 Test 100 control_diag_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_debug_p8_intel
 Checking test 101 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.662852
-  0: The maximum resident set size (KB)                   = 1587780
+  0: The total amount of wall time                        = 164.753986
+  0: The maximum resident set size (KB)                   = 1615488
 
 Test 101 control_debug_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_debug_intel
 Checking test 102 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 946.363039
-  0: The maximum resident set size (KB)                   = 882596
+  0: The total amount of wall time                        = 993.589957
+  0: The maximum resident set size (KB)                   = 880512
 
 Test 102 regional_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_debug_intel
 Checking test 103 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.321561
-  0: The maximum resident set size (KB)                   = 1164064
+  0: The total amount of wall time                        = 276.725210
+  0: The maximum resident set size (KB)                   = 1169804
 
 Test 103 rap_control_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_debug_intel
 Checking test 104 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.535362
-  0: The maximum resident set size (KB)                   = 1145464
+  0: The total amount of wall time                        = 263.979984
+  0: The maximum resident set size (KB)                   = 1169292
 
 Test 104 hrrr_control_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_unified_drag_suite_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_unified_drag_suite_debug_intel
 Checking test 105 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.389535
-  0: The maximum resident set size (KB)                   = 1156320
+  0: The total amount of wall time                        = 274.358952
+  0: The maximum resident set size (KB)                   = 1170800
 
 Test 105 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_diag_debug_intel
 Checking test 106 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.784293
-  0: The maximum resident set size (KB)                   = 1234436
+  0: The total amount of wall time                        = 285.720377
+  0: The maximum resident set size (KB)                   = 1248924
 
 Test 106 rap_diag_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_cires_ugwp_debug_intel
 Checking test 107 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.426115
-  0: The maximum resident set size (KB)                   = 1167616
+  0: The total amount of wall time                        = 277.151532
+  0: The maximum resident set size (KB)                   = 1166672
 
 Test 107 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_unified_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_unified_ugwp_debug_intel
 Checking test 108 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.137340
-  0: The maximum resident set size (KB)                   = 1170256
+  0: The total amount of wall time                        = 282.857460
+  0: The maximum resident set size (KB)                   = 1165164
 
 Test 108 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_lndp_debug_intel
 Checking test 109 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.588370
-  0: The maximum resident set size (KB)                   = 1168840
+  0: The total amount of wall time                        = 276.407904
+  0: The maximum resident set size (KB)                   = 1168852
 
 Test 109 rap_lndp_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_progcld_thompson_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_progcld_thompson_debug_intel
 Checking test 110 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.870291
-  0: The maximum resident set size (KB)                   = 1165312
+  0: The total amount of wall time                        = 275.099448
+  0: The maximum resident set size (KB)                   = 1165080
 
 Test 110 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_noah_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_noah_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_noah_debug_intel
 Checking test 111 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.566581
-  0: The maximum resident set size (KB)                   = 1166508
+  0: The total amount of wall time                        = 264.379069
+  0: The maximum resident set size (KB)                   = 1167704
 
 Test 111 rap_noah_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_sfcdiff_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_sfcdiff_debug_intel
 Checking test 112 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.396963
-  0: The maximum resident set size (KB)                   = 1162544
+  0: The total amount of wall time                        = 272.581996
+  0: The maximum resident set size (KB)                   = 1167404
 
 Test 112 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 445.670817
-  0: The maximum resident set size (KB)                   = 1163620
+  0: The total amount of wall time                        = 446.032846
+  0: The maximum resident set size (KB)                   = 1166468
 
 Test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_v1beta_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_v1beta_debug_intel
 Checking test 114 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.064469
-  0: The maximum resident set size (KB)                   = 1141236
+  0: The total amount of wall time                        = 266.921673
+  0: The maximum resident set size (KB)                   = 1145472
 
 Test 114 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_clm_lake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_clm_lake_debug_intel
 Checking test 115 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 329.042265
-  0: The maximum resident set size (KB)                   = 1139140
+  0: The total amount of wall time                        = 353.894948
+  0: The maximum resident set size (KB)                   = 1158200
 
 Test 115 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_flake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_flake_debug_intel
 Checking test 116 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.659554
-  0: The maximum resident set size (KB)                   = 1170792
+  0: The total amount of wall time                        = 268.080066
+  0: The maximum resident set size (KB)                   = 1163256
 
 Test 116 rap_flake_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_wam_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_wam_debug_intel
 Checking test 117 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 277.162686
-  0: The maximum resident set size (KB)                   = 490952
+  0: The total amount of wall time                        = 280.887032
+  0: The maximum resident set size (KB)                   = 525572
 
 Test 117 control_wam_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -4139,14 +4139,14 @@ Checking test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 214.184752
-  0: The maximum resident set size (KB)                   = 1067996
+  0: The total amount of wall time                        = 217.658378
+  0: The maximum resident set size (KB)                   = 1075412
 
 Test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_dyn32_phy32_intel
 Checking test 119 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4193,14 +4193,14 @@ Checking test 119 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 370.326915
-  0: The maximum resident set size (KB)                   = 964268
+  0: The total amount of wall time                        = 368.616778
+  0: The maximum resident set size (KB)                   = 995796
 
 Test 119 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_dyn32_phy32_intel
 Checking test 120 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4247,14 +4247,14 @@ Checking test 120 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 189.205836
-  0: The maximum resident set size (KB)                   = 942964
+  0: The total amount of wall time                        = 191.407676
+  0: The maximum resident set size (KB)                   = 954260
 
 Test 120 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_qr_dyn32_phy32_intel
 Checking test 121 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4301,14 +4301,14 @@ Checking test 121 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.075817
-  0: The maximum resident set size (KB)                   = 955976
+  0: The total amount of wall time                        = 191.190767
+  0: The maximum resident set size (KB)                   = 933608
 
 Test 121 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_2threads_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_2threads_dyn32_phy32_intel
 Checking test 122 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4355,14 +4355,14 @@ Checking test 122 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 346.788685
-  0: The maximum resident set size (KB)                   = 1014936
+  0: The total amount of wall time                        = 346.705866
+  0: The maximum resident set size (KB)                   = 998280
 
 Test 122 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 123 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4409,14 +4409,14 @@ Checking test 123 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 175.061956
-  0: The maximum resident set size (KB)                   = 931776
+  0: The total amount of wall time                        = 176.696296
+  0: The maximum resident set size (KB)                   = 926168
 
 Test 123 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 124 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4463,14 +4463,14 @@ Checking test 124 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 198.409419
-  0: The maximum resident set size (KB)                   = 888080
+  0: The total amount of wall time                        = 201.015022
+  0: The maximum resident set size (KB)                   = 891156
 
 Test 124 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_restart_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_restart_dyn32_phy32_intel
 Checking test 125 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4509,42 +4509,42 @@ Checking test 125 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 274.169851
-  0: The maximum resident set size (KB)                   = 938028
+  0: The total amount of wall time                        = 274.381635
+  0: The maximum resident set size (KB)                   = 942808
 
 Test 125 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_dyn32_phy32_intel
 Checking test 126 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 99.060726
-  0: The maximum resident set size (KB)                   = 859068
+  0: The total amount of wall time                        = 100.459004
+  0: The maximum resident set size (KB)                   = 855440
 
 Test 126 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_qr_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_qr_dyn32_phy32_intel
 Checking test 127 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.355062
-  0: The maximum resident set size (KB)                   = 858372
+  0: The total amount of wall time                        = 101.826763
+  0: The maximum resident set size (KB)                   = 875716
 
 Test 127 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_dyn64_phy32_intel
 Checking test 128 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4591,81 +4591,81 @@ Checking test 128 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.954358
-  0: The maximum resident set size (KB)                   = 954956
+  0: The total amount of wall time                        = 239.135515
+  0: The maximum resident set size (KB)                   = 956024
 
 Test 128 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_debug_dyn32_phy32_intel
 Checking test 129 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.191332
-  0: The maximum resident set size (KB)                   = 1052232
+  0: The total amount of wall time                        = 272.489202
+  0: The maximum resident set size (KB)                   = 1046960
 
 Test 129 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_debug_dyn32_phy32_intel
 Checking test 130 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 263.221004
-  0: The maximum resident set size (KB)                   = 1044832
+  0: The total amount of wall time                        = 262.950042
+  0: The maximum resident set size (KB)                   = 1048912
 
 Test 130 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_dyn64_phy32_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_dyn64_phy32_debug_intel
 Checking test 131 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.999227
-  0: The maximum resident set size (KB)                   = 1081780
+  0: The total amount of wall time                        = 274.833467
+  0: The maximum resident set size (KB)                   = 1085456
 
 Test 131 rap_control_dyn64_phy32_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_atm_intel
 Checking test 132 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 221.811827
-  0: The maximum resident set size (KB)                   = 1038456
+  0: The total amount of wall time                        = 228.102026
+  0: The maximum resident set size (KB)                   = 1038252
 
 Test 132 hafs_regional_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 133 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 306.103819
-  0: The maximum resident set size (KB)                   = 1405492
+  0: The total amount of wall time                        = 318.190687
+  0: The maximum resident set size (KB)                   = 1407420
 
 Test 133 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_atm_ocn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_atm_ocn_intel
 Checking test 134 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4674,14 +4674,14 @@ Checking test 134 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 378.427474
-  0: The maximum resident set size (KB)                   = 1215292
+  0: The total amount of wall time                        = 382.393496
+  0: The maximum resident set size (KB)                   = 1219308
 
 Test 134 hafs_regional_atm_ocn_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_atm_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_atm_wav_intel
 Checking test 135 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4690,14 +4690,14 @@ Checking test 135 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 743.646492
-  0: The maximum resident set size (KB)                   = 1239032
+  0: The total amount of wall time                        = 743.613902
+  0: The maximum resident set size (KB)                   = 1248852
 
 Test 135 hafs_regional_atm_wav_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_atm_ocn_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_atm_ocn_wav_intel
 Checking test 136 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4708,14 +4708,14 @@ Checking test 136 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 842.491351
-  0: The maximum resident set size (KB)                   = 1259144
+  0: The total amount of wall time                        = 847.760379
+  0: The maximum resident set size (KB)                   = 1266204
 
 Test 136 hafs_regional_atm_ocn_wav_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_1nest_atm_intel
 Checking test 137 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4737,14 +4737,14 @@ Checking test 137 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 295.953346
-  0: The maximum resident set size (KB)                   = 477620
+  0: The total amount of wall time                        = 297.288827
+  0: The maximum resident set size (KB)                   = 499704
 
 Test 137 hafs_regional_1nest_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_1nest_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_1nest_atm_qr_intel
 Checking test 138 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4766,14 +4766,14 @@ Checking test 138 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 305.280377
-  0: The maximum resident set size (KB)                   = 467360
+  0: The total amount of wall time                        = 321.665960
+  0: The maximum resident set size (KB)                   = 473816
 
 Test 138 hafs_regional_1nest_atm_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_telescopic_2nests_atm_intel
 Checking test 139 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4782,14 +4782,14 @@ Checking test 139 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 344.333663
-  0: The maximum resident set size (KB)                   = 511340
+  0: The total amount of wall time                        = 344.931557
+  0: The maximum resident set size (KB)                   = 512028
 
 Test 139 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_global_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_global_1nest_atm_intel
 Checking test 140 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4836,14 +4836,14 @@ Checking test 140 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 136.574736
-  0: The maximum resident set size (KB)                   = 348772
+  0: The total amount of wall time                        = 138.578960
+  0: The maximum resident set size (KB)                   = 345840
 
 Test 140 hafs_global_1nest_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_global_1nest_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_global_1nest_atm_qr_intel
 Checking test 141 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4890,14 +4890,14 @@ Checking test 141 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 143.004148
-  0: The maximum resident set size (KB)                   = 348900
+  0: The total amount of wall time                        = 144.858055
+  0: The maximum resident set size (KB)                   = 348388
 
 Test 141 hafs_global_1nest_atm_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_global_multiple_4nests_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_global_multiple_4nests_atm_intel
 Checking test 142 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4979,14 +4979,14 @@ Checking test 142 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 382.167401
-  0: The maximum resident set size (KB)                   = 427336
+  0: The total amount of wall time                        = 391.014721
+  0: The maximum resident set size (KB)                   = 453468
 
 Test 142 hafs_global_multiple_4nests_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_global_multiple_4nests_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_global_multiple_4nests_atm_qr_intel
 Checking test 143 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5068,14 +5068,14 @@ Checking test 143 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 407.408467
-  0: The maximum resident set size (KB)                   = 465544
+  0: The total amount of wall time                        = 417.413009
+  0: The maximum resident set size (KB)                   = 466412
 
 Test 143 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_specified_moving_1nest_atm_intel
 Checking test 144 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5084,14 +5084,14 @@ Checking test 144 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 191.010740
-  0: The maximum resident set size (KB)                   = 520188
+  0: The total amount of wall time                        = 191.432795
+  0: The maximum resident set size (KB)                   = 514996
 
 Test 144 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_storm_following_1nest_atm_intel
 Checking test 145 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5113,14 +5113,14 @@ Checking test 145 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 180.119293
-  0: The maximum resident set size (KB)                   = 519348
+  0: The total amount of wall time                        = 182.187955
+  0: The maximum resident set size (KB)                   = 516300
 
 Test 145 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_storm_following_1nest_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_storm_following_1nest_atm_qr_intel
 Checking test 146 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5142,14 +5142,14 @@ Checking test 146 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 189.530258
-  0: The maximum resident set size (KB)                   = 498676
+  0: The total amount of wall time                        = 207.987289
+  0: The maximum resident set size (KB)                   = 498860
 
 Test 146 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_storm_following_1nest_atm_ocn_intel
 Checking test 147 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5158,42 +5158,42 @@ Checking test 147 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 222.012384
-  0: The maximum resident set size (KB)                   = 562156
+  0: The total amount of wall time                        = 219.677083
+  0: The maximum resident set size (KB)                   = 563848
 
 Test 147 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_global_storm_following_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_global_storm_following_1nest_atm_intel
 Checking test 148 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 55.526156
-  0: The maximum resident set size (KB)                   = 366244
+  0: The total amount of wall time                        = 55.734830
+  0: The maximum resident set size (KB)                   = 364992
 
 Test 148 hafs_global_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
 Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 706.510415
-  0: The maximum resident set size (KB)                   = 582744
+  0: The total amount of wall time                        = 717.711660
+  0: The maximum resident set size (KB)                   = 585596
 
 Test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
 Checking test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5204,14 +5204,14 @@ Checking test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 479.323745
-  0: The maximum resident set size (KB)                   = 616488
+  0: The total amount of wall time                        = 483.522483
+  0: The maximum resident set size (KB)                   = 611576
 
 Test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_docn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_docn_intel
 Checking test 151 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5219,14 +5219,14 @@ Checking test 151 hafs_regional_docn_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 339.093735
-  0: The maximum resident set size (KB)                   = 1220704
+  0: The total amount of wall time                        = 342.005381
+  0: The maximum resident set size (KB)                   = 1231236
 
 Test 151 hafs_regional_docn_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_oisst_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_docn_oisst_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_docn_oisst_intel
 Checking test 152 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5234,131 +5234,131 @@ Checking test 152 hafs_regional_docn_oisst_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 334.296811
-  0: The maximum resident set size (KB)                   = 1214216
+  0: The total amount of wall time                        = 344.469342
+  0: The maximum resident set size (KB)                   = 1221728
 
 Test 152 hafs_regional_docn_oisst_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_datm_cdeps_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hafs_regional_datm_cdeps_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hafs_regional_datm_cdeps_intel
 Checking test 153 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 952.841903
-  0: The maximum resident set size (KB)                   = 1041376
+  0: The total amount of wall time                        = 958.175847
+  0: The maximum resident set size (KB)                   = 1033224
 
 Test 153 hafs_regional_datm_cdeps_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_control_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_control_cfsr_intel
 Checking test 154 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.955893
- 0: The maximum resident set size (KB)                   = 1051272
+ 0: The total amount of wall time                        = 151.802505
+ 0: The maximum resident set size (KB)                   = 1051252
 
 Test 154 datm_cdeps_control_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_restart_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_restart_cfsr_intel
 Checking test 155 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 91.279699
- 0: The maximum resident set size (KB)                   = 1000740
+ 0: The total amount of wall time                        = 92.556817
+ 0: The maximum resident set size (KB)                   = 1009724
 
 Test 155 datm_cdeps_restart_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_control_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_control_gefs_intel
 Checking test 156 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.473287
- 0: The maximum resident set size (KB)                   = 945436
+ 0: The total amount of wall time                        = 147.660643
+ 0: The maximum resident set size (KB)                   = 963224
 
 Test 156 datm_cdeps_control_gefs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_iau_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_iau_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_iau_gefs_intel
 Checking test 157 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.200746
- 0: The maximum resident set size (KB)                   = 961576
+ 0: The total amount of wall time                        = 149.553697
+ 0: The maximum resident set size (KB)                   = 966180
 
 Test 157 datm_cdeps_iau_gefs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_stochy_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_stochy_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_stochy_gefs_intel
 Checking test 158 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.253097
- 0: The maximum resident set size (KB)                   = 955564
+ 0: The total amount of wall time                        = 155.867394
+ 0: The maximum resident set size (KB)                   = 947808
 
 Test 158 datm_cdeps_stochy_gefs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_ciceC_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_ciceC_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_ciceC_cfsr_intel
 Checking test 159 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.322386
- 0: The maximum resident set size (KB)                   = 1052764
+ 0: The total amount of wall time                        = 149.503435
+ 0: The maximum resident set size (KB)                   = 1063388
 
 Test 159 datm_cdeps_ciceC_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_bulk_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_bulk_cfsr_intel
 Checking test 160 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 152.122846
- 0: The maximum resident set size (KB)                   = 1040516
+ 0: The total amount of wall time                        = 155.765190
+ 0: The maximum resident set size (KB)                   = 1047180
 
 Test 160 datm_cdeps_bulk_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_bulk_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_bulk_gefs_intel
 Checking test 161 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.127782
- 0: The maximum resident set size (KB)                   = 945616
+ 0: The total amount of wall time                        = 149.159032
+ 0: The maximum resident set size (KB)                   = 961116
 
 Test 161 datm_cdeps_bulk_gefs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_mx025_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_mx025_cfsr_intel
 Checking test 162 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -5367,14 +5367,14 @@ Checking test 162 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 439.412784
-  0: The maximum resident set size (KB)                   = 869680
+  0: The total amount of wall time                        = 411.765588
+  0: The maximum resident set size (KB)                   = 874756
 
 Test 162 datm_cdeps_mx025_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_mx025_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_mx025_gefs_intel
 Checking test 163 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -5383,77 +5383,77 @@ Checking test 163 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 422.058886
-  0: The maximum resident set size (KB)                   = 940220
+  0: The total amount of wall time                        = 423.039468
+  0: The maximum resident set size (KB)                   = 926296
 
 Test 163 datm_cdeps_mx025_gefs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_multiple_files_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_multiple_files_cfsr_intel
 Checking test 164 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.329680
- 0: The maximum resident set size (KB)                   = 1048284
+ 0: The total amount of wall time                        = 150.319410
+ 0: The maximum resident set size (KB)                   = 1052068
 
 Test 164 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_3072x1536_cfsr_intel
 Checking test 165 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 217.603229
- 0: The maximum resident set size (KB)                   = 2335888
+ 0: The total amount of wall time                        = 220.416703
+ 0: The maximum resident set size (KB)                   = 2348852
 
 Test 165 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_gfs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_gfs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_gfs_intel
 Checking test 166 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 226.651018
- 0: The maximum resident set size (KB)                   = 2349460
+ 0: The total amount of wall time                        = 220.395592
+ 0: The maximum resident set size (KB)                   = 2358364
 
 Test 166 datm_cdeps_gfs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_debug_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_debug_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_debug_cfsr_intel
 Checking test 167 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 358.862493
- 0: The maximum resident set size (KB)                   = 947484
+ 0: The total amount of wall time                        = 351.595191
+ 0: The maximum resident set size (KB)                   = 973332
 
 Test 167 datm_cdeps_debug_cfsr_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_control_cfsr_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_control_cfsr_faster_intel
 Checking test 168 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.919417
- 0: The maximum resident set size (KB)                   = 1053640
+ 0: The total amount of wall time                        = 150.573612
+ 0: The maximum resident set size (KB)                   = 1063448
 
 Test 168 datm_cdeps_control_cfsr_faster_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_lnd_gswp3_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_lnd_gswp3_intel
 Checking test 169 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5462,14 +5462,14 @@ Checking test 169 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 6.608143
-  0: The maximum resident set size (KB)                   = 263736
+  0: The total amount of wall time                        = 7.200110
+  0: The maximum resident set size (KB)                   = 255796
 
 Test 169 datm_cdeps_lnd_gswp3_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_lnd_gswp3_rst_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_lnd_gswp3_rst_intel
 Checking test 170 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5478,14 +5478,14 @@ Checking test 170 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.057509
-  0: The maximum resident set size (KB)                   = 256800
+  0: The total amount of wall time                        = 13.060279
+  0: The maximum resident set size (KB)                   = 263884
 
 Test 170 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_atmlnd_sbs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_p8_atmlnd_sbs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_p8_atmlnd_sbs_intel
 Checking test 171 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -5570,14 +5570,14 @@ Checking test 171 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 205.808931
-  0: The maximum resident set size (KB)                   = 1604092
+  0: The total amount of wall time                        = 203.538238
+  0: The maximum resident set size (KB)                   = 1607620
 
 Test 171 control_p8_atmlnd_sbs_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmwav_control_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/atmwav_control_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/atmwav_control_noaero_p8_intel
 Checking test 172 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5620,14 +5620,14 @@ Checking test 172 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 92.681942
-  0: The maximum resident set size (KB)                   = 1620780
+  0: The total amount of wall time                        = 94.507642
+  0: The maximum resident set size (KB)                   = 1633416
 
 Test 172 atmwav_control_noaero_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_atmwav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_atmwav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_atmwav_intel
 Checking test 173 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5671,14 +5671,14 @@ Checking test 173 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 89.038373
-  0: The maximum resident set size (KB)                   = 630512
+  0: The total amount of wall time                        = 88.853266
+  0: The maximum resident set size (KB)                   = 658804
 
 Test 173 control_atmwav_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/atmaero_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/atmaero_control_p8_intel
 Checking test 174 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5722,14 +5722,14 @@ Checking test 174 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 230.413542
-  0: The maximum resident set size (KB)                   = 2959116
+  0: The total amount of wall time                        = 234.525081
+  0: The maximum resident set size (KB)                   = 2967524
 
 Test 174 atmaero_control_p8_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/atmaero_control_p8_rad_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/atmaero_control_p8_rad_intel
 Checking test 175 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5773,14 +5773,14 @@ Checking test 175 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 281.438119
-  0: The maximum resident set size (KB)                   = 3025972
+  0: The total amount of wall time                        = 282.622286
+  0: The maximum resident set size (KB)                   = 3033512
 
 Test 175 atmaero_control_p8_rad_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_micro_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/atmaero_control_p8_rad_micro_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/atmaero_control_p8_rad_micro_intel
 Checking test 176 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5824,14 +5824,14 @@ Checking test 176 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 287.788380
-  0: The maximum resident set size (KB)                   = 3050004
+  0: The total amount of wall time                        = 291.952082
+  0: The maximum resident set size (KB)                   = 3046988
 
 Test 176 atmaero_control_p8_rad_micro_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_atmaq_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_atmaq_intel
 Checking test 177 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5847,14 +5847,14 @@ Checking test 177 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 655.594818
-  0: The maximum resident set size (KB)                   = 1422668
+  0: The total amount of wall time                        = 673.884107
+  0: The maximum resident set size (KB)                   = 1293984
 
 Test 177 regional_atmaq_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_atmaq_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_atmaq_debug_intel
 Checking test 178 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5868,14 +5868,14 @@ Checking test 178 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1223.936881
-  0: The maximum resident set size (KB)                   = 1339908
+  0: The total amount of wall time                        = 1198.555712
+  0: The maximum resident set size (KB)                   = 1264172
 
 Test 178 regional_atmaq_debug_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_atmaq_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_atmaq_faster_intel
 Checking test 179 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5891,14 +5891,14 @@ Checking test 179 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 575.818497
-  0: The maximum resident set size (KB)                   = 1355060
+  0: The total amount of wall time                        = 584.772958
+  0: The maximum resident set size (KB)                   = 1453708
 
 Test 179 regional_atmaq_faster_intel PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c48_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_c48_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_c48_gnu
 Checking test 180 control_c48_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5937,14 +5937,14 @@ Checking test 180 control_c48_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 682.136355
-0: The maximum resident set size (KB)                   = 704584
+0: The total amount of wall time                        = 684.165828
+0: The maximum resident set size (KB)                   = 702532
 
 Test 180 control_c48_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_stochy_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_stochy_gnu
 Checking test 181 control_stochy_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5955,14 +5955,14 @@ Checking test 181 control_stochy_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 646.391278
-  0: The maximum resident set size (KB)                   = 477096
+  0: The total amount of wall time                        = 661.715318
+  0: The maximum resident set size (KB)                   = 474980
 
 Test 181 control_stochy_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_ras_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_ras_gnu
 Checking test 182 control_ras_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5973,14 +5973,14 @@ Checking test 182 control_ras_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 834.835968
-  0: The maximum resident set size (KB)                   = 483788
+  0: The total amount of wall time                        = 837.193908
+  0: The maximum resident set size (KB)                   = 485848
 
 Test 182 control_ras_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_p8_gnu
 Checking test 183 control_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -6027,14 +6027,14 @@ Checking test 183 control_p8_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 907.750437
-  0: The maximum resident set size (KB)                   = 1232388
+  0: The total amount of wall time                        = 887.668216
+  0: The maximum resident set size (KB)                   = 1234464
 
 Test 183 control_p8_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_flake_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_flake_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_flake_gnu
 Checking test 184 control_flake_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -6045,14 +6045,14 @@ Checking test 184 control_flake_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1561.608779
-  0: The maximum resident set size (KB)                   = 522864
+  0: The total amount of wall time                        = 1577.699981
+  0: The maximum resident set size (KB)                   = 524268
 
 Test 184 control_flake_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_gnu
 Checking test 185 rap_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -6099,14 +6099,14 @@ Checking test 185 rap_control_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1468.265227
-  0: The maximum resident set size (KB)                   = 824236
+  0: The total amount of wall time                        = 1482.757858
+  0: The maximum resident set size (KB)                   = 823200
 
 Test 185 rap_control_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_decomp_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_decomp_gnu
 Checking test 186 rap_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -6153,14 +6153,14 @@ Checking test 186 rap_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1458.925621
-  0: The maximum resident set size (KB)                   = 827784
+  0: The total amount of wall time                        = 1466.650741
+  0: The maximum resident set size (KB)                   = 823900
 
 Test 186 rap_decomp_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_2threads_gnu
 Checking test 187 rap_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -6207,14 +6207,14 @@ Checking test 187 rap_2threads_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1333.314435
-  0: The maximum resident set size (KB)                   = 898176
+  0: The total amount of wall time                        = 1320.560318
+  0: The maximum resident set size (KB)                   = 897432
 
 Test 187 rap_2threads_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_restart_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_restart_gnu
 Checking test 188 rap_restart_gnu results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -6253,14 +6253,14 @@ Checking test 188 rap_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 719.409921
-  0: The maximum resident set size (KB)                   = 549196
+  0: The total amount of wall time                        = 724.755196
+  0: The maximum resident set size (KB)                   = 548044
 
 Test 188 rap_restart_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_sfcdiff_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_sfcdiff_gnu
 Checking test 189 rap_sfcdiff_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6307,14 +6307,14 @@ Checking test 189 rap_sfcdiff_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1449.596327
-  0: The maximum resident set size (KB)                   = 823080
+  0: The total amount of wall time                        = 1527.355940
+  0: The maximum resident set size (KB)                   = 828324
 
 Test 189 rap_sfcdiff_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_sfcdiff_decomp_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_sfcdiff_decomp_gnu
 Checking test 190 rap_sfcdiff_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6361,14 +6361,14 @@ Checking test 190 rap_sfcdiff_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1446.373313
-  0: The maximum resident set size (KB)                   = 824300
+  0: The total amount of wall time                        = 1446.728749
+  0: The maximum resident set size (KB)                   = 828736
 
 Test 190 rap_sfcdiff_decomp_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_sfcdiff_restart_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_sfcdiff_restart_gnu
 Checking test 191 rap_sfcdiff_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -6407,14 +6407,14 @@ Checking test 191 rap_sfcdiff_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1072.314177
-  0: The maximum resident set size (KB)                   = 549268
+  0: The total amount of wall time                        = 1078.454193
+  0: The maximum resident set size (KB)                   = 549948
 
 Test 191 rap_sfcdiff_restart_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_gnu
 Checking test 192 hrrr_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6461,14 +6461,14 @@ Checking test 192 hrrr_control_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1419.790516
-  0: The maximum resident set size (KB)                   = 825240
+  0: The total amount of wall time                        = 1479.760232
+  0: The maximum resident set size (KB)                   = 828708
 
 Test 192 hrrr_control_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_qr_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_qr_gnu
 Checking test 193 hrrr_control_qr_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6515,14 +6515,14 @@ Checking test 193 hrrr_control_qr_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1438.958767
-  0: The maximum resident set size (KB)                   = 836612
+  0: The total amount of wall time                        = 1448.864793
+  0: The maximum resident set size (KB)                   = 832032
 
 Test 193 hrrr_control_qr_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_2threads_gnu
 Checking test 194 hrrr_control_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6569,14 +6569,14 @@ Checking test 194 hrrr_control_2threads_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1519.502350
-  0: The maximum resident set size (KB)                   = 891952
+  0: The total amount of wall time                        = 1514.430579
+  0: The maximum resident set size (KB)                   = 891148
 
 Test 194 hrrr_control_2threads_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_decomp_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_decomp_gnu
 Checking test 195 hrrr_control_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6623,42 +6623,42 @@ Checking test 195 hrrr_control_decomp_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1420.364434
-  0: The maximum resident set size (KB)                   = 821916
+  0: The total amount of wall time                        = 1391.312848
+  0: The maximum resident set size (KB)                   = 821532
 
 Test 195 hrrr_control_decomp_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_gnu
 Checking test 196 hrrr_control_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1047.491195
-  0: The maximum resident set size (KB)                   = 544600
+  0: The total amount of wall time                        = 1047.565280
+  0: The maximum resident set size (KB)                   = 544508
 
 Test 196 hrrr_control_restart_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_qr_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_qr_gnu
 Checking test 197 hrrr_control_restart_qr_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1068.125027
-  0: The maximum resident set size (KB)                   = 559008
+  0: The total amount of wall time                        = 1050.217100
+  0: The maximum resident set size (KB)                   = 559180
 
 Test 197 hrrr_control_restart_qr_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_v1beta_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_v1beta_gnu
 Checking test 198 rrfs_v1beta_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6705,14 +6705,14 @@ Checking test 198 rrfs_v1beta_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1480.336695
-  0: The maximum resident set size (KB)                   = 826400
+  0: The total amount of wall time                        = 1439.798172
+  0: The maximum resident set size (KB)                   = 821956
 
 Test 198 rrfs_v1beta_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_gnu
 Checking test 199 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6728,14 +6728,14 @@ Checking test 199 rrfs_smoke_conus13km_hrrr_warm_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 823.588756
-  0: The maximum resident set size (KB)                   = 663132
+  0: The total amount of wall time                        = 787.201652
+  0: The maximum resident set size (KB)                   = 664228
 
 Test 199 rrfs_smoke_conus13km_hrrr_warm_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_2threads_gnu
 Checking test 200 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6744,14 +6744,14 @@ Checking test 200 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1053.371490
-  0: The maximum resident set size (KB)                   = 658976
+  0: The total amount of wall time                        = 1054.537433
+  0: The maximum resident set size (KB)                   = 658680
 
 Test 200 rrfs_smoke_conus13km_hrrr_warm_2threads_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_radar_tten_warm_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_radar_tten_warm_gnu
 Checking test 201 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6760,14 +6760,14 @@ Checking test 201 rrfs_smoke_conus13km_radar_tten_warm_gnu results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 781.678284
-  0: The maximum resident set size (KB)                   = 665040
+  0: The total amount of wall time                        = 793.523825
+  0: The maximum resident set size (KB)                   = 667248
 
 Test 201 rrfs_smoke_conus13km_radar_tten_warm_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_conus13km_hrrr_warm_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_conus13km_hrrr_warm_gnu
 Checking test 202 rrfs_conus13km_hrrr_warm_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -6783,262 +6783,262 @@ Checking test 202 rrfs_conus13km_hrrr_warm_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 748.839413
-  0: The maximum resident set size (KB)                   = 642088
+  0: The total amount of wall time                        = 789.476056
+  0: The maximum resident set size (KB)                   = 640668
 
 Test 202 rrfs_conus13km_hrrr_warm_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu
 Checking test 203 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 428.806891
-  0: The maximum resident set size (KB)                   = 651716
+  0: The total amount of wall time                        = 418.024447
+  0: The maximum resident set size (KB)                   = 653852
 
 Test 203 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_diag_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_diag_debug_gnu
 Checking test 204 control_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 124.357079
-  0: The maximum resident set size (KB)                   = 525664
+  0: The total amount of wall time                        = 121.441366
+  0: The maximum resident set size (KB)                   = 526808
 
 Test 204 control_diag_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/regional_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/regional_debug_gnu
 Checking test 205 regional_debug_gnu results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 743.380542
-  0: The maximum resident set size (KB)                   = 591892
+  0: The total amount of wall time                        = 742.851782
+  0: The maximum resident set size (KB)                   = 592144
 
 Test 205 regional_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_debug_gnu
 Checking test 206 rap_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 175.732145
-  0: The maximum resident set size (KB)                   = 840832
+  0: The total amount of wall time                        = 172.532346
+  0: The maximum resident set size (KB)                   = 840352
 
 Test 206 rap_control_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_debug_gnu
 Checking test 207 hrrr_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.965648
-  0: The maximum resident set size (KB)                   = 834420
+  0: The total amount of wall time                        = 166.350821
+  0: The maximum resident set size (KB)                   = 833952
 
 Test 207 hrrr_control_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_diag_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_diag_debug_gnu
 Checking test 208 rap_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 207.574935
-  0: The maximum resident set size (KB)                   = 920416
+  0: The total amount of wall time                        = 208.769396
+  0: The maximum resident set size (KB)                   = 919048
 
 Test 208 rap_diag_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_noah_sfcdiff_cires_ugwp_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_noah_sfcdiff_cires_ugwp_debug_gnu
 Checking test 209 rap_noah_sfcdiff_cires_ugwp_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.304922
-  0: The maximum resident set size (KB)                   = 837384
+  0: The total amount of wall time                        = 274.663745
+  0: The maximum resident set size (KB)                   = 836764
 
 Test 209 rap_noah_sfcdiff_cires_ugwp_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_progcld_thompson_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_progcld_thompson_debug_gnu
 Checking test 210 rap_progcld_thompson_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.437685
-  0: The maximum resident set size (KB)                   = 836352
+  0: The total amount of wall time                        = 174.284288
+  0: The maximum resident set size (KB)                   = 838024
 
 Test 210 rap_progcld_thompson_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_v1beta_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_v1beta_debug_gnu
 Checking test 211 rrfs_v1beta_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.383708
-  0: The maximum resident set size (KB)                   = 832508
+  0: The total amount of wall time                        = 169.805491
+  0: The maximum resident set size (KB)                   = 837632
 
 Test 211 rrfs_v1beta_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_ras_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_ras_debug_gnu
 Checking test 212 control_ras_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.910066
-  0: The maximum resident set size (KB)                   = 480368
+  0: The total amount of wall time                        = 101.567741
+  0: The maximum resident set size (KB)                   = 478244
 
 Test 212 control_ras_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_stochy_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_stochy_debug_gnu
 Checking test 213 control_stochy_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 123.063307
-  0: The maximum resident set size (KB)                   = 475088
+  0: The total amount of wall time                        = 116.797470
+  0: The maximum resident set size (KB)                   = 469676
 
 Test 213 control_stochy_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_debug_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_debug_p8_gnu
 Checking test 214 control_debug_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.530962
-  0: The maximum resident set size (KB)                   = 1226288
+  0: The total amount of wall time                        = 117.201770
+  0: The maximum resident set size (KB)                   = 1226884
 
 Test 214 control_debug_p8_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
 Checking test 215 rrfs_smoke_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 629.811121
-  0: The maximum resident set size (KB)                   = 678076
+  0: The total amount of wall time                        = 652.632855
+  0: The maximum resident set size (KB)                   = 669860
 
 Test 215 rrfs_smoke_conus13km_hrrr_warm_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu
 Checking test 216 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 751.885602
-  0: The maximum resident set size (KB)                   = 677344
+  0: The total amount of wall time                        = 751.705495
+  0: The maximum resident set size (KB)                   = 665208
 
 Test 216 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rrfs_conus13km_hrrr_warm_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rrfs_conus13km_hrrr_warm_debug_gnu
 Checking test 217 rrfs_conus13km_hrrr_warm_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 584.158648
-  0: The maximum resident set size (KB)                   = 658064
+  0: The total amount of wall time                        = 582.152059
+  0: The maximum resident set size (KB)                   = 657060
 
 Test 217 rrfs_conus13km_hrrr_warm_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_flake_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_flake_debug_gnu
 Checking test 218 rap_flake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.005364
-  0: The maximum resident set size (KB)                   = 835996
+  0: The total amount of wall time                        = 168.433109
+  0: The maximum resident set size (KB)                   = 837236
 
 Test 218 rap_flake_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_clm_lake_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_clm_lake_debug_gnu
 Checking test 219 rap_clm_lake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 191.773917
-  0: The maximum resident set size (KB)                   = 842960
+  0: The total amount of wall time                        = 195.931335
+  0: The maximum resident set size (KB)                   = 838172
 
 Test 219 rap_clm_lake_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/control_wam_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/control_wam_debug_gnu
 Checking test 220 control_wam_debug_gnu results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 184.826219
-  0: The maximum resident set size (KB)                   = 189180
+  0: The total amount of wall time                        = 183.186503
+  0: The maximum resident set size (KB)                   = 189404
 
 Test 220 control_wam_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_dyn32_phy32_gnu
 Checking test 221 rap_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7085,14 +7085,14 @@ Checking test 221 rap_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1437.299539
-  0: The maximum resident set size (KB)                   = 680284
+  0: The total amount of wall time                        = 1484.366814
+  0: The maximum resident set size (KB)                   = 685704
 
 Test 221 rap_control_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_dyn32_phy32_gnu
 Checking test 222 hrrr_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7139,14 +7139,14 @@ Checking test 222 hrrr_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 723.771717
-  0: The maximum resident set size (KB)                   = 682484
+  0: The total amount of wall time                        = 729.642334
+  0: The maximum resident set size (KB)                   = 684100
 
 Test 222 hrrr_control_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_qr_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_qr_dyn32_phy32_gnu
 Checking test 223 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7193,14 +7193,14 @@ Checking test 223 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 740.700187
-  0: The maximum resident set size (KB)                   = 690628
+  0: The total amount of wall time                        = 730.124573
+  0: The maximum resident set size (KB)                   = 691704
 
 Test 223 hrrr_control_qr_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_2threads_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_2threads_dyn32_phy32_gnu
 Checking test 224 rap_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7247,14 +7247,14 @@ Checking test 224 rap_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1337.595278
-  0: The maximum resident set size (KB)                   = 731804
+  0: The total amount of wall time                        = 1338.944923
+  0: The maximum resident set size (KB)                   = 727208
 
 Test 224 rap_2threads_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_2threads_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_2threads_dyn32_phy32_gnu
 Checking test 225 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7301,14 +7301,14 @@ Checking test 225 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 763.842467
-  0: The maximum resident set size (KB)                   = 722504
+  0: The total amount of wall time                        = 752.520307
+  0: The maximum resident set size (KB)                   = 723672
 
 Test 225 hrrr_control_2threads_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_decomp_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_decomp_dyn32_phy32_gnu
 Checking test 226 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7355,14 +7355,14 @@ Checking test 226 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 714.207347
-  0: The maximum resident set size (KB)                   = 679928
+  0: The total amount of wall time                        = 731.881257
+  0: The maximum resident set size (KB)                   = 681400
 
 Test 226 hrrr_control_decomp_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_restart_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_restart_dyn32_phy32_gnu
 Checking test 227 rap_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -7401,42 +7401,42 @@ Checking test 227 rap_restart_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1080.504300
-  0: The maximum resident set size (KB)                   = 510680
+  0: The total amount of wall time                        = 1077.256292
+  0: The maximum resident set size (KB)                   = 512344
 
 Test 227 rap_restart_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_dyn32_phy32_gnu
 Checking test 228 hrrr_control_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 362.330802
-  0: The maximum resident set size (KB)                   = 507052
+  0: The total amount of wall time                        = 356.157306
+  0: The maximum resident set size (KB)                   = 504220
 
 Test 228 hrrr_control_restart_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_restart_qr_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_restart_qr_dyn32_phy32_gnu
 Checking test 229 hrrr_control_restart_qr_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 377.731930
-  0: The maximum resident set size (KB)                   = 522344
+  0: The total amount of wall time                        = 378.354026
+  0: The maximum resident set size (KB)                   = 521364
 
 Test 229 hrrr_control_restart_qr_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_dyn64_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_dyn64_phy32_gnu
 Checking test 230 rap_control_dyn64_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7483,56 +7483,56 @@ Checking test 230 rap_control_dyn64_phy32_gnu results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1056.339895
-  0: The maximum resident set size (KB)                   = 703732
+  0: The total amount of wall time                        = 1060.060883
+  0: The maximum resident set size (KB)                   = 710240
 
 Test 230 rap_control_dyn64_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_debug_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_debug_dyn32_phy32_gnu
 Checking test 231 rap_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 176.681546
-  0: The maximum resident set size (KB)                   = 696608
+  0: The total amount of wall time                        = 171.805842
+  0: The maximum resident set size (KB)                   = 692404
 
 Test 231 rap_control_debug_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/hrrr_control_debug_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/hrrr_control_debug_dyn32_phy32_gnu
 Checking test 232 hrrr_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.301937
-  0: The maximum resident set size (KB)                   = 692360
+  0: The total amount of wall time                        = 166.766297
+  0: The maximum resident set size (KB)                   = 691236
 
 Test 232 hrrr_control_debug_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/rap_control_dyn64_phy32_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/rap_control_dyn64_phy32_debug_gnu
 Checking test 233 rap_control_dyn64_phy32_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 205.691624
-  0: The maximum resident set size (KB)                   = 710900
+  0: The total amount of wall time                        = 200.383584
+  0: The maximum resident set size (KB)                   = 712776
 
 Test 233 rap_control_dyn64_phy32_debug_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_p8_gnu
 Checking test 234 cpld_control_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7597,14 +7597,14 @@ Checking test 234 cpld_control_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1757.157913
-  0: The maximum resident set size (KB)                   = 1429100
+  0: The total amount of wall time                        = 1865.686725
+  0: The maximum resident set size (KB)                   = 1422016
 
 Test 234 cpld_control_p8_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_nowave_noaero_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_nowave_noaero_p8_gnu
 Checking test 235 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7666,14 +7666,14 @@ Checking test 235 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1236.747505
-  0: The maximum resident set size (KB)                   = 1333012
+  0: The total amount of wall time                        = 1214.859457
+  0: The maximum resident set size (KB)                   = 1328064
 
 Test 235 cpld_control_nowave_noaero_p8_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_debug_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_debug_p8_gnu
 Checking test 236 cpld_debug_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -7726,14 +7726,14 @@ Checking test 236 cpld_debug_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 920.909551
-  0: The maximum resident set size (KB)                   = 1431032
+  0: The total amount of wall time                        = 993.053867
+  0: The maximum resident set size (KB)                   = 1437912
 
 Test 236 cpld_debug_p8_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_control_pdlib_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_control_pdlib_p8_gnu
 Checking test 237 cpld_control_pdlib_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7797,14 +7797,14 @@ Checking test 237 cpld_control_pdlib_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1688.828378
-  0: The maximum resident set size (KB)                   = 1291748
+  0: The total amount of wall time                        = 1704.318189
+  0: The maximum resident set size (KB)                   = 1285420
 
 Test 237 cpld_control_pdlib_p8_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_pdlib_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/cpld_debug_pdlib_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/cpld_debug_pdlib_p8_gnu
 Checking test 238 cpld_debug_pdlib_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -7856,25 +7856,25 @@ Checking test 238 cpld_debug_pdlib_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 927.690734
-  0: The maximum resident set size (KB)                   = 1296280
+  0: The total amount of wall time                        = 923.165175
+  0: The maximum resident set size (KB)                   = 1294200
 
 Test 238 cpld_debug_pdlib_p8_gnu PASS
 
 
 baseline dir = /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_107207/datm_cdeps_control_cfsr_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_35996/datm_cdeps_control_cfsr_gnu
 Checking test 239 datm_cdeps_control_cfsr_gnu results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 169.589792
- 0: The maximum resident set size (KB)                   = 657400
+ 0: The total amount of wall time                        = 172.150745
+ 0: The maximum resident set size (KB)                   = 664724
 
 Test 239 datm_cdeps_control_cfsr_gnu PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sat Jun 24 22:29:25 UTC 2023
-Elapsed time: 02h:36m:21s. Have a nice day!
+Wed Jun 28 14:19:14 UTC 2023
+Elapsed time: 01h:59m:30s. Have a nice day!

--- a/tests/logs/RegressionTests_jet.log
+++ b/tests/logs/RegressionTests_jet.log
@@ -1,52 +1,52 @@
-Thu Jun 22 18:21:54 UTC 2023
+Tue Jun 27 23:24:42 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: 2d5a7ba68ca795af5ce01c7619099940d309bfde
+Testing UFSWM Hash: 2e508553d6cc8463a0244285d542f54fc083ed31
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-1401-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- f9d68ad799a8dcdaa2fdb706fe51204641a82b6b ../FV3 (heads/develop)
+ 596f540cff635a802d07cacf652d49b30d62ea6e ../FV3 (remotes/origin/unused_ccpp_suites)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 2243 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 2295 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 003 elapsed time 2140 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 004 elapsed time 323 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 294 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 1707 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 007 elapsed time 1963 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 008 elapsed time 3346 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 011 elapsed time 2083 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 013 elapsed time 2007 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 1957 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 015 elapsed time 1823 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 016 elapsed time 2028 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 017 elapsed time 329 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 1808 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 020 elapsed time 1862 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 021 elapsed time 223 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 254 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 1941 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 026 elapsed time 1915 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 027 elapsed time 286 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 028 elapsed time 139 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 277 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 001 elapsed time 2085 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 2281 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 003 elapsed time 2148 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 004 elapsed time 298 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 288 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 1987 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 007 elapsed time 1978 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 008 elapsed time 3343 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 011 elapsed time 2040 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 013 elapsed time 1994 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 1952 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 015 elapsed time 1789 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 016 elapsed time 1805 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 017 elapsed time 311 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 242 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 1821 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 020 elapsed time 1911 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 021 elapsed time 260 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 260 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 1948 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 026 elapsed time 1892 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 027 elapsed time 270 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 028 elapsed time 146 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 297 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
 Compile 030 elapsed time 79 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 031 elapsed time 2074 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 032 elapsed time 2265 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 033 elapsed time 2387 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 034 elapsed time 2462 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 031 elapsed time 1986 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 032 elapsed time 1931 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 033 elapsed time 1882 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 034 elapsed time 1852 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_mixedmode_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_p8_mixedmode_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_mixedmode_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -111,14 +111,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 404.521990
-  0: The maximum resident set size (KB)                   = 1752236
+  0: The total amount of wall time                        = 416.835818
+  0: The maximum resident set size (KB)                   = 1752616
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_gfsv17_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_gfsv17_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_gfsv17_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -182,14 +182,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 289.793269
-  0: The maximum resident set size (KB)                   = 1602620
+  0: The total amount of wall time                        = 292.238729
+  0: The maximum resident set size (KB)                   = 1610548
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -254,14 +254,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 452.855283
-  0: The maximum resident set size (KB)                   = 1798380
+  0: The total amount of wall time                        = 469.015323
+  0: The maximum resident set size (KB)                   = 1768036
 
 Test 003 cpld_control_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_restart_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -314,14 +314,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 256.852757
-  0: The maximum resident set size (KB)                   = 1492628
+  0: The total amount of wall time                        = 260.199138
+  0: The maximum resident set size (KB)                   = 1487968
 
 Test 004 cpld_restart_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -386,14 +386,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 455.369562
-  0: The maximum resident set size (KB)                   = 1782372
+  0: The total amount of wall time                        = 456.040108
+  0: The maximum resident set size (KB)                   = 1802144
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_restart_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -446,14 +446,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 275.571952
-  0: The maximum resident set size (KB)                   = 1520672
+  0: The total amount of wall time                        = 281.901655
+  0: The maximum resident set size (KB)                   = 1497720
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_2threads_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -506,14 +506,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 472.756578
-  0: The maximum resident set size (KB)                   = 1995180
+  0: The total amount of wall time                        = 499.153814
+  0: The maximum resident set size (KB)                   = 1988776
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_decomp_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -566,14 +566,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 453.272737
-  0: The maximum resident set size (KB)                   = 1793492
+  0: The total amount of wall time                        = 463.102501
+  0: The maximum resident set size (KB)                   = 1792596
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_mpi_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -626,14 +626,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 380.798531
-  0: The maximum resident set size (KB)                   = 1740468
+  0: The total amount of wall time                        = 412.821037
+  0: The maximum resident set size (KB)                   = 1741560
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_ciceC_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_ciceC_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_ciceC_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -698,14 +698,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 452.073692
-  0: The maximum resident set size (KB)                   = 1804392
+  0: The total amount of wall time                        = 454.886260
+  0: The maximum resident set size (KB)                   = 1776572
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_noaero_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_noaero_p8_intel
 Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -769,14 +769,14 @@ Checking test 011 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 347.141566
-  0: The maximum resident set size (KB)                   = 1637908
+  0: The total amount of wall time                        = 357.989008
+  0: The maximum resident set size (KB)                   = 1632860
 
 Test 011 cpld_control_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_c96_noaero_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_nowave_noaero_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_nowave_noaero_p8_intel
 Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -838,14 +838,14 @@ Checking test 012 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 348.135190
-  0: The maximum resident set size (KB)                   = 1685072
+  0: The total amount of wall time                        = 346.045593
+  0: The maximum resident set size (KB)                   = 1698108
 
 Test 012 cpld_control_nowave_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_debug_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_debug_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_debug_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_debug_p8_intel
 Checking test 013 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -898,14 +898,14 @@ Checking test 013 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 673.085737
-  0: The maximum resident set size (KB)                   = 1828720
+  0: The total amount of wall time                        = 692.702032
+  0: The maximum resident set size (KB)                   = 1813324
 
 Test 013 cpld_debug_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_debug_noaero_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_debug_noaero_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_debug_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_debug_noaero_p8_intel
 Checking test 014 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -957,14 +957,14 @@ Checking test 014 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 470.917918
-  0: The maximum resident set size (KB)                   = 1639480
+  0: The total amount of wall time                        = 472.410996
+  0: The maximum resident set size (KB)                   = 1644288
 
 Test 014 cpld_debug_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_noaero_p8_agrid_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_noaero_p8_agrid_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_agrid_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_noaero_p8_agrid_intel
 Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1026,14 +1026,14 @@ Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 371.564685
-  0: The maximum resident set size (KB)                   = 1671388
+  0: The total amount of wall time                        = 366.237754
+  0: The maximum resident set size (KB)                   = 1688284
 
 Test 015 cpld_control_noaero_p8_agrid_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_c48_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_c48_intel
 Checking test 016 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1083,14 +1083,14 @@ Checking test 016 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 798.915669
- 0: The maximum resident set size (KB)                   = 2774940
+ 0: The total amount of wall time                        = 794.375530
+ 0: The maximum resident set size (KB)                   = 2777288
 
 Test 016 cpld_control_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_warmstart_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_warmstart_c48_intel
 Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1140,14 +1140,14 @@ Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 214.868226
- 0: The maximum resident set size (KB)                   = 2760456
+ 0: The total amount of wall time                        = 209.412132
+ 0: The maximum resident set size (KB)                   = 2759784
 
 Test 017 cpld_warmstart_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_warmstart_c48_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_restart_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_restart_c48_intel
 Checking test 018 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1197,14 +1197,14 @@ Checking test 018 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 113.045065
- 0: The maximum resident set size (KB)                   = 2198348
+ 0: The total amount of wall time                        = 112.589565
+ 0: The maximum resident set size (KB)                   = 2194768
 
 Test 018 cpld_restart_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/cpld_control_p8_faster_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/cpld_control_p8_faster_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/cpld_control_p8_faster_intel
 Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1269,14 +1269,14 @@ Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 426.611293
-  0: The maximum resident set size (KB)                   = 1797888
+  0: The total amount of wall time                        = 450.603773
+  0: The maximum resident set size (KB)                   = 1787476
 
 Test 019 cpld_control_p8_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_flake_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_flake_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_flake_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_flake_intel
 Checking test 020 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1287,14 +1287,14 @@ Checking test 020 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 258.976066
-  0: The maximum resident set size (KB)                   = 623888
+  0: The total amount of wall time                        = 254.579556
+  0: The maximum resident set size (KB)                   = 624832
 
 Test 020 control_flake_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_CubedSphereGrid_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_CubedSphereGrid_intel
 Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1321,28 +1321,28 @@ Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 182.880788
-  0: The maximum resident set size (KB)                   = 572908
+  0: The total amount of wall time                        = 220.650454
+  0: The maximum resident set size (KB)                   = 570636
 
 Test 021 control_CubedSphereGrid_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_parallel_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_CubedSphereGrid_parallel_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_parallel_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_CubedSphereGrid_parallel_intel
 Checking test 022 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf024.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 182.557617
-  0: The maximum resident set size (KB)                   = 573492
+  0: The total amount of wall time                        = 180.841276
+  0: The maximum resident set size (KB)                   = 570608
 
 Test 022 control_CubedSphereGrid_parallel_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_latlon_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_latlon_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_latlon_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_latlon_intel
 Checking test 023 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1353,14 +1353,14 @@ Checking test 023 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 186.602682
-  0: The maximum resident set size (KB)                   = 574000
+  0: The total amount of wall time                        = 184.527673
+  0: The maximum resident set size (KB)                   = 570384
 
 Test 023 control_latlon_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wrtGauss_netcdf_parallel_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_wrtGauss_netcdf_parallel_intel
 Checking test 024 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1371,14 +1371,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 190.250073
-  0: The maximum resident set size (KB)                   = 576272
+  0: The total amount of wall time                        = 198.312004
+  0: The maximum resident set size (KB)                   = 570480
 
 Test 024 control_wrtGauss_netcdf_parallel_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c48_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c48_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_c48_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_c48_intel
 Checking test 025 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1417,14 +1417,14 @@ Checking test 025 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 598.251116
-0: The maximum resident set size (KB)                   = 805312
+0: The total amount of wall time                        = 614.190143
+0: The maximum resident set size (KB)                   = 798540
 
 Test 025 control_c48_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c192_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c192_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_c192_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_c192_intel
 Checking test 026 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1435,14 +1435,14 @@ Checking test 026 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 729.831404
-  0: The maximum resident set size (KB)                   = 697044
+  0: The total amount of wall time                        = 750.699132
+  0: The maximum resident set size (KB)                   = 693228
 
 Test 026 control_c192_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c384_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c384_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_c384_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_c384_intel
 Checking test 027 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1453,14 +1453,14 @@ Checking test 027 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 933.223671
-  0: The maximum resident set size (KB)                   = 1051624
+  0: The total amount of wall time                        = 950.558591
+  0: The maximum resident set size (KB)                   = 1056708
 
 Test 027 control_c384_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_c384gdas_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_c384gdas_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_c384gdas_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_c384gdas_intel
 Checking test 028 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1503,14 +1503,14 @@ Checking test 028 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 792.014395
-  0: The maximum resident set size (KB)                   = 1202684
+  0: The total amount of wall time                        = 822.368782
+  0: The maximum resident set size (KB)                   = 1193524
 
 Test 028 control_c384gdas_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_stochy_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_stochy_intel
 Checking test 029 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1521,28 +1521,28 @@ Checking test 029 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 124.034575
-  0: The maximum resident set size (KB)                   = 579176
+  0: The total amount of wall time                        = 139.349381
+  0: The maximum resident set size (KB)                   = 578508
 
 Test 029 control_stochy_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_stochy_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_stochy_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_stochy_restart_intel
 Checking test 030 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 65.777939
-  0: The maximum resident set size (KB)                   = 393632
+  0: The total amount of wall time                        = 70.221202
+  0: The maximum resident set size (KB)                   = 391188
 
 Test 030 control_stochy_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_lndp_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_lndp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_lndp_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_lndp_intel
 Checking test 031 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1553,14 +1553,14 @@ Checking test 031 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 113.410401
-  0: The maximum resident set size (KB)                   = 581108
+  0: The total amount of wall time                        = 114.624260
+  0: The maximum resident set size (KB)                   = 576088
 
 Test 031 control_lndp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_iovr4_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_iovr4_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_iovr4_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_iovr4_intel
 Checking test 032 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1575,14 +1575,14 @@ Checking test 032 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 192.652888
-  0: The maximum resident set size (KB)                   = 577104
+  0: The total amount of wall time                        = 192.173874
+  0: The maximum resident set size (KB)                   = 569828
 
 Test 032 control_iovr4_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_iovr5_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_iovr5_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_iovr5_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_iovr5_intel
 Checking test 033 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1597,14 +1597,14 @@ Checking test 033 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 188.933123
-  0: The maximum resident set size (KB)                   = 579000
+  0: The total amount of wall time                        = 191.600398
+  0: The maximum resident set size (KB)                   = 573400
 
 Test 033 control_iovr5_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_p8_intel
 Checking test 034 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1651,14 +1651,14 @@ Checking test 034 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 229.967041
-  0: The maximum resident set size (KB)                   = 1552672
+  0: The total amount of wall time                        = 227.246272
+  0: The maximum resident set size (KB)                   = 1550328
 
 Test 034 control_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_restart_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_restart_p8_intel
 Checking test 035 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1697,14 +1697,14 @@ Checking test 035 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 117.089592
-  0: The maximum resident set size (KB)                   = 784032
+  0: The total amount of wall time                        = 118.627006
+  0: The maximum resident set size (KB)                   = 777336
 
 Test 035 control_restart_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_qr_p8_intel
 Checking test 036 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 036 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 223.396538
-  0: The maximum resident set size (KB)                   = 1560332
+  0: The total amount of wall time                        = 227.430740
+  0: The maximum resident set size (KB)                   = 1555816
 
 Test 036 control_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_restart_qr_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_restart_qr_p8_intel
 Checking test 037 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1797,14 +1797,14 @@ Checking test 037 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 118.715301
-  0: The maximum resident set size (KB)                   = 788924
+  0: The total amount of wall time                        = 124.153552
+  0: The maximum resident set size (KB)                   = 781872
 
 Test 037 control_restart_qr_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_decomp_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_decomp_p8_intel
 Checking test 038 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1847,14 +1847,14 @@ Checking test 038 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 233.410155
-  0: The maximum resident set size (KB)                   = 1537328
+  0: The total amount of wall time                        = 231.542281
+  0: The maximum resident set size (KB)                   = 1539344
 
 Test 038 control_decomp_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_2threads_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_2threads_p8_intel
 Checking test 039 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1897,14 +1897,14 @@ Checking test 039 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 210.822738
-  0: The maximum resident set size (KB)                   = 1630172
+  0: The total amount of wall time                        = 211.862060
+  0: The maximum resident set size (KB)                   = 1625336
 
 Test 039 control_2threads_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_lndp_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_lndp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_lndp_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_p8_lndp_intel
 Checking test 040 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1923,14 +1923,14 @@ Checking test 040 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 424.381662
-  0: The maximum resident set size (KB)                   = 1550760
+  0: The total amount of wall time                        = 444.332744
+  0: The maximum resident set size (KB)                   = 1544592
 
 Test 040 control_p8_lndp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_rrtmgp_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_rrtmgp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_rrtmgp_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_p8_rrtmgp_intel
 Checking test 041 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1977,14 +1977,14 @@ Checking test 041 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 298.523686
-  0: The maximum resident set size (KB)                   = 1622872
+  0: The total amount of wall time                        = 317.570984
+  0: The maximum resident set size (KB)                   = 1610396
 
 Test 041 control_p8_rrtmgp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_mynn_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_mynn_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_mynn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_p8_mynn_intel
 Checking test 042 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2031,14 +2031,14 @@ Checking test 042 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 232.262045
-  0: The maximum resident set size (KB)                   = 1541752
+  0: The total amount of wall time                        = 231.818883
+  0: The maximum resident set size (KB)                   = 1548996
 
 Test 042 control_p8_mynn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/merra2_thompson_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/merra2_thompson_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/merra2_thompson_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/merra2_thompson_intel
 Checking test 043 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2085,14 +2085,14 @@ Checking test 043 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 258.405741
-  0: The maximum resident set size (KB)                   = 1556928
+  0: The total amount of wall time                        = 259.471986
+  0: The maximum resident set size (KB)                   = 1555876
 
 Test 043 merra2_thompson_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_control_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_control_intel
 Checking test 044 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2103,28 +2103,28 @@ Checking test 044 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 397.091595
-  0: The maximum resident set size (KB)                   = 785260
+  0: The total amount of wall time                        = 400.275634
+  0: The maximum resident set size (KB)                   = 784236
 
 Test 044 regional_control_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_restart_intel
 Checking test 045 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 208.008915
-  0: The maximum resident set size (KB)                   = 784904
+  0: The total amount of wall time                        = 213.416728
+  0: The maximum resident set size (KB)                   = 781120
 
 Test 045 regional_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_control_qr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_control_qr_intel
 Checking test 046 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2135,28 +2135,28 @@ Checking test 046 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 398.499874
-  0: The maximum resident set size (KB)                   = 791344
+  0: The total amount of wall time                        = 412.401377
+  0: The maximum resident set size (KB)                   = 792040
 
 Test 046 regional_control_qr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_restart_qr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_restart_qr_intel
 Checking test 047 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 202.398131
-  0: The maximum resident set size (KB)                   = 783992
+  0: The total amount of wall time                        = 201.649685
+  0: The maximum resident set size (KB)                   = 781676
 
 Test 047 regional_restart_qr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_decomp_intel
 Checking test 048 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2167,14 +2167,14 @@ Checking test 048 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 412.951581
-  0: The maximum resident set size (KB)                   = 778868
+  0: The total amount of wall time                        = 439.149442
+  0: The maximum resident set size (KB)                   = 776576
 
 Test 048 regional_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_2threads_intel
 Checking test 049 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2185,28 +2185,28 @@ Checking test 049 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 235.473845
-  0: The maximum resident set size (KB)                   = 774148
+  0: The total amount of wall time                        = 295.021892
+  0: The maximum resident set size (KB)                   = 768984
 
 Test 049 regional_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_netcdf_parallel_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_netcdf_parallel_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_netcdf_parallel_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_netcdf_parallel_intel
 Checking test 050 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 386.590903
-  0: The maximum resident set size (KB)                   = 784216
+  0: The total amount of wall time                        = 425.787239
+  0: The maximum resident set size (KB)                   = 783024
 
 Test 050 regional_netcdf_parallel_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_2dwrtdecomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_2dwrtdecomp_intel
 Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2217,14 +2217,14 @@ Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 395.695645
-  0: The maximum resident set size (KB)                   = 793740
+  0: The total amount of wall time                        = 404.812271
+  0: The maximum resident set size (KB)                   = 785588
 
 Test 051 regional_2dwrtdecomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_control_intel
 Checking test 052 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2271,14 +2271,14 @@ Checking test 052 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 589.656341
-  0: The maximum resident set size (KB)                   = 959172
+  0: The total amount of wall time                        = 619.225585
+  0: The maximum resident set size (KB)                   = 944428
 
 Test 052 rap_control_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_spp_sppt_shum_skeb_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_spp_sppt_shum_skeb_intel
 Checking test 053 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2289,14 +2289,14 @@ Checking test 053 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 309.647291
-  0: The maximum resident set size (KB)                   = 1093704
+  0: The total amount of wall time                        = 318.171209
+  0: The maximum resident set size (KB)                   = 1101156
 
 Test 053 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_decomp_intel
 Checking test 054 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2343,14 +2343,14 @@ Checking test 054 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 612.664842
-  0: The maximum resident set size (KB)                   = 945120
+  0: The total amount of wall time                        = 646.666027
+  0: The maximum resident set size (KB)                   = 938028
 
 Test 054 rap_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_2threads_intel
 Checking test 055 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2397,14 +2397,14 @@ Checking test 055 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 555.136745
-  0: The maximum resident set size (KB)                   = 1035080
+  0: The total amount of wall time                        = 573.589317
+  0: The maximum resident set size (KB)                   = 1029912
 
 Test 055 rap_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_restart_intel
 Checking test 056 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2443,14 +2443,14 @@ Checking test 056 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 311.906231
-  0: The maximum resident set size (KB)                   = 827956
+  0: The total amount of wall time                        = 302.715683
+  0: The maximum resident set size (KB)                   = 829648
 
 Test 056 rap_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_sfcdiff_intel
 Checking test 057 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2497,14 +2497,14 @@ Checking test 057 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 595.859763
-  0: The maximum resident set size (KB)                   = 948740
+  0: The total amount of wall time                        = 620.657420
+  0: The maximum resident set size (KB)                   = 955460
 
 Test 057 rap_sfcdiff_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_sfcdiff_decomp_intel
 Checking test 058 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2551,14 +2551,14 @@ Checking test 058 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 631.288318
-  0: The maximum resident set size (KB)                   = 938860
+  0: The total amount of wall time                        = 660.517113
+  0: The maximum resident set size (KB)                   = 949060
 
 Test 058 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_sfcdiff_restart_intel
 Checking test 059 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2597,14 +2597,14 @@ Checking test 059 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 435.538603
-  0: The maximum resident set size (KB)                   = 831612
+  0: The total amount of wall time                        = 441.836292
+  0: The maximum resident set size (KB)                   = 841580
 
 Test 059 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_intel
 Checking test 060 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2632,16 +2632,16 @@ Checking test 060 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
@@ -2651,14 +2651,14 @@ Checking test 060 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 568.425398
-  0: The maximum resident set size (KB)                   = 951272
+  0: The total amount of wall time                        = 590.700435
+  0: The maximum resident set size (KB)                   = 947332
 
 Test 060 hrrr_control_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_qr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_qr_intel
 Checking test 061 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2705,14 +2705,14 @@ Checking test 061 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 563.135433
-  0: The maximum resident set size (KB)                   = 960656
+  0: The total amount of wall time                        = 580.803085
+  0: The maximum resident set size (KB)                   = 967252
 
 Test 061 hrrr_control_qr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_decomp_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_decomp_intel
 Checking test 062 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2740,16 +2740,16 @@ Checking test 062 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
@@ -2759,14 +2759,14 @@ Checking test 062 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 596.633945
-  0: The maximum resident set size (KB)                   = 951376
+  0: The total amount of wall time                        = 619.957477
+  0: The maximum resident set size (KB)                   = 947892
 
 Test 062 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_2threads_intel
 Checking test 063 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2794,16 +2794,16 @@ Checking test 063 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
  Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc ............ALT CHECK......OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
@@ -2813,42 +2813,42 @@ Checking test 063 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 526.762507
-  0: The maximum resident set size (KB)                   = 1014792
+  0: The total amount of wall time                        = 550.204107
+  0: The maximum resident set size (KB)                   = 1011760
 
 Test 063 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_restart_intel
 Checking test 064 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 418.021823
-  0: The maximum resident set size (KB)                   = 838692
+  0: The total amount of wall time                        = 423.471167
+  0: The maximum resident set size (KB)                   = 837624
 
 Test 064 hrrr_control_restart_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_qr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_restart_qr_intel
 Checking test 065 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 421.280277
-  0: The maximum resident set size (KB)                   = 854648
+  0: The total amount of wall time                        = 427.510053
+  0: The maximum resident set size (KB)                   = 852276
 
 Test 065 hrrr_control_restart_qr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1beta_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_v1beta_intel
 Checking test 066 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2895,14 +2895,14 @@ Checking test 066 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 601.597541
-  0: The maximum resident set size (KB)                   = 954080
+  0: The total amount of wall time                        = 608.908142
+  0: The maximum resident set size (KB)                   = 951640
 
 Test 066 rrfs_v1beta_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1nssl_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_v1nssl_intel
 Checking test 067 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2917,14 +2917,14 @@ Checking test 067 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 711.713546
-  0: The maximum resident set size (KB)                   = 628800
+  0: The total amount of wall time                        = 727.821172
+  0: The maximum resident set size (KB)                   = 631540
 
 Test 067 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_v1nssl_nohailnoccn_intel
 Checking test 068 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2939,14 +2939,14 @@ Checking test 068 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 707.982244
-  0: The maximum resident set size (KB)                   = 635536
+  0: The total amount of wall time                        = 710.531186
+  0: The maximum resident set size (KB)                   = 630176
 
 Test 068 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 069 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2962,14 +2962,14 @@ Checking test 069 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 197.603339
-  0: The maximum resident set size (KB)                   = 902156
+  0: The total amount of wall time                        = 198.085759
+  0: The maximum resident set size (KB)                   = 905088
 
 Test 069 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2978,14 +2978,14 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 128.248768
-  0: The maximum resident set size (KB)                   = 872272
+  0: The total amount of wall time                        = 131.278291
+  0: The maximum resident set size (KB)                   = 868720
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_conus13km_hrrr_warm_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_conus13km_hrrr_warm_intel
 Checking test 071 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3001,14 +3001,14 @@ Checking test 071 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 176.516553
-  0: The maximum resident set size (KB)                   = 874612
+  0: The total amount of wall time                        = 176.444831
+  0: The maximum resident set size (KB)                   = 874760
 
 Test 071 rrfs_conus13km_hrrr_warm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_radar_tten_warm_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_smoke_conus13km_radar_tten_warm_intel
 Checking test 072 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3017,26 +3017,26 @@ Checking test 072 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 199.338798
-  0: The maximum resident set size (KB)                   = 910760
+  0: The total amount of wall time                        = 201.289003
+  0: The maximum resident set size (KB)                   = 913520
 
 Test 072 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
 Checking test 073 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 116.078382
-  0: The maximum resident set size (KB)                   = 891524
+  0: The total amount of wall time                        = 112.736907
+  0: The maximum resident set size (KB)                   = 895928
 
 Test 073 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmg_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmg_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_csawmg_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_csawmg_intel
 Checking test 074 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3047,14 +3047,14 @@ Checking test 074 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 468.067220
-  0: The maximum resident set size (KB)                   = 672956
+  0: The total amount of wall time                        = 459.251675
+  0: The maximum resident set size (KB)                   = 664976
 
 Test 074 control_csawmg_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmgt_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_csawmgt_intel
 Checking test 075 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3065,14 +3065,14 @@ Checking test 075 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 460.199912
-  0: The maximum resident set size (KB)                   = 667108
+  0: The total amount of wall time                        = 448.729208
+  0: The maximum resident set size (KB)                   = 663416
 
 Test 075 control_csawmgt_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_ras_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_ras_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_ras_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_ras_intel
 Checking test 076 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3083,26 +3083,26 @@ Checking test 076 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 248.462259
-  0: The maximum resident set size (KB)                   = 635344
+  0: The total amount of wall time                        = 256.054440
+  0: The maximum resident set size (KB)                   = 633036
 
 Test 076 control_ras_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wam_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wam_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_wam_intel
 Checking test 077 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 150.974707
-  0: The maximum resident set size (KB)                   = 485320
+  0: The total amount of wall time                        = 161.790072
+  0: The maximum resident set size (KB)                   = 487472
 
 Test 077 control_wam_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_faster_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_faster_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_p8_faster_intel
 Checking test 078 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3149,14 +3149,14 @@ Checking test 078 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 211.305588
-  0: The maximum resident set size (KB)                   = 1552500
+  0: The total amount of wall time                        = 209.769422
+  0: The maximum resident set size (KB)                   = 1539668
 
 Test 078 control_p8_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_control_faster_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_control_faster_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_control_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_control_faster_intel
 Checking test 079 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3167,56 +3167,56 @@ Checking test 079 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 368.467879
-  0: The maximum resident set size (KB)                   = 793248
+  0: The total amount of wall time                        = 373.336186
+  0: The maximum resident set size (KB)                   = 782040
 
 Test 079 regional_control_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_smoke_conus13km_hrrr_warm_debug_intel
 Checking test 080 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 1076.754596
-  0: The maximum resident set size (KB)                   = 932448
+  0: The total amount of wall time                        = 1082.586589
+  0: The maximum resident set size (KB)                   = 929884
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
 Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 632.349554
-  0: The maximum resident set size (KB)                   = 897852
+  0: The total amount of wall time                        = 621.481091
+  0: The maximum resident set size (KB)                   = 898660
 
 Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_conus13km_hrrr_warm_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_conus13km_hrrr_warm_debug_intel
 Checking test 082 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 963.277850
-  0: The maximum resident set size (KB)                   = 903872
+  0: The total amount of wall time                        = 964.844247
+  0: The maximum resident set size (KB)                   = 903444
 
 Test 082 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_CubedSphereGrid_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_CubedSphereGrid_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_CubedSphereGrid_debug_intel
 Checking test 083 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3243,348 +3243,348 @@ Checking test 083 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 184.993414
-  0: The maximum resident set size (KB)                   = 730392
+  0: The total amount of wall time                        = 185.115278
+  0: The maximum resident set size (KB)                   = 744584
 
 Test 083 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wrtGauss_netcdf_parallel_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 084 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 186.806760
-  0: The maximum resident set size (KB)                   = 738512
+  0: The total amount of wall time                        = 186.133744
+  0: The maximum resident set size (KB)                   = 731832
 
 Test 084 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_stochy_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_stochy_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_stochy_debug_intel
 Checking test 085 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 211.507235
-  0: The maximum resident set size (KB)                   = 741452
+  0: The total amount of wall time                        = 219.771622
+  0: The maximum resident set size (KB)                   = 736244
 
 Test 085 control_stochy_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_lndp_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_lndp_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_lndp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_lndp_debug_intel
 Checking test 086 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.295067
-  0: The maximum resident set size (KB)                   = 736460
+  0: The total amount of wall time                        = 188.575162
+  0: The maximum resident set size (KB)                   = 732524
 
 Test 086 control_lndp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmg_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmg_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_csawmg_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_csawmg_debug_intel
 Checking test 087 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.929669
-  0: The maximum resident set size (KB)                   = 780924
+  0: The total amount of wall time                        = 298.274889
+  0: The maximum resident set size (KB)                   = 782264
 
 Test 087 control_csawmg_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_csawmgt_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_csawmgt_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_csawmgt_debug_intel
 Checking test 088 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.662722
-  0: The maximum resident set size (KB)                   = 783184
+  0: The total amount of wall time                        = 292.756681
+  0: The maximum resident set size (KB)                   = 784492
 
 Test 088 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_ras_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_ras_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_ras_debug_intel
 Checking test 089 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 191.791935
-  0: The maximum resident set size (KB)                   = 746692
+  0: The total amount of wall time                        = 189.753950
+  0: The maximum resident set size (KB)                   = 746824
 
 Test 089 control_ras_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_diag_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_diag_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_diag_debug_intel
 Checking test 090 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.626234
-  0: The maximum resident set size (KB)                   = 785568
+  0: The total amount of wall time                        = 196.260264
+  0: The maximum resident set size (KB)                   = 795080
 
 Test 090 control_diag_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_debug_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_debug_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_debug_p8_intel
 Checking test 091 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 212.386800
-  0: The maximum resident set size (KB)                   = 1566024
+  0: The total amount of wall time                        = 217.002880
+  0: The maximum resident set size (KB)                   = 1558660
 
 Test 091 control_debug_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_debug_intel
 Checking test 092 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1268.478785
-  0: The maximum resident set size (KB)                   = 802564
+  0: The total amount of wall time                        = 1266.553182
+  0: The maximum resident set size (KB)                   = 804164
 
 Test 092 regional_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_control_debug_intel
 Checking test 093 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 348.628326
-  0: The maximum resident set size (KB)                   = 1106156
+  0: The total amount of wall time                        = 352.250452
+  0: The maximum resident set size (KB)                   = 1110548
 
 Test 093 rap_control_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_debug_intel
 Checking test 094 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 336.773772
-  0: The maximum resident set size (KB)                   = 1112308
+  0: The total amount of wall time                        = 337.303911
+  0: The maximum resident set size (KB)                   = 1104848
 
 Test 094 hrrr_control_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_unified_drag_suite_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_unified_drag_suite_debug_intel
 Checking test 095 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 347.695101
-  0: The maximum resident set size (KB)                   = 1111588
+  0: The total amount of wall time                        = 349.501062
+  0: The maximum resident set size (KB)                   = 1113108
 
 Test 095 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_diag_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_diag_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_diag_debug_intel
 Checking test 096 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 364.708746
-  0: The maximum resident set size (KB)                   = 1195580
+  0: The total amount of wall time                        = 362.954091
+  0: The maximum resident set size (KB)                   = 1191020
 
 Test 096 rap_diag_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_cires_ugwp_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_cires_ugwp_debug_intel
 Checking test 097 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 354.323338
-  0: The maximum resident set size (KB)                   = 1113252
+  0: The total amount of wall time                        = 354.718052
+  0: The maximum resident set size (KB)                   = 1112516
 
 Test 097 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_cires_ugwp_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_unified_ugwp_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_unified_ugwp_debug_intel
 Checking test 098 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 356.864633
-  0: The maximum resident set size (KB)                   = 1117036
+  0: The total amount of wall time                        = 355.724865
+  0: The maximum resident set size (KB)                   = 1111824
 
 Test 098 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_lndp_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_lndp_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_lndp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_lndp_debug_intel
 Checking test 099 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 347.999813
-  0: The maximum resident set size (KB)                   = 1112176
+  0: The total amount of wall time                        = 349.707729
+  0: The maximum resident set size (KB)                   = 1112092
 
 Test 099 rap_lndp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_progcld_thompson_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_progcld_thompson_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_progcld_thompson_debug_intel
 Checking test 100 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.182411
-  0: The maximum resident set size (KB)                   = 1107872
+  0: The total amount of wall time                        = 348.137451
+  0: The maximum resident set size (KB)                   = 1107612
 
 Test 100 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_noah_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_noah_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_noah_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_noah_debug_intel
 Checking test 101 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.578959
-  0: The maximum resident set size (KB)                   = 1112716
+  0: The total amount of wall time                        = 342.191496
+  0: The maximum resident set size (KB)                   = 1116704
 
 Test 101 rap_noah_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_sfcdiff_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_sfcdiff_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_sfcdiff_debug_intel
 Checking test 102 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 346.575542
-  0: The maximum resident set size (KB)                   = 1108628
+  0: The total amount of wall time                        = 348.296686
+  0: The maximum resident set size (KB)                   = 1109252
 
 Test 102 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_noah_sfcdiff_cires_ugwp_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 572.173051
-  0: The maximum resident set size (KB)                   = 1111536
+  0: The total amount of wall time                        = 572.508862
+  0: The maximum resident set size (KB)                   = 1109904
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rrfs_v1beta_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rrfs_v1beta_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rrfs_v1beta_debug_intel
 Checking test 104 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.767735
-  0: The maximum resident set size (KB)                   = 1104696
+  0: The total amount of wall time                        = 339.347773
+  0: The maximum resident set size (KB)                   = 1110148
 
 Test 104 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_clm_lake_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_clm_lake_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_clm_lake_debug_intel
 Checking test 105 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 431.056172
-  0: The maximum resident set size (KB)                   = 1096380
+  0: The total amount of wall time                        = 424.195192
+  0: The maximum resident set size (KB)                   = 1118536
 
 Test 105 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_flake_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_flake_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_flake_debug_intel
 Checking test 106 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.851149
-  0: The maximum resident set size (KB)                   = 1111424
+  0: The total amount of wall time                        = 349.124471
+  0: The maximum resident set size (KB)                   = 1111908
 
 Test 106 rap_flake_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_wam_debug_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_wam_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_wam_debug_intel
 Checking test 107 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 354.455800
-  0: The maximum resident set size (KB)                   = 432364
+  0: The total amount of wall time                        = 357.126690
+  0: The maximum resident set size (KB)                   = 433548
 
 Test 107 control_wam_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 108 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3595,14 +3595,14 @@ Checking test 108 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 288.336473
-  0: The maximum resident set size (KB)                   = 987480
+  0: The total amount of wall time                        = 290.120181
+  0: The maximum resident set size (KB)                   = 994060
 
 Test 108 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_control_dyn32_phy32_intel
 Checking test 109 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3649,14 +3649,14 @@ Checking test 109 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 482.804390
-  0: The maximum resident set size (KB)                   = 850992
+  0: The total amount of wall time                        = 495.801857
+  0: The maximum resident set size (KB)                   = 847748
 
 Test 109 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_dyn32_phy32_intel
 Checking test 110 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3703,14 +3703,14 @@ Checking test 110 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 250.727648
-  0: The maximum resident set size (KB)                   = 830996
+  0: The total amount of wall time                        = 261.514272
+  0: The maximum resident set size (KB)                   = 839888
 
 Test 110 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_qr_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_qr_dyn32_phy32_intel
 Checking test 111 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3757,14 +3757,14 @@ Checking test 111 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 247.346904
-  0: The maximum resident set size (KB)                   = 846108
+  0: The total amount of wall time                        = 257.689259
+  0: The maximum resident set size (KB)                   = 846304
 
 Test 111 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_2threads_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_2threads_dyn32_phy32_intel
 Checking test 112 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3811,14 +3811,14 @@ Checking test 112 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 460.768182
-  0: The maximum resident set size (KB)                   = 888752
+  0: The total amount of wall time                        = 467.260569
+  0: The maximum resident set size (KB)                   = 893708
 
 Test 112 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_2threads_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 113 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3865,14 +3865,14 @@ Checking test 113 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.956940
-  0: The maximum resident set size (KB)                   = 880816
+  0: The total amount of wall time                        = 244.575630
+  0: The maximum resident set size (KB)                   = 874668
 
 Test 113 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_decomp_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 114 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3919,14 +3919,14 @@ Checking test 114 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 263.453946
-  0: The maximum resident set size (KB)                   = 830984
+  0: The total amount of wall time                        = 270.010844
+  0: The maximum resident set size (KB)                   = 835848
 
 Test 114 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_restart_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_restart_dyn32_phy32_intel
 Checking test 115 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3965,42 +3965,42 @@ Checking test 115 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 352.599030
-  0: The maximum resident set size (KB)                   = 802332
+  0: The total amount of wall time                        = 359.564295
+  0: The maximum resident set size (KB)                   = 808912
 
 Test 115 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_restart_dyn32_phy32_intel
 Checking test 116 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 128.417058
-  0: The maximum resident set size (KB)                   = 759368
+  0: The total amount of wall time                        = 132.905437
+  0: The maximum resident set size (KB)                   = 761996
 
 Test 116 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_restart_qr_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_restart_qr_dyn32_phy32_intel
 Checking test 117 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 131.416949
-  0: The maximum resident set size (KB)                   = 785244
+  0: The total amount of wall time                        = 131.710692
+  0: The maximum resident set size (KB)                   = 788452
 
 Test 117 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_dyn64_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_dyn64_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_control_dyn64_phy32_intel
 Checking test 118 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4047,81 +4047,81 @@ Checking test 118 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 311.247188
-  0: The maximum resident set size (KB)                   = 872632
+  0: The total amount of wall time                        = 319.604748
+  0: The maximum resident set size (KB)                   = 876056
 
 Test 118 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_debug_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_control_debug_dyn32_phy32_intel
 Checking test 119 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.837119
-  0: The maximum resident set size (KB)                   = 1002264
+  0: The total amount of wall time                        = 342.679462
+  0: The maximum resident set size (KB)                   = 992712
 
 Test 119 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hrrr_control_debug_dyn32_phy32_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hrrr_control_debug_dyn32_phy32_intel
 Checking test 120 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 338.615567
-  0: The maximum resident set size (KB)                   = 990688
+  0: The total amount of wall time                        = 340.318266
+  0: The maximum resident set size (KB)                   = 988848
 
 Test 120 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/rap_control_dyn64_phy32_debug_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/rap_control_dyn64_phy32_debug_intel
 Checking test 121 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.739325
-  0: The maximum resident set size (KB)                   = 1035480
+  0: The total amount of wall time                        = 348.518941
+  0: The maximum resident set size (KB)                   = 1030932
 
 Test 121 rap_control_dyn64_phy32_debug_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hafs_regional_atm_intel
 Checking test 122 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 961.723902
-  0: The maximum resident set size (KB)                   = 1215940
+  0: The total amount of wall time                        = 322.942982
+  0: The maximum resident set size (KB)                   = 1206788
 
 Test 122 hafs_regional_atm_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_thompson_gfdlsf_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 123 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 1115.626393
-  0: The maximum resident set size (KB)                   = 1588788
+  0: The total amount of wall time                        = 418.825148
+  0: The maximum resident set size (KB)                   = 1591504
 
 Test 123 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_ocn_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hafs_regional_atm_ocn_intel
 Checking test 124 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4130,14 +4130,14 @@ Checking test 124 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1207.521701
-  0: The maximum resident set size (KB)                   = 1293848
+  0: The total amount of wall time                        = 509.705565
+  0: The maximum resident set size (KB)                   = 1295108
 
 Test 124 hafs_regional_atm_ocn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_wav_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_wav_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_wav_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hafs_regional_atm_wav_intel
 Checking test 125 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4146,14 +4146,14 @@ Checking test 125 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1587.520121
-  0: The maximum resident set size (KB)                   = 1323848
+  0: The total amount of wall time                        = 923.671672
+  0: The maximum resident set size (KB)                   = 1324960
 
 Test 125 hafs_regional_atm_wav_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_atm_ocn_wav_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_atm_ocn_wav_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_wav_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hafs_regional_atm_ocn_wav_intel
 Checking test 126 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4164,14 +4164,14 @@ Checking test 126 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1719.986857
-  0: The maximum resident set size (KB)                   = 1340580
+  0: The total amount of wall time                        = 1036.237764
+  0: The maximum resident set size (KB)                   = 1343032
 
 Test 126 hafs_regional_atm_ocn_wav_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_docn_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hafs_regional_docn_intel
 Checking test 127 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4179,14 +4179,14 @@ Checking test 127 hafs_regional_docn_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1014.346961
-  0: The maximum resident set size (KB)                   = 1299592
+  0: The total amount of wall time                        = 465.183296
+  0: The maximum resident set size (KB)                   = 1296224
 
 Test 127 hafs_regional_docn_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/hafs_regional_docn_oisst_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/hafs_regional_docn_oisst_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_oisst_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/hafs_regional_docn_oisst_intel
 Checking test 128 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4194,118 +4194,118 @@ Checking test 128 hafs_regional_docn_oisst_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1126.162789
-  0: The maximum resident set size (KB)                   = 1283928
+  0: The total amount of wall time                        = 464.224295
+  0: The maximum resident set size (KB)                   = 1197328
 
 Test 128 hafs_regional_docn_oisst_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_control_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_control_cfsr_intel
 Checking test 129 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 203.644076
- 0: The maximum resident set size (KB)                   = 953964
+ 0: The total amount of wall time                        = 205.853322
+ 0: The maximum resident set size (KB)                   = 957100
 
 Test 129 datm_cdeps_control_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_restart_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_restart_cfsr_intel
 Checking test 130 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 122.306546
- 0: The maximum resident set size (KB)                   = 952644
+ 0: The total amount of wall time                        = 124.058684
+ 0: The maximum resident set size (KB)                   = 936588
 
 Test 130 datm_cdeps_restart_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_gefs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_control_gefs_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_control_gefs_intel
 Checking test 131 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 199.430108
- 0: The maximum resident set size (KB)                   = 865016
+ 0: The total amount of wall time                        = 200.180440
+ 0: The maximum resident set size (KB)                   = 856696
 
 Test 131 datm_cdeps_control_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_iau_gefs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_iau_gefs_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_iau_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_iau_gefs_intel
 Checking test 132 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 201.503007
- 0: The maximum resident set size (KB)                   = 852860
+ 0: The total amount of wall time                        = 203.226987
+ 0: The maximum resident set size (KB)                   = 865484
 
 Test 132 datm_cdeps_iau_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_stochy_gefs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_stochy_gefs_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_stochy_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_stochy_gefs_intel
 Checking test 133 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 203.641562
- 0: The maximum resident set size (KB)                   = 858788
+ 0: The total amount of wall time                        = 205.290939
+ 0: The maximum resident set size (KB)                   = 858448
 
 Test 133 datm_cdeps_stochy_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_ciceC_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_ciceC_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_ciceC_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_ciceC_cfsr_intel
 Checking test 134 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 205.765666
- 0: The maximum resident set size (KB)                   = 961560
+ 0: The total amount of wall time                        = 205.835357
+ 0: The maximum resident set size (KB)                   = 964620
 
 Test 134 datm_cdeps_ciceC_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_bulk_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_bulk_cfsr_intel
 Checking test 135 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 205.142450
- 0: The maximum resident set size (KB)                   = 975772
+ 0: The total amount of wall time                        = 205.401971
+ 0: The maximum resident set size (KB)                   = 971052
 
 Test 135 datm_cdeps_bulk_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_bulk_gefs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_bulk_gefs_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_bulk_gefs_intel
 Checking test 136 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 199.257446
- 0: The maximum resident set size (KB)                   = 856944
+ 0: The total amount of wall time                        = 201.960542
+ 0: The maximum resident set size (KB)                   = 866180
 
 Test 136 datm_cdeps_bulk_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_mx025_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_mx025_cfsr_intel
 Checking test 137 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4314,14 +4314,14 @@ Checking test 137 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 548.391328
-  0: The maximum resident set size (KB)                   = 761456
+  0: The total amount of wall time                        = 552.353930
+  0: The maximum resident set size (KB)                   = 764584
 
 Test 137 datm_cdeps_mx025_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_mx025_gefs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_mx025_gefs_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_gefs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_mx025_gefs_intel
 Checking test 138 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -4330,77 +4330,77 @@ Checking test 138 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 528.510003
-  0: The maximum resident set size (KB)                   = 735248
+  0: The total amount of wall time                        = 540.179533
+  0: The maximum resident set size (KB)                   = 734472
 
 Test 138 datm_cdeps_mx025_gefs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_multiple_files_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_multiple_files_cfsr_intel
 Checking test 139 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 203.313014
- 0: The maximum resident set size (KB)                   = 960480
+ 0: The total amount of wall time                        = 204.725426
+ 0: The maximum resident set size (KB)                   = 976568
 
 Test 139 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_3072x1536_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_3072x1536_cfsr_intel
 Checking test 140 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 284.615957
- 0: The maximum resident set size (KB)                   = 2187688
+ 0: The total amount of wall time                        = 277.201846
+ 0: The maximum resident set size (KB)                   = 2185468
 
 Test 140 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_gfs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_gfs_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_gfs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_gfs_intel
 Checking test 141 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 294.465776
- 0: The maximum resident set size (KB)                   = 2251232
+ 0: The total amount of wall time                        = 276.543613
+ 0: The maximum resident set size (KB)                   = 2193176
 
 Test 141 datm_cdeps_gfs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_debug_cfsr_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_debug_cfsr_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_debug_cfsr_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_debug_cfsr_intel
 Checking test 142 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 459.817879
- 0: The maximum resident set size (KB)                   = 911300
+ 0: The total amount of wall time                        = 460.709844
+ 0: The maximum resident set size (KB)                   = 936920
 
 Test 142 datm_cdeps_debug_cfsr_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_control_cfsr_faster_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_control_cfsr_faster_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_faster_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_control_cfsr_faster_intel
 Checking test 143 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 205.384397
- 0: The maximum resident set size (KB)                   = 971712
+ 0: The total amount of wall time                        = 206.781363
+ 0: The maximum resident set size (KB)                   = 955600
 
 Test 143 datm_cdeps_control_cfsr_faster_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_lnd_gswp3_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_lnd_gswp3_intel
 Checking test 144 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4409,14 +4409,14 @@ Checking test 144 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 10.142880
-  0: The maximum resident set size (KB)                   = 245980
+  0: The total amount of wall time                        = 13.964217
+  0: The maximum resident set size (KB)                   = 240144
 
 Test 144 datm_cdeps_lnd_gswp3_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/datm_cdeps_lnd_gswp3_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/datm_cdeps_lnd_gswp3_rst_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/datm_cdeps_lnd_gswp3_rst_intel
 Checking test 145 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -4425,14 +4425,14 @@ Checking test 145 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 18.630930
-  0: The maximum resident set size (KB)                   = 249188
+  0: The total amount of wall time                        = 18.303466
+  0: The maximum resident set size (KB)                   = 249736
 
 Test 145 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_p8_atmlnd_sbs_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_p8_atmlnd_sbs_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_p8_atmlnd_sbs_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_p8_atmlnd_sbs_intel
 Checking test 146 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4517,14 +4517,14 @@ Checking test 146 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 288.438613
-  0: The maximum resident set size (KB)                   = 1597396
+  0: The total amount of wall time                        = 277.982276
+  0: The maximum resident set size (KB)                   = 1596004
 
 Test 146 control_p8_atmlnd_sbs_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmwav_control_noaero_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmwav_control_noaero_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/atmwav_control_noaero_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/atmwav_control_noaero_p8_intel
 Checking test 147 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4567,14 +4567,14 @@ Checking test 147 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 139.580677
-  0: The maximum resident set size (KB)                   = 1567684
+  0: The total amount of wall time                        = 123.900247
+  0: The maximum resident set size (KB)                   = 1567844
 
 Test 147 atmwav_control_noaero_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/control_atmwav_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/control_atmwav_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/control_atmwav_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/control_atmwav_intel
 Checking test 148 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -4618,14 +4618,14 @@ Checking test 148 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 123.956289
-  0: The maximum resident set size (KB)                   = 597892
+  0: The total amount of wall time                        = 124.710216
+  0: The maximum resident set size (KB)                   = 602404
 
 Test 148 control_atmwav_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmaero_control_p8_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/atmaero_control_p8_intel
 Checking test 149 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4669,14 +4669,14 @@ Checking test 149 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 346.034732
-  0: The maximum resident set size (KB)                   = 1655896
+  0: The total amount of wall time                        = 300.710360
+  0: The maximum resident set size (KB)                   = 1634508
 
 Test 149 atmaero_control_p8_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmaero_control_p8_rad_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/atmaero_control_p8_rad_intel
 Checking test 150 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4720,14 +4720,14 @@ Checking test 150 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 417.463852
-  0: The maximum resident set size (KB)                   = 1673052
+  0: The total amount of wall time                        = 373.538796
+  0: The maximum resident set size (KB)                   = 1679520
 
 Test 150 atmaero_control_p8_rad_intel PASS
 
 
-baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230621/atmaero_control_p8_rad_micro_intel
-working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_220577/atmaero_control_p8_rad_micro_intel
+baseline dir = /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_micro_intel
+working dir  = /lfs4/HFIP/hfv3gfs/role.epic/RT_RUNDIRS/role.epic/FV3_RT/rt_79480/atmaero_control_p8_rad_micro_intel
 Checking test 151 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4771,12 +4771,12 @@ Checking test 151 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 416.505252
-  0: The maximum resident set size (KB)                   = 1673392
+  0: The total amount of wall time                        = 380.041795
+  0: The maximum resident set size (KB)                   = 1682832
 
 Test 151 atmaero_control_p8_rad_micro_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Jun 22 21:22:50 UTC 2023
-Elapsed time: 03h:00m:57s. Have a nice day!
+Wed Jun 28 02:26:04 UTC 2023
+Elapsed time: 03h:01m:23s. Have a nice day!

--- a/tests/logs/RegressionTests_orion.log
+++ b/tests/logs/RegressionTests_orion.log
@@ -1,59 +1,59 @@
-Sun Jun 25 10:22:17 CDT 2023
+Tue Jun 27 14:49:40 CDT 2023
 Start Regression test
 
-Testing UFSWM Hash: 785450c5a5b1911f352d8ea9d9e013a72c30a98b
+Testing UFSWM Hash: 2e508553d6cc8463a0244285d542f54fc083ed31
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
+ 596f540cff635a802d07cacf652d49b30d62ea6e ../FV3 (remotes/origin/unused_ccpp_suites)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 805 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 861 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 746 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 004 elapsed time 292 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 005 elapsed time 281 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 006 elapsed time 754 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 762 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 885 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 009 elapsed time 1040 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 010 elapsed time 269 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 011 elapsed time 790 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 739 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 648 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 610 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 708 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 278 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 204 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 668 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 614 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 181 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 209 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 692 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 236 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 781 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 026 elapsed time 679 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 027 elapsed time 222 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 028 elapsed time 129 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 029 elapsed time 194 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 030 elapsed time 84 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 662 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 032 elapsed time 690 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 033 elapsed time 660 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 661 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 601 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 214 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 037 elapsed time 622 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 768 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 823 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 808 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 004 elapsed time 502 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 242 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 006 elapsed time 750 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 750 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 815 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 009 elapsed time 934 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 010 elapsed time 344 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 011 elapsed time 783 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 727 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 622 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 635 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 602 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 267 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 203 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 633 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 606 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 213 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 675 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 208 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 700 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 026 elapsed time 646 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 027 elapsed time 216 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 028 elapsed time 128 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 029 elapsed time 206 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 030 elapsed time 58 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 634 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 032 elapsed time 641 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 033 elapsed time 692 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 641 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 625 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 191 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 037 elapsed time 656 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_mixedmode_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_p8_mixedmode_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -118,14 +118,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 307.114887
-  0: The maximum resident set size (KB)                   = 3146384
+  0: The total amount of wall time                        = 313.125479
+  0: The maximum resident set size (KB)                   = 3077840
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_gfsv17_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_gfsv17_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -189,14 +189,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 219.774096
-  0: The maximum resident set size (KB)                   = 1699024
+  0: The total amount of wall time                        = 314.439358
+  0: The maximum resident set size (KB)                   = 1693920
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -261,14 +261,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 341.761644
-  0: The maximum resident set size (KB)                   = 3182992
+  0: The total amount of wall time                        = 341.187553
+  0: The maximum resident set size (KB)                   = 3171568
 
 Test 003 cpld_control_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_restart_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -321,14 +321,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 202.074357
-  0: The maximum resident set size (KB)                   = 3052220
+  0: The total amount of wall time                        = 206.732934
+  0: The maximum resident set size (KB)                   = 3050496
 
 Test 004 cpld_restart_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_qr_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -393,14 +393,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 349.040692
-  0: The maximum resident set size (KB)                   = 3190816
+  0: The total amount of wall time                        = 342.679760
+  0: The maximum resident set size (KB)                   = 3185104
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_restart_qr_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -453,14 +453,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 209.051192
-  0: The maximum resident set size (KB)                   = 3065336
+  0: The total amount of wall time                        = 208.470482
+  0: The maximum resident set size (KB)                   = 3057108
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_2threads_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -513,14 +513,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 396.860257
-  0: The maximum resident set size (KB)                   = 3521092
+  0: The total amount of wall time                        = 405.624427
+  0: The maximum resident set size (KB)                   = 3518508
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_decomp_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -573,14 +573,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 343.574088
-  0: The maximum resident set size (KB)                   = 3170280
+  0: The total amount of wall time                        = 341.310465
+  0: The maximum resident set size (KB)                   = 3169344
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_mpi_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -633,14 +633,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 283.958692
-  0: The maximum resident set size (KB)                   = 3034084
+  0: The total amount of wall time                        = 284.112801
+  0: The maximum resident set size (KB)                   = 3028884
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_ciceC_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_ciceC_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -705,14 +705,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 343.620311
-  0: The maximum resident set size (KB)                   = 3178824
+  0: The total amount of wall time                        = 341.542468
+  0: The maximum resident set size (KB)                   = 3171616
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c192_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_c192_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_c192_p8_intel
 Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -765,14 +765,14 @@ Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 634.319738
-  0: The maximum resident set size (KB)                   = 3260760
+  0: The total amount of wall time                        = 633.782499
+  0: The maximum resident set size (KB)                   = 3260044
 
 Test 011 cpld_control_c192_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c192_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_restart_c192_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_restart_c192_p8_intel
 Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -825,20 +825,124 @@ Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 436.419086
-  0: The maximum resident set size (KB)                   = 3158292
+  0: The total amount of wall time                        = 451.350252
+  0: The maximum resident set size (KB)                   = 3159956
 
 Test 012 cpld_restart_c192_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_bmark_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_bmark_p8_intel
 Checking test 013 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
- Comparing atmf006.nc ............ALT CHECK......ERROR
+ Comparing atmf006.nc .........OK
+ Comparing GFSFLX.GrbF06 .........OK
+ Comparing GFSPRS.GrbF06 .........OK
+ Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
+ Comparing RESTART/20130401.060000.coupler.res .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res_1.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res_2.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2013-04-01-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
+ Comparing 20130401.060000.out_pnt.ww3 .........OK
+ Comparing 20130401.060000.out_grd.ww3 .........OK
+
+   0: The total amount of wall time                        = 859.149135
+   0: The maximum resident set size (KB)                   = 4036568
+
+Test 013 cpld_bmark_p8_intel PASS
+
+
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_restart_bmark_p8_intel
+Checking test 014 cpld_restart_bmark_p8_intel results ....
+ Comparing sfcf006.nc .........OK
+ Comparing atmf006.nc .........OK
+ Comparing GFSFLX.GrbF06 .........OK
+ Comparing GFSPRS.GrbF06 .........OK
+ Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
+ Comparing RESTART/20130401.060000.coupler.res .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20130401.060000.sfc_data.tile6.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res_1.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res_2.nc .........OK
+ Comparing RESTART/20130401.060000.MOM.res_3.nc .........OK
+ Comparing RESTART/iced.2013-04-01-21600.nc .........OK
+ Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
+ Comparing 20130401.060000.out_pnt.ww3 .........OK
+ Comparing 20130401.060000.out_grd.ww3 .........OK
+
+   0: The total amount of wall time                        = 534.424169
+   0: The maximum resident set size (KB)                   = 3954976
+
+Test 014 cpld_restart_bmark_p8_intel PASS
+
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_noaero_p8_intel
 Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -902,14 +1006,14 @@ Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 252.087858
-  0: The maximum resident set size (KB)                   = 1724804
+  0: The total amount of wall time                        = 255.075905
+  0: The maximum resident set size (KB)                   = 1733696
 
 Test 015 cpld_control_noaero_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_nowave_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_nowave_noaero_p8_intel
 Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -971,14 +1075,14 @@ Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 256.067955
-  0: The maximum resident set size (KB)                   = 1769520
+  0: The total amount of wall time                        = 259.226528
+  0: The maximum resident set size (KB)                   = 1765524
 
 Test 016 cpld_control_nowave_noaero_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_debug_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_debug_p8_intel
 Checking test 017 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1031,14 +1135,14 @@ Checking test 017 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 544.514163
-  0: The maximum resident set size (KB)                   = 3241608
+  0: The total amount of wall time                        = 553.589214
+  0: The maximum resident set size (KB)                   = 3241612
 
 Test 017 cpld_debug_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_noaero_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_debug_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_debug_noaero_p8_intel
 Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1090,14 +1194,14 @@ Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 380.776922
-  0: The maximum resident set size (KB)                   = 1735168
+  0: The total amount of wall time                        = 455.461610
+  0: The maximum resident set size (KB)                   = 1735492
 
 Test 018 cpld_debug_noaero_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_agrid_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_noaero_p8_agrid_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_noaero_p8_agrid_intel
 Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1159,14 +1263,14 @@ Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 263.807376
-  0: The maximum resident set size (KB)                   = 1768448
+  0: The total amount of wall time                        = 263.543301
+  0: The maximum resident set size (KB)                   = 1773320
 
 Test 019 cpld_control_noaero_p8_agrid_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_c48_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_c48_intel
 Checking test 020 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1216,14 +1320,14 @@ Checking test 020 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 495.934573
- 0: The maximum resident set size (KB)                   = 2800916
+ 0: The total amount of wall time                        = 499.506510
+ 0: The maximum resident set size (KB)                   = 2813488
 
 Test 020 cpld_control_c48_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_warmstart_c48_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_warmstart_c48_intel
 Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1273,14 +1377,14 @@ Checking test 021 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 134.730235
- 0: The maximum resident set size (KB)                   = 2793128
+ 0: The total amount of wall time                        = 137.563956
+ 0: The maximum resident set size (KB)                   = 2794916
 
 Test 021 cpld_warmstart_c48_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_restart_c48_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_restart_c48_intel
 Checking test 022 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1330,14 +1434,14 @@ Checking test 022 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
- 0: The total amount of wall time                        = 70.305671
- 0: The maximum resident set size (KB)                   = 2237576
+ 0: The total amount of wall time                        = 75.498507
+ 0: The maximum resident set size (KB)                   = 2236500
 
 Test 022 cpld_restart_c48_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_p8_faster_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_p8_faster_intel
 Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1402,14 +1506,14 @@ Checking test 023 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 321.612683
-  0: The maximum resident set size (KB)                   = 3183448
+  0: The total amount of wall time                        = 319.513608
+  0: The maximum resident set size (KB)                   = 3171356
 
 Test 023 cpld_control_p8_faster_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_control_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_control_pdlib_p8_intel
 Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1473,14 +1577,14 @@ Checking test 024 cpld_control_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1188.699140
-  0: The maximum resident set size (KB)                   = 1760556
+  0: The total amount of wall time                        = 1190.301364
+  0: The maximum resident set size (KB)                   = 1761120
 
 Test 024 cpld_control_pdlib_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_restart_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_restart_pdlib_p8_intel
 Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1532,14 +1636,14 @@ Checking test 025 cpld_restart_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 584.599774
-  0: The maximum resident set size (KB)                   = 1030872
+  0: The total amount of wall time                        = 587.256549
+  0: The maximum resident set size (KB)                   = 1030224
 
 Test 025 cpld_restart_pdlib_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_control_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_mpi_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_mpi_pdlib_p8_intel
 Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1603,14 +1707,14 @@ Checking test 026 cpld_mpi_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1059.810327
-  0: The maximum resident set size (KB)                   = 1660840
+  0: The total amount of wall time                        = 1058.988676
+  0: The maximum resident set size (KB)                   = 1662148
 
 Test 026 cpld_mpi_pdlib_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_debug_pdlib_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/cpld_debug_pdlib_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/cpld_debug_pdlib_p8_intel
 Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1662,14 +1766,14 @@ Checking test 027 cpld_debug_pdlib_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1373.541918
-  0: The maximum resident set size (KB)                   = 1702388
+  0: The total amount of wall time                        = 1396.987748
+  0: The maximum resident set size (KB)                   = 1699896
 
 Test 027 cpld_debug_pdlib_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_flake_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_flake_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_flake_intel
 Checking test 028 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1680,14 +1784,14 @@ Checking test 028 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 193.066060
-  0: The maximum resident set size (KB)                   = 685892
+  0: The total amount of wall time                        = 195.196385
+  0: The maximum resident set size (KB)                   = 677124
 
 Test 028 control_flake_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_CubedSphereGrid_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_CubedSphereGrid_intel
 Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1714,28 +1818,28 @@ Checking test 029 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 131.878213
-  0: The maximum resident set size (KB)                   = 629972
+  0: The total amount of wall time                        = 131.088214
+  0: The maximum resident set size (KB)                   = 627008
 
 Test 029 control_CubedSphereGrid_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_parallel_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_CubedSphereGrid_parallel_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_CubedSphereGrid_parallel_intel
 Checking test 030 control_CubedSphereGrid_parallel_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 127.775022
-  0: The maximum resident set size (KB)                   = 629060
+  0: The total amount of wall time                        = 129.293805
+  0: The maximum resident set size (KB)                   = 629772
 
 Test 030 control_CubedSphereGrid_parallel_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_latlon_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_latlon_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_latlon_intel
 Checking test 031 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1746,32 +1850,32 @@ Checking test 031 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.234266
-  0: The maximum resident set size (KB)                   = 631004
+  0: The total amount of wall time                        = 133.610018
+  0: The maximum resident set size (KB)                   = 627316
 
 Test 031 control_latlon_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_wrtGauss_netcdf_parallel_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_wrtGauss_netcdf_parallel_intel
 Checking test 032 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf024.nc .........OK
+ Comparing atmf024.nc ............ALT CHECK......OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.415583
-  0: The maximum resident set size (KB)                   = 630800
+  0: The total amount of wall time                        = 136.819525
+  0: The maximum resident set size (KB)                   = 629308
 
 Test 032 control_wrtGauss_netcdf_parallel_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c48_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_c48_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_c48_intel
 Checking test 033 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1810,14 +1914,14 @@ Checking test 033 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 344.526382
-0: The maximum resident set size (KB)                   = 819600
+0: The total amount of wall time                        = 347.199973
+0: The maximum resident set size (KB)                   = 817308
 
 Test 033 control_c48_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c192_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_c192_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_c192_intel
 Checking test 034 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1828,14 +1932,14 @@ Checking test 034 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 525.943792
-  0: The maximum resident set size (KB)                   = 771084
+  0: The total amount of wall time                        = 524.624724
+  0: The maximum resident set size (KB)                   = 769256
 
 Test 034 control_c192_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c384_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_c384_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_c384_intel
 Checking test 035 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1846,14 +1950,14 @@ Checking test 035 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 573.378659
-  0: The maximum resident set size (KB)                   = 1235288
+  0: The total amount of wall time                        = 631.752145
+  0: The maximum resident set size (KB)                   = 1213168
 
 Test 035 control_c384_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_c384gdas_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_c384gdas_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_c384gdas_intel
 Checking test 036 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1896,14 +2000,14 @@ Checking test 036 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 507.660007
-  0: The maximum resident set size (KB)                   = 1344916
+  0: The total amount of wall time                        = 511.111515
+  0: The maximum resident set size (KB)                   = 1347296
 
 Test 036 control_c384gdas_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_stochy_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_stochy_intel
 Checking test 037 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1914,28 +2018,28 @@ Checking test 037 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 88.119385
-  0: The maximum resident set size (KB)                   = 633416
+  0: The total amount of wall time                        = 87.145395
+  0: The maximum resident set size (KB)                   = 634948
 
 Test 037 control_stochy_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_stochy_restart_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_stochy_restart_intel
 Checking test 038 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 47.798545
-  0: The maximum resident set size (KB)                   = 486412
+  0: The total amount of wall time                        = 48.013688
+  0: The maximum resident set size (KB)                   = 482384
 
 Test 038 control_stochy_restart_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_lndp_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_lndp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_lndp_intel
 Checking test 039 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1946,14 +2050,14 @@ Checking test 039 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 82.613693
-  0: The maximum resident set size (KB)                   = 636404
+  0: The total amount of wall time                        = 82.478639
+  0: The maximum resident set size (KB)                   = 634844
 
 Test 039 control_lndp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_iovr4_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_iovr4_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_iovr4_intel
 Checking test 040 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1968,14 +2072,14 @@ Checking test 040 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.218308
-  0: The maximum resident set size (KB)                   = 629916
+  0: The total amount of wall time                        = 134.226049
+  0: The maximum resident set size (KB)                   = 630248
 
 Test 040 control_iovr4_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_iovr5_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_iovr5_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_iovr5_intel
 Checking test 041 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1990,14 +2094,14 @@ Checking test 041 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 136.086041
-  0: The maximum resident set size (KB)                   = 630172
+  0: The total amount of wall time                        = 134.132697
+  0: The maximum resident set size (KB)                   = 632960
 
 Test 041 control_iovr5_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_p8_intel
 Checking test 042 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2044,14 +2148,14 @@ Checking test 042 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 167.973454
-  0: The maximum resident set size (KB)                   = 1613168
+  0: The total amount of wall time                        = 168.984367
+  0: The maximum resident set size (KB)                   = 1592020
 
 Test 042 control_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_restart_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_restart_p8_intel
 Checking test 043 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2090,14 +2194,14 @@ Checking test 043 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 87.903760
-  0: The maximum resident set size (KB)                   = 885552
+  0: The total amount of wall time                        = 88.592398
+  0: The maximum resident set size (KB)                   = 875764
 
 Test 043 control_restart_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_qr_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_qr_p8_intel
 Checking test 044 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2144,14 +2248,14 @@ Checking test 044 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 181.000766
-  0: The maximum resident set size (KB)                   = 1608580
+  0: The total amount of wall time                        = 173.055267
+  0: The maximum resident set size (KB)                   = 1607688
 
 Test 044 control_qr_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_restart_qr_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_restart_qr_p8_intel
 Checking test 045 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2190,14 +2294,14 @@ Checking test 045 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 89.118548
-  0: The maximum resident set size (KB)                   = 877632
+  0: The total amount of wall time                        = 91.435089
+  0: The maximum resident set size (KB)                   = 870152
 
 Test 045 control_restart_qr_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_decomp_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_decomp_p8_intel
 Checking test 046 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2240,14 +2344,14 @@ Checking test 046 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.907153
-  0: The maximum resident set size (KB)                   = 1593484
+  0: The total amount of wall time                        = 174.249904
+  0: The maximum resident set size (KB)                   = 1587584
 
 Test 046 control_decomp_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_2threads_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_2threads_p8_intel
 Checking test 047 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2290,14 +2394,14 @@ Checking test 047 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.134679
-  0: The maximum resident set size (KB)                   = 1696876
+  0: The total amount of wall time                        = 174.619612
+  0: The maximum resident set size (KB)                   = 1696672
 
 Test 047 control_2threads_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_lndp_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_p8_lndp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_p8_lndp_intel
 Checking test 048 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2316,14 +2420,14 @@ Checking test 048 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 311.072105
-  0: The maximum resident set size (KB)                   = 1609524
+  0: The total amount of wall time                        = 311.063343
+  0: The maximum resident set size (KB)                   = 1608700
 
 Test 048 control_p8_lndp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_rrtmgp_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_p8_rrtmgp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_p8_rrtmgp_intel
 Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2370,14 +2474,14 @@ Checking test 049 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 226.913233
-  0: The maximum resident set size (KB)                   = 1670160
+  0: The total amount of wall time                        = 226.780843
+  0: The maximum resident set size (KB)                   = 1667552
 
 Test 049 control_p8_rrtmgp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_mynn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_p8_mynn_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_p8_mynn_intel
 Checking test 050 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2424,14 +2528,14 @@ Checking test 050 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.253666
-  0: The maximum resident set size (KB)                   = 1611508
+  0: The total amount of wall time                        = 171.186865
+  0: The maximum resident set size (KB)                   = 1606816
 
 Test 050 control_p8_mynn_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/merra2_thompson_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/merra2_thompson_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/merra2_thompson_intel
 Checking test 051 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2478,14 +2582,14 @@ Checking test 051 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.225838
-  0: The maximum resident set size (KB)                   = 1615228
+  0: The total amount of wall time                        = 191.057167
+  0: The maximum resident set size (KB)                   = 1611272
 
 Test 051 merra2_thompson_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_control_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_control_intel
 Checking test 052 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2496,28 +2600,28 @@ Checking test 052 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 288.402429
-  0: The maximum resident set size (KB)                   = 866832
+  0: The total amount of wall time                        = 291.667114
+  0: The maximum resident set size (KB)                   = 867408
 
 Test 052 regional_control_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_restart_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_restart_intel
 Checking test 053 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 147.797671
-  0: The maximum resident set size (KB)                   = 863496
+  0: The total amount of wall time                        = 150.131822
+  0: The maximum resident set size (KB)                   = 866396
 
 Test 053 regional_restart_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_control_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_control_qr_intel
 Checking test 054 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2528,28 +2632,28 @@ Checking test 054 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 287.597176
-  0: The maximum resident set size (KB)                   = 869372
+  0: The total amount of wall time                        = 291.939696
+  0: The maximum resident set size (KB)                   = 871756
 
 Test 054 regional_control_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_restart_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_restart_qr_intel
 Checking test 055 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 148.561875
-  0: The maximum resident set size (KB)                   = 864376
+  0: The total amount of wall time                        = 149.635502
+  0: The maximum resident set size (KB)                   = 863892
 
 Test 055 regional_restart_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_decomp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_decomp_intel
 Checking test 056 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2560,14 +2664,14 @@ Checking test 056 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 306.694931
-  0: The maximum resident set size (KB)                   = 860832
+  0: The total amount of wall time                        = 312.929651
+  0: The maximum resident set size (KB)                   = 864316
 
 Test 056 regional_decomp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_2threads_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_2threads_intel
 Checking test 057 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2578,14 +2682,14 @@ Checking test 057 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 199.150024
-  0: The maximum resident set size (KB)                   = 852960
+  0: The total amount of wall time                        = 201.731092
+  0: The maximum resident set size (KB)                   = 849532
 
 Test 057 regional_2threads_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_noquilt_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_noquilt_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_noquilt_intel
 Checking test 058 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2593,28 +2697,28 @@ Checking test 058 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 286.833910
-  0: The maximum resident set size (KB)                   = 857220
+  0: The total amount of wall time                        = 289.358177
+  0: The maximum resident set size (KB)                   = 854404
 
 Test 058 regional_noquilt_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_netcdf_parallel_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_netcdf_parallel_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_netcdf_parallel_intel
 Checking test 059 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 285.492444
-  0: The maximum resident set size (KB)                   = 862748
+  0: The total amount of wall time                        = 289.291917
+  0: The maximum resident set size (KB)                   = 864732
 
 Test 059 regional_netcdf_parallel_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_2dwrtdecomp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_2dwrtdecomp_intel
 Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2625,14 +2729,14 @@ Checking test 060 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 288.616166
-  0: The maximum resident set size (KB)                   = 864084
+  0: The total amount of wall time                        = 289.574091
+  0: The maximum resident set size (KB)                   = 870976
 
 Test 060 regional_2dwrtdecomp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/fv3_regional_wofs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_wofs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_wofs_intel
 Checking test 061 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2643,14 +2747,14 @@ Checking test 061 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 368.494191
-  0: The maximum resident set size (KB)                   = 626940
+  0: The total amount of wall time                        = 369.228333
+  0: The maximum resident set size (KB)                   = 625832
 
 Test 061 regional_wofs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_control_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_control_intel
 Checking test 062 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2697,14 +2801,14 @@ Checking test 062 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 445.185713
-  0: The maximum resident set size (KB)                   = 1063688
+  0: The total amount of wall time                        = 447.115343
+  0: The maximum resident set size (KB)                   = 1062536
 
 Test 062 rap_control_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_spp_sppt_shum_skeb_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_spp_sppt_shum_skeb_intel
 Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2715,14 +2819,14 @@ Checking test 063 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 261.540705
-  0: The maximum resident set size (KB)                   = 1196232
+  0: The total amount of wall time                        = 265.359317
+  0: The maximum resident set size (KB)                   = 1199568
 
 Test 063 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_decomp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_decomp_intel
 Checking test 064 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2769,14 +2873,14 @@ Checking test 064 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 465.385322
-  0: The maximum resident set size (KB)                   = 1001660
+  0: The total amount of wall time                        = 467.869170
+  0: The maximum resident set size (KB)                   = 1010904
 
 Test 064 rap_decomp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_2threads_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_2threads_intel
 Checking test 065 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2823,14 +2927,14 @@ Checking test 065 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 451.869889
-  0: The maximum resident set size (KB)                   = 1136688
+  0: The total amount of wall time                        = 452.216250
+  0: The maximum resident set size (KB)                   = 1146960
 
 Test 065 rap_2threads_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_restart_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_restart_intel
 Checking test 066 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2869,14 +2973,14 @@ Checking test 066 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 225.860053
-  0: The maximum resident set size (KB)                   = 962548
+  0: The total amount of wall time                        = 228.136806
+  0: The maximum resident set size (KB)                   = 965936
 
 Test 066 rap_restart_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_sfcdiff_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_sfcdiff_intel
 Checking test 067 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2923,14 +3027,14 @@ Checking test 067 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 445.003611
-  0: The maximum resident set size (KB)                   = 1059612
+  0: The total amount of wall time                        = 446.149610
+  0: The maximum resident set size (KB)                   = 1067232
 
 Test 067 rap_sfcdiff_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_sfcdiff_decomp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_sfcdiff_decomp_intel
 Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2977,14 +3081,14 @@ Checking test 068 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 469.299646
-  0: The maximum resident set size (KB)                   = 997948
+  0: The total amount of wall time                        = 470.034739
+  0: The maximum resident set size (KB)                   = 997228
 
 Test 068 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_sfcdiff_restart_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_sfcdiff_restart_intel
 Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3023,14 +3127,14 @@ Checking test 069 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.548857
-  0: The maximum resident set size (KB)                   = 989296
+  0: The total amount of wall time                        = 331.590016
+  0: The maximum resident set size (KB)                   = 992172
 
 Test 069 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_intel
 Checking test 070 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3077,14 +3181,14 @@ Checking test 070 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 429.899940
-  0: The maximum resident set size (KB)                   = 1061220
+  0: The total amount of wall time                        = 430.596304
+  0: The maximum resident set size (KB)                   = 1056328
 
 Test 070 hrrr_control_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_qr_intel
 Checking test 071 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3131,14 +3235,14 @@ Checking test 071 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 426.768841
-  0: The maximum resident set size (KB)                   = 1061700
+  0: The total amount of wall time                        = 429.159255
+  0: The maximum resident set size (KB)                   = 1068508
 
 Test 071 hrrr_control_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_decomp_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_decomp_intel
 Checking test 072 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3185,14 +3289,14 @@ Checking test 072 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 446.440263
-  0: The maximum resident set size (KB)                   = 1005840
+  0: The total amount of wall time                        = 448.958621
+  0: The maximum resident set size (KB)                   = 997220
 
 Test 072 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_2threads_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_2threads_intel
 Checking test 073 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3239,42 +3343,42 @@ Checking test 073 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 360.583376
-  0: The maximum resident set size (KB)                   = 1074464
+  0: The total amount of wall time                        = 365.321302
+  0: The maximum resident set size (KB)                   = 1079380
 
 Test 073 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_restart_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_restart_intel
 Checking test 074 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 322.034573
-  0: The maximum resident set size (KB)                   = 976784
+  0: The total amount of wall time                        = 325.175718
+  0: The maximum resident set size (KB)                   = 957572
 
 Test 074 hrrr_control_restart_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_restart_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_restart_qr_intel
 Checking test 075 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 322.308504
-  0: The maximum resident set size (KB)                   = 1000628
+  0: The total amount of wall time                        = 323.871897
+  0: The maximum resident set size (KB)                   = 991080
 
 Test 075 hrrr_control_restart_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_v1beta_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_v1beta_intel
 Checking test 076 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3321,14 +3425,14 @@ Checking test 076 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 437.709528
-  0: The maximum resident set size (KB)                   = 1055124
+  0: The total amount of wall time                        = 437.327290
+  0: The maximum resident set size (KB)                   = 1057052
 
 Test 076 rrfs_v1beta_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_v1nssl_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_v1nssl_intel
 Checking test 077 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3343,14 +3447,14 @@ Checking test 077 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 523.357637
-  0: The maximum resident set size (KB)                   = 688488
+  0: The total amount of wall time                        = 524.576507
+  0: The maximum resident set size (KB)                   = 693668
 
 Test 077 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_v1nssl_nohailnoccn_intel
 Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3365,14 +3469,14 @@ Checking test 078 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 513.222732
-  0: The maximum resident set size (KB)                   = 755120
+  0: The total amount of wall time                        = 513.981706
+  0: The maximum resident set size (KB)                   = 760424
 
 Test 078 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3388,14 +3492,14 @@ Checking test 079 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 149.437379
-  0: The maximum resident set size (KB)                   = 1035196
+  0: The total amount of wall time                        = 147.726833
+  0: The maximum resident set size (KB)                   = 1035092
 
 Test 079 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
 Checking test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3404,14 +3508,14 @@ Checking test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 99.989065
-  0: The maximum resident set size (KB)                   = 942648
+  0: The total amount of wall time                        = 98.278767
+  0: The maximum resident set size (KB)                   = 944164
 
 Test 080 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_conus13km_hrrr_warm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_conus13km_hrrr_warm_intel
 Checking test 081 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3427,14 +3531,14 @@ Checking test 081 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 134.222191
-  0: The maximum resident set size (KB)                   = 989856
+  0: The total amount of wall time                        = 131.876955
+  0: The maximum resident set size (KB)                   = 996960
 
 Test 081 rrfs_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_smoke_conus13km_radar_tten_warm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_smoke_conus13km_radar_tten_warm_intel
 Checking test 082 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3443,26 +3547,26 @@ Checking test 082 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 151.963147
-  0: The maximum resident set size (KB)                   = 1031360
+  0: The total amount of wall time                        = 149.990752
+  0: The maximum resident set size (KB)                   = 1034832
 
 Test 082 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
 Checking test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 82.518328
-  0: The maximum resident set size (KB)                   = 1023924
+  0: The total amount of wall time                        = 84.613066
+  0: The maximum resident set size (KB)                   = 1031332
 
 Test 083 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmg_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_csawmg_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_csawmg_intel
 Checking test 084 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3473,14 +3577,14 @@ Checking test 084 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 337.130114
-  0: The maximum resident set size (KB)                   = 726668
+  0: The total amount of wall time                        = 336.354362
+  0: The maximum resident set size (KB)                   = 723228
 
 Test 084 control_csawmg_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_csawmgt_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_csawmgt_intel
 Checking test 085 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3491,14 +3595,14 @@ Checking test 085 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 330.368306
-  0: The maximum resident set size (KB)                   = 731236
+  0: The total amount of wall time                        = 330.052891
+  0: The maximum resident set size (KB)                   = 716168
 
 Test 085 control_csawmgt_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_ras_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_ras_intel
 Checking test 086 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3509,26 +3613,26 @@ Checking test 086 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 180.852724
-  0: The maximum resident set size (KB)                   = 726068
+  0: The total amount of wall time                        = 181.796153
+  0: The maximum resident set size (KB)                   = 728588
 
 Test 086 control_ras_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_wam_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_wam_intel
 Checking test 087 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 112.539095
-  0: The maximum resident set size (KB)                   = 640660
+  0: The total amount of wall time                        = 111.156116
+  0: The maximum resident set size (KB)                   = 640404
 
 Test 087 control_wam_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_p8_faster_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_p8_faster_intel
 Checking test 088 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3575,14 +3679,14 @@ Checking test 088 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.950539
-  0: The maximum resident set size (KB)                   = 1602648
+  0: The total amount of wall time                        = 154.391346
+  0: The maximum resident set size (KB)                   = 1613972
 
 Test 088 control_p8_faster_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_control_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_control_faster_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_control_faster_intel
 Checking test 089 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3593,56 +3697,56 @@ Checking test 089 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 265.288012
-  0: The maximum resident set size (KB)                   = 871004
+  0: The total amount of wall time                        = 263.093362
+  0: The maximum resident set size (KB)                   = 863272
 
 Test 089 regional_control_faster_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_smoke_conus13km_hrrr_warm_debug_intel
 Checking test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 836.622978
-  0: The maximum resident set size (KB)                   = 1062808
+  0: The total amount of wall time                        = 1483.619984
+  0: The maximum resident set size (KB)                   = 1062124
 
 Test 090 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
 Checking test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 476.679393
-  0: The maximum resident set size (KB)                   = 974036
+  0: The total amount of wall time                        = 496.078173
+  0: The maximum resident set size (KB)                   = 980016
 
 Test 091 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_conus13km_hrrr_warm_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_conus13km_hrrr_warm_debug_intel
 Checking test 092 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 759.546605
-  0: The maximum resident set size (KB)                   = 1019584
+  0: The total amount of wall time                        = 757.466035
+  0: The maximum resident set size (KB)                   = 1021556
 
 Test 092 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_CubedSphereGrid_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_CubedSphereGrid_debug_intel
 Checking test 093 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3669,347 +3773,366 @@ Checking test 093 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 154.148507
-  0: The maximum resident set size (KB)                   = 794092
+  0: The total amount of wall time                        = 148.094708
+  0: The maximum resident set size (KB)                   = 795036
 
 Test 093 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 094 control_wrtGauss_netcdf_parallel_debug_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.619730
-  0: The maximum resident set size (KB)                   = 795488
+  0: The total amount of wall time                        = 150.718397
+  0: The maximum resident set size (KB)                   = 796580
 
 Test 094 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_stochy_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_stochy_debug_intel
 Checking test 095 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.453920
-  0: The maximum resident set size (KB)                   = 805536
+  0: The total amount of wall time                        = 175.424991
+  0: The maximum resident set size (KB)                   = 797692
 
 Test 095 control_stochy_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_lndp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_lndp_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_lndp_debug_intel
 Checking test 096 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.077306
-  0: The maximum resident set size (KB)                   = 798332
+  0: The total amount of wall time                        = 154.181783
+  0: The maximum resident set size (KB)                   = 798756
 
 Test 096 control_lndp_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmg_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_csawmg_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_csawmg_debug_intel
 Checking test 097 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.422980
-  0: The maximum resident set size (KB)                   = 844288
+  0: The total amount of wall time                        = 233.072014
+  0: The maximum resident set size (KB)                   = 846916
 
 Test 097 control_csawmg_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_csawmgt_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_csawmgt_debug_intel
 Checking test 098 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 226.605415
-  0: The maximum resident set size (KB)                   = 845416
+  0: The total amount of wall time                        = 233.507454
+  0: The maximum resident set size (KB)                   = 844508
 
 Test 098 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_ras_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_ras_debug_intel
 Checking test 099 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 153.813034
-  0: The maximum resident set size (KB)                   = 805860
+  0: The total amount of wall time                        = 155.585313
+  0: The maximum resident set size (KB)                   = 805704
 
 Test 099 control_ras_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_diag_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_diag_debug_intel
 Checking test 100 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.086453
-  0: The maximum resident set size (KB)                   = 850864
+  0: The total amount of wall time                        = 156.872921
+  0: The maximum resident set size (KB)                   = 848852
 
 Test 100 control_diag_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_debug_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_debug_p8_intel
 Checking test 101 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.435263
-  0: The maximum resident set size (KB)                   = 1627820
+  0: The total amount of wall time                        = 174.986037
+  0: The maximum resident set size (KB)                   = 1631780
 
 Test 101 control_debug_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_debug_intel
 Checking test 102 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1010.498003
-  0: The maximum resident set size (KB)                   = 881700
+  0: The total amount of wall time                        = 1017.055662
+  0: The maximum resident set size (KB)                   = 889428
 
 Test 102 regional_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_control_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_control_debug_intel
 Checking test 103 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.846174
-  0: The maximum resident set size (KB)                   = 1177616
+  0: The total amount of wall time                        = 272.017147
+  0: The maximum resident set size (KB)                   = 1171920
 
 Test 103 rap_control_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_debug_intel
 Checking test 104 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.780798
-  0: The maximum resident set size (KB)                   = 1169024
+  0: The total amount of wall time                        = 269.297788
+  0: The maximum resident set size (KB)                   = 1174880
 
 Test 104 hrrr_control_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_unified_drag_suite_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_unified_drag_suite_debug_intel
 Checking test 105 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.229389
-  0: The maximum resident set size (KB)                   = 1169960
+  0: The total amount of wall time                        = 274.169458
+  0: The maximum resident set size (KB)                   = 1174376
 
 Test 105 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_diag_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_diag_debug_intel
 Checking test 106 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.182736
-  0: The maximum resident set size (KB)                   = 1258924
+  0: The total amount of wall time                        = 293.596802
+  0: The maximum resident set size (KB)                   = 1249852
 
 Test 106 rap_diag_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_cires_ugwp_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_cires_ugwp_debug_intel
 Checking test 107 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.999158
-  0: The maximum resident set size (KB)                   = 1168528
+  0: The total amount of wall time                        = 287.539605
+  0: The maximum resident set size (KB)                   = 1180276
 
 Test 107 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_unified_ugwp_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_unified_ugwp_debug_intel
 Checking test 108 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.850158
-  0: The maximum resident set size (KB)                   = 1177180
+  0: The total amount of wall time                        = 284.795557
+  0: The maximum resident set size (KB)                   = 1174664
 
 Test 108 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_lndp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_lndp_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_lndp_debug_intel
 Checking test 109 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.694241
-  0: The maximum resident set size (KB)                   = 1180572
+  0: The total amount of wall time                        = 283.226994
+  0: The maximum resident set size (KB)                   = 1180856
 
 Test 109 rap_lndp_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_progcld_thompson_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_progcld_thompson_debug_intel
 Checking test 110 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.568271
-  0: The maximum resident set size (KB)                   = 1170340
+  0: The total amount of wall time                        = 279.585379
+  0: The maximum resident set size (KB)                   = 1178412
 
 Test 110 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_noah_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_noah_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_noah_debug_intel
 Checking test 111 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.816814
-  0: The maximum resident set size (KB)                   = 1174532
+  0: The total amount of wall time                        = 276.183020
+  0: The maximum resident set size (KB)                   = 1173024
 
 Test 111 rap_noah_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_sfcdiff_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_sfcdiff_debug_intel
 Checking test 112 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.260100
-  0: The maximum resident set size (KB)                   = 1179676
+  0: The total amount of wall time                        = 283.737140
+  0: The maximum resident set size (KB)                   = 1179220
 
 Test 112 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 457.410154
-  0: The maximum resident set size (KB)                   = 1174620
+  0: The total amount of wall time                        = 448.640720
+  0: The maximum resident set size (KB)                   = 1170592
 
 Test 113 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rrfs_v1beta_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rrfs_v1beta_debug_intel
 Checking test 114 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.419479
-  0: The maximum resident set size (KB)                   = 1169648
+  0: The total amount of wall time                        = 274.963653
+  0: The maximum resident set size (KB)                   = 1174104
 
 Test 114 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_clm_lake_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_clm_lake_debug_intel
 Checking test 115 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 335.601880
-  0: The maximum resident set size (KB)                   = 1172840
+  0: The total amount of wall time                        = 351.909990
+  0: The maximum resident set size (KB)                   = 1173588
 
 Test 115 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_flake_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_flake_debug_intel
 Checking test 116 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.695703
-  0: The maximum resident set size (KB)                   = 1169300
+  0: The total amount of wall time                        = 284.933674
+  0: The maximum resident set size (KB)                   = 1133232
 
 Test 116 rap_flake_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_wam_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_wam_debug_intel
 Checking test 117 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
- Comparing atmf019.nc ............ALT CHECK......ERROR
+ Comparing atmf019.nc .........OK
+
+  0: The total amount of wall time                        = 283.425525
+  0: The maximum resident set size (KB)                   = 517748
+
+Test 117 control_wam_debug_intel PASS
+
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
- Comparing dynf000.nc ............ALT CHECK......ERROR
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
+ Comparing PRSLEV.GrbF00 .........OK
+ Comparing PRSLEV.GrbF01 .........OK
+ Comparing NATLEV.GrbF00 .........OK
+ Comparing NATLEV.GrbF01 .........OK
+
+  0: The total amount of wall time                        = 246.722399
+  0: The maximum resident set size (KB)                   = 1082212
+
+Test 118 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
+
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_control_dyn32_phy32_intel
 Checking test 119 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4056,14 +4179,14 @@ Checking test 119 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 370.751344
-  0: The maximum resident set size (KB)                   = 1003800
+  0: The total amount of wall time                        = 367.657171
+  0: The maximum resident set size (KB)                   = 1000612
 
 Test 119 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_dyn32_phy32_intel
 Checking test 120 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4074,50 +4197,50 @@ Checking test 120 hrrr_control_dyn32_phy32_intel results ....
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........NOT OK
- Comparing GFSPRS.GrbF09 ............MISSING baseline
- Comparing GFSPRS.GrbF12 ............MISSING baseline
- Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 190.185590
-  0: The maximum resident set size (KB)                   = 952432
+  0: The total amount of wall time                        = 189.800893
+  0: The maximum resident set size (KB)                   = 959204
 
-Test 120 hrrr_control_dyn32_phy32_intel FAIL Tries: 2
+Test 120 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_qr_dyn32_phy32_intel
 Checking test 121 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4164,14 +4287,14 @@ Checking test 121 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.577961
-  0: The maximum resident set size (KB)                   = 967812
+  0: The total amount of wall time                        = 190.555987
+  0: The maximum resident set size (KB)                   = 967220
 
 Test 121 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_2threads_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_2threads_dyn32_phy32_intel
 Checking test 122 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4218,14 +4341,14 @@ Checking test 122 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 381.237764
-  0: The maximum resident set size (KB)                   = 1023412
+  0: The total amount of wall time                        = 377.109832
+  0: The maximum resident set size (KB)                   = 1023752
 
 Test 122 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 123 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4236,50 +4359,50 @@ Checking test 123 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........NOT OK
- Comparing GFSPRS.GrbF09 ............MISSING baseline
- Comparing GFSPRS.GrbF12 ............MISSING baseline
- Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 163.198737
-  0: The maximum resident set size (KB)                   = 938016
+  0: The total amount of wall time                        = 163.112288
+  0: The maximum resident set size (KB)                   = 934604
 
-Test 123 hrrr_control_2threads_dyn32_phy32_intel FAIL Tries: 2
+Test 123 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 124 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4290,50 +4413,50 @@ Checking test 124 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........NOT OK
- Comparing GFSPRS.GrbF09 ............MISSING baseline
- Comparing GFSPRS.GrbF12 ............MISSING baseline
- Comparing RESTART/20210322.120000.coupler.res ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.phy_data.tile6.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............MISSING baseline
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............MISSING baseline
+ Comparing GFSPRS.GrbF00 .........OK
+ Comparing GFSPRS.GrbF09 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+ Comparing RESTART/20210322.120000.coupler.res .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
+ Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.300733
-  0: The maximum resident set size (KB)                   = 903660
+  0: The total amount of wall time                        = 199.983170
+  0: The maximum resident set size (KB)                   = 907064
 
-Test 124 hrrr_control_decomp_dyn32_phy32_intel FAIL Tries: 2
+Test 124 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_restart_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_restart_dyn32_phy32_intel
 Checking test 125 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4372,28 +4495,42 @@ Checking test 125 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 274.015871
-  0: The maximum resident set size (KB)                   = 944860
+  0: The total amount of wall time                        = 273.618204
+  0: The maximum resident set size (KB)                   = 952296
 
 Test 125 rap_restart_dyn32_phy32_intel PASS
 
 
+baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_restart_dyn32_phy32_intel
+Checking test 126 hrrr_control_restart_dyn32_phy32_intel results ....
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
+ Comparing GFSFLX.GrbF12 .........OK
+ Comparing GFSPRS.GrbF12 .........OK
+
+  0: The total amount of wall time                        = 98.570362
+  0: The maximum resident set size (KB)                   = 867232
+
+Test 126 hrrr_control_restart_dyn32_phy32_intel PASS
+
+
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_restart_qr_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_restart_qr_dyn32_phy32_intel
 Checking test 127 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.770500
-  0: The maximum resident set size (KB)                   = 875320
+  0: The total amount of wall time                        = 101.250479
+  0: The maximum resident set size (KB)                   = 876404
 
 Test 127 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_control_dyn64_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_control_dyn64_phy32_intel
 Checking test 128 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4440,81 +4577,81 @@ Checking test 128 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.830438
-  0: The maximum resident set size (KB)                   = 966996
+  0: The total amount of wall time                        = 235.782914
+  0: The maximum resident set size (KB)                   = 965768
 
 Test 128 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_control_debug_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_control_debug_dyn32_phy32_intel
 Checking test 129 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.608554
-  0: The maximum resident set size (KB)                   = 1055548
+  0: The total amount of wall time                        = 275.269704
+  0: The maximum resident set size (KB)                   = 1059224
 
 Test 129 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hrrr_control_debug_dyn32_phy32_intel
 Checking test 130 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.457107
-  0: The maximum resident set size (KB)                   = 1055576
+  0: The total amount of wall time                        = 265.480895
+  0: The maximum resident set size (KB)                   = 1059024
 
 Test 130 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/rap_control_dyn64_phy32_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/rap_control_dyn64_phy32_debug_intel
 Checking test 131 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.062087
-  0: The maximum resident set size (KB)                   = 1093272
+  0: The total amount of wall time                        = 278.682496
+  0: The maximum resident set size (KB)                   = 1099648
 
 Test 131 rap_control_dyn64_phy32_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_atm_intel
 Checking test 132 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 253.997397
-  0: The maximum resident set size (KB)                   = 1050072
+  0: The total amount of wall time                        = 247.997577
+  0: The maximum resident set size (KB)                   = 1054488
 
 Test 132 hafs_regional_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 133 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 395.025147
-  0: The maximum resident set size (KB)                   = 1419312
+  0: The total amount of wall time                        = 382.027358
+  0: The maximum resident set size (KB)                   = 1423724
 
 Test 133 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_atm_ocn_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_atm_ocn_intel
 Checking test 134 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4523,14 +4660,14 @@ Checking test 134 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 376.467481
-  0: The maximum resident set size (KB)                   = 1230116
+  0: The total amount of wall time                        = 376.006442
+  0: The maximum resident set size (KB)                   = 1229284
 
 Test 134 hafs_regional_atm_ocn_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_wav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_atm_wav_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_atm_wav_intel
 Checking test 135 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4539,14 +4676,14 @@ Checking test 135 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 738.276964
-  0: The maximum resident set size (KB)                   = 1254912
+  0: The total amount of wall time                        = 752.425263
+  0: The maximum resident set size (KB)                   = 1260384
 
 Test 135 hafs_regional_atm_wav_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_wav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_atm_ocn_wav_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_atm_ocn_wav_intel
 Checking test 136 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4557,14 +4694,14 @@ Checking test 136 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 853.423786
-  0: The maximum resident set size (KB)                   = 1273092
+  0: The total amount of wall time                        = 834.096754
+  0: The maximum resident set size (KB)                   = 1277052
 
 Test 136 hafs_regional_atm_ocn_wav_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_1nest_atm_intel
 Checking test 137 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4586,14 +4723,14 @@ Checking test 137 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 338.824410
-  0: The maximum resident set size (KB)                   = 505608
+  0: The total amount of wall time                        = 340.888140
+  0: The maximum resident set size (KB)                   = 486160
 
 Test 137 hafs_regional_1nest_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_1nest_atm_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_1nest_atm_qr_intel
 Checking test 138 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4615,14 +4752,14 @@ Checking test 138 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 348.919691
-  0: The maximum resident set size (KB)                   = 479336
+  0: The total amount of wall time                        = 344.481896
+  0: The maximum resident set size (KB)                   = 476576
 
 Test 138 hafs_regional_1nest_atm_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_telescopic_2nests_atm_intel
 Checking test 139 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4631,14 +4768,14 @@ Checking test 139 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 388.977104
-  0: The maximum resident set size (KB)                   = 510108
+  0: The total amount of wall time                        = 386.974320
+  0: The maximum resident set size (KB)                   = 480188
 
 Test 139 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_global_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_global_1nest_atm_intel
 Checking test 140 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4685,14 +4822,14 @@ Checking test 140 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 164.091890
-  0: The maximum resident set size (KB)                   = 355128
+  0: The total amount of wall time                        = 164.265995
+  0: The maximum resident set size (KB)                   = 352984
 
 Test 140 hafs_global_1nest_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_global_1nest_atm_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_global_1nest_atm_qr_intel
 Checking test 141 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4739,14 +4876,14 @@ Checking test 141 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 169.845918
-  0: The maximum resident set size (KB)                   = 355816
+  0: The total amount of wall time                        = 166.341431
+  0: The maximum resident set size (KB)                   = 355208
 
 Test 141 hafs_global_1nest_atm_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_global_multiple_4nests_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_global_multiple_4nests_atm_intel
 Checking test 142 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4828,14 +4965,14 @@ Checking test 142 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 435.634977
-  0: The maximum resident set size (KB)                   = 430832
+  0: The total amount of wall time                        = 436.309972
+  0: The maximum resident set size (KB)                   = 429464
 
 Test 142 hafs_global_multiple_4nests_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_global_multiple_4nests_atm_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_global_multiple_4nests_atm_qr_intel
 Checking test 143 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4917,14 +5054,14 @@ Checking test 143 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-  0: The total amount of wall time                        = 451.921138
-  0: The maximum resident set size (KB)                   = 448840
+  0: The total amount of wall time                        = 448.726303
+  0: The maximum resident set size (KB)                   = 446580
 
 Test 143 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_specified_moving_1nest_atm_intel
 Checking test 144 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4933,14 +5070,14 @@ Checking test 144 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 218.324509
-  0: The maximum resident set size (KB)                   = 519820
+  0: The total amount of wall time                        = 217.136379
+  0: The maximum resident set size (KB)                   = 514452
 
 Test 144 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_storm_following_1nest_atm_intel
 Checking test 145 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4962,14 +5099,14 @@ Checking test 145 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 204.209730
-  0: The maximum resident set size (KB)                   = 517724
+  0: The total amount of wall time                        = 205.780262
+  0: The maximum resident set size (KB)                   = 521108
 
 Test 145 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_storm_following_1nest_atm_qr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_storm_following_1nest_atm_qr_intel
 Checking test 146 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4991,14 +5128,14 @@ Checking test 146 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-  0: The total amount of wall time                        = 215.597563
-  0: The maximum resident set size (KB)                   = 509236
+  0: The total amount of wall time                        = 214.797927
+  0: The maximum resident set size (KB)                   = 504532
 
 Test 146 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_storm_following_1nest_atm_ocn_intel
 Checking test 147 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5007,42 +5144,42 @@ Checking test 147 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 285.657313
-  0: The maximum resident set size (KB)                   = 570824
+  0: The total amount of wall time                        = 285.397256
+  0: The maximum resident set size (KB)                   = 566180
 
 Test 147 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_global_storm_following_1nest_atm_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_global_storm_following_1nest_atm_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_global_storm_following_1nest_atm_intel
 Checking test 148 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 66.474274
-  0: The maximum resident set size (KB)                   = 374948
+  0: The total amount of wall time                        = 68.397108
+  0: The maximum resident set size (KB)                   = 368092
 
 Test 148 hafs_global_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
 Checking test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 745.438747
-  0: The maximum resident set size (KB)                   = 583788
+  0: The total amount of wall time                        = 751.812127
+  0: The maximum resident set size (KB)                   = 584968
 
 Test 149 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
 Checking test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5053,14 +5190,14 @@ Checking test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 535.981353
-  0: The maximum resident set size (KB)                   = 620112
+  0: The total amount of wall time                        = 538.312363
+  0: The maximum resident set size (KB)                   = 621076
 
 Test 150 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_docn_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_docn_intel
 Checking test 151 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5068,14 +5205,14 @@ Checking test 151 hafs_regional_docn_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 351.028435
-  0: The maximum resident set size (KB)                   = 1237904
+  0: The total amount of wall time                        = 338.039003
+  0: The maximum resident set size (KB)                   = 1228296
 
 Test 151 hafs_regional_docn_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_docn_oisst_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_docn_oisst_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_docn_oisst_intel
 Checking test 152 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5083,131 +5220,131 @@ Checking test 152 hafs_regional_docn_oisst_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 341.489495
-  0: The maximum resident set size (KB)                   = 1224428
+  0: The total amount of wall time                        = 341.048326
+  0: The maximum resident set size (KB)                   = 1224284
 
 Test 152 hafs_regional_docn_oisst_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hafs_regional_datm_cdeps_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/hafs_regional_datm_cdeps_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/hafs_regional_datm_cdeps_intel
 Checking test 153 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 930.755781
-  0: The maximum resident set size (KB)                   = 1038908
+  0: The total amount of wall time                        = 940.752793
+  0: The maximum resident set size (KB)                   = 1039348
 
 Test 153 hafs_regional_datm_cdeps_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_control_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_control_cfsr_intel
 Checking test 154 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.389965
- 0: The maximum resident set size (KB)                   = 1066676
+ 0: The total amount of wall time                        = 144.236159
+ 0: The maximum resident set size (KB)                   = 1060716
 
 Test 154 datm_cdeps_control_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_restart_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_restart_cfsr_intel
 Checking test 155 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 89.788165
- 0: The maximum resident set size (KB)                   = 1021816
+ 0: The total amount of wall time                        = 89.317681
+ 0: The maximum resident set size (KB)                   = 1024420
 
 Test 155 datm_cdeps_restart_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_control_gefs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_control_gefs_intel
 Checking test 156 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.210448
- 0: The maximum resident set size (KB)                   = 971536
+ 0: The total amount of wall time                        = 141.953928
+ 0: The maximum resident set size (KB)                   = 974976
 
 Test 156 datm_cdeps_control_gefs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_iau_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_iau_gefs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_iau_gefs_intel
 Checking test 157 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 143.940343
- 0: The maximum resident set size (KB)                   = 962860
+ 0: The total amount of wall time                        = 142.501449
+ 0: The maximum resident set size (KB)                   = 968216
 
 Test 157 datm_cdeps_iau_gefs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_stochy_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_stochy_gefs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_stochy_gefs_intel
 Checking test 158 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.329302
- 0: The maximum resident set size (KB)                   = 967932
+ 0: The total amount of wall time                        = 141.235393
+ 0: The maximum resident set size (KB)                   = 976444
 
 Test 158 datm_cdeps_stochy_gefs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_ciceC_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_ciceC_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_ciceC_cfsr_intel
 Checking test 159 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 147.340409
- 0: The maximum resident set size (KB)                   = 1069584
+ 0: The total amount of wall time                        = 144.033446
+ 0: The maximum resident set size (KB)                   = 1047724
 
 Test 159 datm_cdeps_ciceC_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_bulk_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_bulk_cfsr_intel
 Checking test 160 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.309784
- 0: The maximum resident set size (KB)                   = 1066708
+ 0: The total amount of wall time                        = 143.069750
+ 0: The maximum resident set size (KB)                   = 1060552
 
 Test 160 datm_cdeps_bulk_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_bulk_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_bulk_gefs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_bulk_gefs_intel
 Checking test 161 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.871142
- 0: The maximum resident set size (KB)                   = 973976
+ 0: The total amount of wall time                        = 140.849948
+ 0: The maximum resident set size (KB)                   = 974796
 
 Test 161 datm_cdeps_bulk_gefs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_mx025_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_mx025_cfsr_intel
 Checking test 162 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -5216,14 +5353,14 @@ Checking test 162 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 432.144428
-  0: The maximum resident set size (KB)                   = 872168
+  0: The total amount of wall time                        = 443.249958
+  0: The maximum resident set size (KB)                   = 870984
 
 Test 162 datm_cdeps_mx025_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_mx025_gefs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_mx025_gefs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_mx025_gefs_intel
 Checking test 163 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -5232,77 +5369,77 @@ Checking test 163 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 430.852728
-  0: The maximum resident set size (KB)                   = 924652
+  0: The total amount of wall time                        = 445.120165
+  0: The maximum resident set size (KB)                   = 936468
 
 Test 163 datm_cdeps_mx025_gefs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_multiple_files_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_multiple_files_cfsr_intel
 Checking test 164 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.140057
- 0: The maximum resident set size (KB)                   = 1061648
+ 0: The total amount of wall time                        = 142.185130
+ 0: The maximum resident set size (KB)                   = 1076460
 
 Test 164 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_3072x1536_cfsr_intel
 Checking test 165 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.863743
- 0: The maximum resident set size (KB)                   = 2368480
+ 0: The total amount of wall time                        = 192.972448
+ 0: The maximum resident set size (KB)                   = 2360120
 
 Test 165 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_gfs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_gfs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_gfs_intel
 Checking test 166 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 192.996628
- 0: The maximum resident set size (KB)                   = 2366156
+ 0: The total amount of wall time                        = 193.609448
+ 0: The maximum resident set size (KB)                   = 2362260
 
 Test 166 datm_cdeps_gfs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_debug_cfsr_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_debug_cfsr_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_debug_cfsr_intel
 Checking test 167 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 350.890931
- 0: The maximum resident set size (KB)                   = 988976
+ 0: The total amount of wall time                        = 345.005014
+ 0: The maximum resident set size (KB)                   = 986708
 
 Test 167 datm_cdeps_debug_cfsr_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_control_cfsr_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_control_cfsr_faster_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_control_cfsr_faster_intel
 Checking test 168 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 145.452795
- 0: The maximum resident set size (KB)                   = 1070288
+ 0: The total amount of wall time                        = 148.324324
+ 0: The maximum resident set size (KB)                   = 1050868
 
 Test 168 datm_cdeps_control_cfsr_faster_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_lnd_gswp3_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_lnd_gswp3_intel
 Checking test 169 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5311,14 +5448,14 @@ Checking test 169 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 6.891969
-  0: The maximum resident set size (KB)                   = 258136
+  0: The total amount of wall time                        = 6.798869
+  0: The maximum resident set size (KB)                   = 267432
 
 Test 169 datm_cdeps_lnd_gswp3_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/datm_cdeps_lnd_gswp3_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/datm_cdeps_lnd_gswp3_rst_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/datm_cdeps_lnd_gswp3_rst_intel
 Checking test 170 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5327,14 +5464,14 @@ Checking test 170 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 12.483342
-  0: The maximum resident set size (KB)                   = 265348
+  0: The total amount of wall time                        = 12.948113
+  0: The maximum resident set size (KB)                   = 243736
 
 Test 170 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_p8_atmlnd_sbs_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_p8_atmlnd_sbs_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_p8_atmlnd_sbs_intel
 Checking test 171 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -5419,14 +5556,14 @@ Checking test 171 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 201.184313
-  0: The maximum resident set size (KB)                   = 1615400
+  0: The total amount of wall time                        = 201.217906
+  0: The maximum resident set size (KB)                   = 1620052
 
 Test 171 control_p8_atmlnd_sbs_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmwav_control_noaero_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/atmwav_control_noaero_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/atmwav_control_noaero_p8_intel
 Checking test 172 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5469,14 +5606,14 @@ Checking test 172 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 93.218482
-  0: The maximum resident set size (KB)                   = 1643108
+  0: The total amount of wall time                        = 93.210714
+  0: The maximum resident set size (KB)                   = 1645876
 
 Test 172 atmwav_control_noaero_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_atmwav_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/control_atmwav_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/control_atmwav_intel
 Checking test 173 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5520,14 +5657,14 @@ Checking test 173 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 87.416925
-  0: The maximum resident set size (KB)                   = 658284
+  0: The total amount of wall time                        = 86.153447
+  0: The maximum resident set size (KB)                   = 664496
 
 Test 173 control_atmwav_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/atmaero_control_p8_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/atmaero_control_p8_intel
 Checking test 174 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5571,14 +5708,14 @@ Checking test 174 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 226.618749
-  0: The maximum resident set size (KB)                   = 2978740
+  0: The total amount of wall time                        = 226.457187
+  0: The maximum resident set size (KB)                   = 2983028
 
 Test 174 atmaero_control_p8_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/atmaero_control_p8_rad_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/atmaero_control_p8_rad_intel
 Checking test 175 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5622,14 +5759,14 @@ Checking test 175 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 279.297282
-  0: The maximum resident set size (KB)                   = 3055392
+  0: The total amount of wall time                        = 283.083438
+  0: The maximum resident set size (KB)                   = 3046288
 
 Test 175 atmaero_control_p8_rad_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_micro_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/atmaero_control_p8_rad_micro_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/atmaero_control_p8_rad_micro_intel
 Checking test 176 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5673,14 +5810,14 @@ Checking test 176 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 281.395301
-  0: The maximum resident set size (KB)                   = 3044784
+  0: The total amount of wall time                        = 284.091737
+  0: The maximum resident set size (KB)                   = 3060076
 
 Test 176 atmaero_control_p8_rad_micro_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_atmaq_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_atmaq_intel
 Checking test 177 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5696,14 +5833,14 @@ Checking test 177 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 632.431479
-  0: The maximum resident set size (KB)                   = 1485484
+  0: The total amount of wall time                        = 622.164655
+  0: The maximum resident set size (KB)                   = 1476576
 
 Test 177 regional_atmaq_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_atmaq_debug_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_atmaq_debug_intel
 Checking test 178 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5717,14 +5854,14 @@ Checking test 178 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 1196.022086
-  0: The maximum resident set size (KB)                   = 1404288
+  0: The total amount of wall time                        = 1206.232923
+  0: The maximum resident set size (KB)                   = 1408028
 
 Test 178 regional_atmaq_debug_intel PASS
 
 
 baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_faster_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_260641/regional_atmaq_faster_intel
+working dir  = /work/noaa/epic-ps/jongkim/rt-1795/stmp/jongkim/FV3_RT/rt_339328/regional_atmaq_faster_intel
 Checking test 179 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5740,270 +5877,12 @@ Checking test 179 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 537.708130
-  0: The maximum resident set size (KB)                   = 1480764
+  0: The total amount of wall time                        = 542.277509
+  0: The maximum resident set size (KB)                   = 1301144
 
 Test 179 regional_atmaq_faster_intel PASS
- 
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_376308/cpld_bmark_p8_intel
-Checking test 001 cpld_bmark_p8_intel results ....
- Comparing sfcf006.nc .........OK
- Comparing atmf006.nc .........OK
- Comparing GFSFLX.GrbF06 .........OK
- Comparing GFSPRS.GrbF06 .........OK
- Comparing gocart.inst_aod.20130401_0600z.nc4 .........OK
- Comparing RESTART/20130401.060000.coupler.res .........OK
- Comparing RESTART/20130401.060000.fv_core.res.nc .........OK
- Comparing RESTART/20130401.060000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20130401.060000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20130401.060000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20130401.060000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20130401.060000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20130401.060000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20130401.060000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20130401.060000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20130401.060000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20130401.060000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20130401.060000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20130401.060000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20130401.060000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20130401.060000.phy_data.tile1.nc .........OK
- Comparing RESTART/20130401.060000.phy_data.tile2.nc .........OK
- Comparing RESTART/20130401.060000.phy_data.tile3.nc .........OK
- Comparing RESTART/20130401.060000.phy_data.tile4.nc .........OK
- Comparing RESTART/20130401.060000.phy_data.tile5.nc .........OK
- Comparing RESTART/20130401.060000.phy_data.tile6.nc .........OK
- Comparing RESTART/20130401.060000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20130401.060000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20130401.060000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20130401.060000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20130401.060000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20130401.060000.sfc_data.tile6.nc .........OK
- Comparing RESTART/20130401.060000.MOM.res.nc .........OK
- Comparing RESTART/20130401.060000.MOM.res_1.nc .........OK
- Comparing RESTART/20130401.060000.MOM.res_2.nc .........OK
- Comparing RESTART/20130401.060000.MOM.res_3.nc .........OK
- Comparing RESTART/iced.2013-04-01-21600.nc .........OK
- Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
- Comparing 20130401.060000.out_pnt.ww3 .........OK
- Comparing 20130401.060000.out_grd.ww3 .........OK
-
-   0: The total amount of wall time                        = 861.683155
-   0: The maximum resident set size (KB)                   = 4039452
-
-Test 001 cpld_bmark_p8_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_376308/control_wam_intel
-Checking test 002 control_wam_intel results ....
- Comparing sfcf024.nc .........OK
- Comparing atmf024.nc .........OK
-
-  0: The total amount of wall time                        = 110.757260
-  0: The maximum resident set size (KB)                   = 642084
-
-Test 002 control_wam_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_376308/control_wam_debug_intel
-Checking test 003 control_wam_debug_intel results ....
- Comparing sfcf019.nc .........OK
- Comparing atmf019.nc .........OK
-
-  0: The total amount of wall time                        = 284.225541
-  0: The maximum resident set size (KB)                   = 530212
-
-Test 003 control_wam_debug_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_376308/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-Checking test 004 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
- Comparing dynf000.nc .........OK
- Comparing dynf001.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf001.nc .........OK
- Comparing PRSLEV.GrbF00 .........OK
- Comparing PRSLEV.GrbF01 .........OK
- Comparing NATLEV.GrbF00 .........OK
- Comparing NATLEV.GrbF01 .........OK
-
-  0: The total amount of wall time                        = 245.612185
-  0: The maximum resident set size (KB)                   = 1078180
-
-Test 004 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_376308/hrrr_control_dyn32_phy32_intel
-Checking test 005 hrrr_control_dyn32_phy32_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 190.613954
-  0: The maximum resident set size (KB)                   = 956144
-
-Test 005 hrrr_control_dyn32_phy32_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_376308/hrrr_control_2threads_dyn32_phy32_intel
-Checking test 006 hrrr_control_2threads_dyn32_phy32_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 163.325924
-  0: The maximum resident set size (KB)                   = 933912
-
-Test 006 hrrr_control_2threads_dyn32_phy32_intel PASS
-
-
-baseline dir = /work/noaa/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /work/noaa/epic-ps/zshrader/rt-1795/stmp/zshrader/FV3_RT/rt_376308/hrrr_control_decomp_dyn32_phy32_intel
-Checking test 007 hrrr_control_decomp_dyn32_phy32_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf009.nc .........OK
- Comparing sfcf012.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf009.nc .........OK
- Comparing atmf012.nc .........OK
- Comparing GFSFLX.GrbF00 .........OK
- Comparing GFSFLX.GrbF09 .........OK
- Comparing GFSFLX.GrbF12 .........OK
- Comparing GFSPRS.GrbF00 .........OK
- Comparing GFSPRS.GrbF09 .........OK
- Comparing GFSPRS.GrbF12 .........OK
- Comparing RESTART/20210322.120000.coupler.res .........OK
- Comparing RESTART/20210322.120000.fv_core.res.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_core.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/20210322.120000.fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.phy_data.tile6.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile1.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile2.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile3.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile4.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
- Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
-
-  0: The total amount of wall time                        = 198.640498
-  0: The maximum resident set size (KB)                   = 905436
-
-Test 007 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Sun Jun 25 14:55:58 CDT 2023
-Elapsed time: 00h:35m:59s. Have a nice day!
+Tue Jun 27 16:11:52 CDT 2023
+Elapsed time: 01h:22m:13s. Have a nice day!

--- a/tests/logs/RegressionTests_wcoss2.log
+++ b/tests/logs/RegressionTests_wcoss2.log
@@ -1,47 +1,47 @@
-Mon Jun 26 13:34:21 UTC 2023
+Wed Jun 28 02:17:11 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: eb51ae1a92f27efc83117fcff3ab5be62d887b37
+Testing UFSWM Hash: ba897e418f82f1c0a1b787c52b198706c8c7f7ed
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  5840cd1931e2e32b9dfded0c19049d0f1ec3d04c ../CICE-interface/CICE (CICE6.0.0-440-g5840cd1)
  cec8db8d09fa0a0b016d197a68edc67cbd100d97 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-2294-gcec8db8)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- 79256c2923245d559ebf08d961de78e48901d33c ../FV3 (remotes/origin/develop-c3)
+ 596f540cff635a802d07cacf652d49b30d62ea6e ../FV3 (remotes/origin/unused_ccpp_suites)
  b94145fca46169bbc53ec6b8d4ed849715dc5130 ../GOCART (rt-v5_29_1_BPL91_1-exRT4-514-gb94145f)
  24437531dcf8580aadaf6ebeb9de544ccfc674f9 ../HYCOM-interface/HYCOM (2.3.00-120-g2443753)
  fdbfa2523650b81a0771f3fb1791ea3e3dce66db ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9713-gfdbfa2523)
  e1260f1ee711f66a1141010d13511a69c0f8637b ../NOAHMP-interface/noahmp (v3.7.1-292-ge1260f1)
  c4b116886b5ef9af5fb4942d7161074df3402732 ../WW3 (6.07.1-325-gc4b11688)
  3bfa4468d85e5b63980c28434f494967f38b10a3 ../stochastic_physics (ufs-v2.0.0-171-g3bfa446)
-Compile 001 elapsed time 612 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 615 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 003 elapsed time 578 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 566 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 1174 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 008 elapsed time 664 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 011 elapsed time 2099 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 1741 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 1101 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 1005 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 016 elapsed time 678 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 774 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 018 elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 019 elapsed time 660 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 020 elapsed time 968 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 021 elapsed time 622 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 022 elapsed time 383 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 023 elapsed time 637 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 024 elapsed time 733 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 025 elapsed time 720 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 031 elapsed time 1112 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 034 elapsed time 700 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 035 elapsed time 723 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 036 elapsed time 336 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 1105 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1754 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 003 elapsed time 1117 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 1746 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 527 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 008 elapsed time 630 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 011 elapsed time 555 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 497 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 1111 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 446 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 016 elapsed time 564 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 1390 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 018 elapsed time 617 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 019 elapsed time 476 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 020 elapsed time 1173 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 021 elapsed time 212 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 022 elapsed time 968 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 023 elapsed time 694 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 024 elapsed time 338 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 025 elapsed time 915 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 031 elapsed time 901 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 034 elapsed time 1012 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 035 elapsed time 701 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 036 elapsed time 351 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_mixedmode_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_p8_mixedmode_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -106,14 +106,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 336.735640
-The maximum resident set size (KB)                   = 2960376
+The total amount of wall time                        = 335.330672
+The maximum resident set size (KB)                   = 2951624
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_gfsv17_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_gfsv17_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -177,14 +177,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 256.172148
-The maximum resident set size (KB)                   = 1567684
+The total amount of wall time                        = 253.521747
+The maximum resident set size (KB)                   = 1569312
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -249,14 +249,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.283078
-The maximum resident set size (KB)                   = 2983340
+The total amount of wall time                        = 383.685772
+The maximum resident set size (KB)                   = 2977284
 
 Test 003 cpld_control_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_restart_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -309,14 +309,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 238.777774
-The maximum resident set size (KB)                   = 2865568
+The total amount of wall time                        = 232.988388
+The maximum resident set size (KB)                   = 2869360
 
 Test 004 cpld_restart_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -381,14 +381,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 390.487625
-The maximum resident set size (KB)                   = 2997472
+The total amount of wall time                        = 384.672725
+The maximum resident set size (KB)                   = 2991408
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_restart_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -441,14 +441,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 241.711718
-The maximum resident set size (KB)                   = 2886636
+The total amount of wall time                        = 234.017927
+The maximum resident set size (KB)                   = 2874104
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_2threads_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -501,14 +501,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 367.572257
-The maximum resident set size (KB)                   = 3286896
+The total amount of wall time                        = 364.180610
+The maximum resident set size (KB)                   = 3283804
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_decomp_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -561,14 +561,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.417078
-The maximum resident set size (KB)                   = 2979696
+The total amount of wall time                        = 378.701781
+The maximum resident set size (KB)                   = 2972932
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_mpi_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -621,14 +621,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 321.060348
-The maximum resident set size (KB)                   = 2913876
+The total amount of wall time                        = 315.914649
+The maximum resident set size (KB)                   = 2909124
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_ciceC_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_ciceC_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -693,14 +693,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 386.094891
-The maximum resident set size (KB)                   = 2981724
+The total amount of wall time                        = 384.783103
+The maximum resident set size (KB)                   = 2977236
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_bmark_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_bmark_p8_intel
 Checking test 011 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -748,14 +748,14 @@ Checking test 011 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 941.652223
-The maximum resident set size (KB)                   = 3924884
+The total amount of wall time                        = 940.878049
+The maximum resident set size (KB)                   = 3921752
 
 Test 011 cpld_bmark_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_bmark_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_restart_bmark_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_restart_bmark_p8_intel
 Checking test 012 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -803,14 +803,14 @@ Checking test 012 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 673.697358
-The maximum resident set size (KB)                   = 3870892
+The total amount of wall time                        = 656.360541
+The maximum resident set size (KB)                   = 3874292
 
 Test 012 cpld_restart_bmark_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_noaero_p8_intel
 Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -874,14 +874,14 @@ Checking test 013 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 286.889482
-The maximum resident set size (KB)                   = 1575748
+The total amount of wall time                        = 280.934485
+The maximum resident set size (KB)                   = 1576920
 
 Test 013 cpld_control_noaero_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_c96_noaero_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_nowave_noaero_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_nowave_noaero_p8_intel
 Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -943,14 +943,14 @@ Checking test 014 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 301.080261
-The maximum resident set size (KB)                   = 1632456
+The total amount of wall time                        = 297.806916
+The maximum resident set size (KB)                   = 1629532
 
 Test 014 cpld_control_nowave_noaero_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_noaero_p8_agrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_noaero_p8_agrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_noaero_p8_agrid_intel
 Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1012,14 +1012,14 @@ Checking test 015 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 307.821744
-The maximum resident set size (KB)                   = 1628932
+The total amount of wall time                        = 304.079077
+The maximum resident set size (KB)                   = 1626200
 
 Test 015 cpld_control_noaero_p8_agrid_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_c48_intel
 Checking test 016 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1069,14 +1069,14 @@ Checking test 016 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-The total amount of wall time                        = 438.124997
-The maximum resident set size (KB)                   = 2638332
+The total amount of wall time                        = 435.931061
+The maximum resident set size (KB)                   = 2632688
 
 Test 016 cpld_control_c48_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_warmstart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_warmstart_c48_intel
 Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1126,14 +1126,14 @@ Checking test 017 cpld_warmstart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 130.515138
-The maximum resident set size (KB)                   = 2644836
+The total amount of wall time                        = 123.591772
+The maximum resident set size (KB)                   = 2644864
 
 Test 017 cpld_warmstart_c48_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_warmstart_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_restart_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_restart_c48_intel
 Checking test 018 cpld_restart_c48_intel results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1183,14 +1183,14 @@ Checking test 018 cpld_restart_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-43200.nc .........OK
 
-The total amount of wall time                        = 71.059762
-The maximum resident set size (KB)                   = 2058260
+The total amount of wall time                        = 71.161100
+The maximum resident set size (KB)                   = 2056036
 
 Test 018 cpld_restart_c48_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/cpld_control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/cpld_control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/cpld_control_p8_faster_intel
 Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1255,14 +1255,14 @@ Checking test 019 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-The total amount of wall time                        = 385.288593
-The maximum resident set size (KB)                   = 2982252
+The total amount of wall time                        = 381.537165
+The maximum resident set size (KB)                   = 2984068
 
 Test 019 cpld_control_p8_faster_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_flake_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_flake_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_flake_intel
 Checking test 020 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1273,14 +1273,14 @@ Checking test 020 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 216.940871
-The maximum resident set size (KB)                   = 568084
+The total amount of wall time                        = 217.788456
+The maximum resident set size (KB)                   = 569296
 
 Test 020 control_flake_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_CubedSphereGrid_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_CubedSphereGrid_intel
 Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1307,14 +1307,14 @@ Checking test 021 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-The total amount of wall time                        = 133.968690
-The maximum resident set size (KB)                   = 513260
+The total amount of wall time                        = 132.042128
+The maximum resident set size (KB)                   = 516184
 
 Test 021 control_CubedSphereGrid_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_latlon_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_latlon_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_latlon_intel
 Checking test 022 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1325,14 +1325,14 @@ Checking test 022 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 135.820942
-The maximum resident set size (KB)                   = 518340
+The total amount of wall time                        = 138.566321
+The maximum resident set size (KB)                   = 512680
 
 Test 022 control_latlon_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_wrtGauss_netcdf_parallel_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_wrtGauss_netcdf_parallel_intel
 Checking test 023 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1343,14 +1343,14 @@ Checking test 023 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 140.197417
-The maximum resident set size (KB)                   = 518904
+The total amount of wall time                        = 139.841025
+The maximum resident set size (KB)                   = 517052
 
 Test 023 control_wrtGauss_netcdf_parallel_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c48_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_c48_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_c48_intel
 Checking test 024 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1389,14 +1389,14 @@ Checking test 024 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 326.878169
-The maximum resident set size (KB)                   = 674412
+The total amount of wall time                        = 328.267724
+The maximum resident set size (KB)                   = 675572
 
 Test 024 control_c48_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c192_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_c192_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_c192_intel
 Checking test 025 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1407,14 +1407,14 @@ Checking test 025 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 533.592600
-The maximum resident set size (KB)                   = 618344
+The total amount of wall time                        = 535.776038
+The maximum resident set size (KB)                   = 616704
 
 Test 025 control_c192_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c384_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_c384_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_c384_intel
 Checking test 026 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1425,14 +1425,14 @@ Checking test 026 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 571.763781
-The maximum resident set size (KB)                   = 930036
+The total amount of wall time                        = 571.195375
+The maximum resident set size (KB)                   = 928600
 
 Test 026 control_c384_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_c384gdas_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_c384gdas_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_c384gdas_intel
 Checking test 027 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1475,14 +1475,14 @@ Checking test 027 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 503.179208
-The maximum resident set size (KB)                   = 1057664
+The total amount of wall time                        = 506.687153
+The maximum resident set size (KB)                   = 1065504
 
 Test 027 control_c384gdas_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_stochy_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_stochy_intel
 Checking test 028 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1493,28 +1493,28 @@ Checking test 028 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 91.890945
-The maximum resident set size (KB)                   = 524240
+The total amount of wall time                        = 94.645870
+The maximum resident set size (KB)                   = 525048
 
 Test 028 control_stochy_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_stochy_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_stochy_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_stochy_restart_intel
 Checking test 029 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 49.232188
-The maximum resident set size (KB)                   = 291788
+The total amount of wall time                        = 49.420040
+The maximum resident set size (KB)                   = 288604
 
 Test 029 control_stochy_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_lndp_intel
 Checking test 030 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1525,14 +1525,14 @@ Checking test 030 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 84.947852
-The maximum resident set size (KB)                   = 521480
+The total amount of wall time                        = 87.630951
+The maximum resident set size (KB)                   = 518508
 
 Test 030 control_lndp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_iovr4_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_iovr4_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_iovr4_intel
 Checking test 031 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1547,14 +1547,14 @@ Checking test 031 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 137.599639
-The maximum resident set size (KB)                   = 518096
+The total amount of wall time                        = 136.520959
+The maximum resident set size (KB)                   = 516552
 
 Test 031 control_iovr4_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_iovr5_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_iovr5_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_iovr5_intel
 Checking test 032 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1569,14 +1569,14 @@ Checking test 032 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 137.578946
-The maximum resident set size (KB)                   = 516272
+The total amount of wall time                        = 139.676590
+The maximum resident set size (KB)                   = 514100
 
 Test 032 control_iovr5_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_p8_intel
 Checking test 033 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1623,14 +1623,14 @@ Checking test 033 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 182.781622
-The maximum resident set size (KB)                   = 1493172
+The total amount of wall time                        = 181.468948
+The maximum resident set size (KB)                   = 1490824
 
 Test 033 control_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_restart_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_restart_p8_intel
 Checking test 034 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1669,14 +1669,14 @@ Checking test 034 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 102.569519
-The maximum resident set size (KB)                   = 657872
+The total amount of wall time                        = 101.727509
+The maximum resident set size (KB)                   = 657484
 
 Test 034 control_restart_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_qr_p8_intel
 Checking test 035 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1723,14 +1723,14 @@ Checking test 035 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 180.935127
-The maximum resident set size (KB)                   = 1503092
+The total amount of wall time                        = 179.352505
+The maximum resident set size (KB)                   = 1494908
 
 Test 035 control_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_restart_qr_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_restart_qr_p8_intel
 Checking test 036 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1769,14 +1769,14 @@ Checking test 036 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 105.410011
-The maximum resident set size (KB)                   = 674032
+The total amount of wall time                        = 103.092600
+The maximum resident set size (KB)                   = 669360
 
 Test 036 control_restart_qr_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_decomp_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_decomp_p8_intel
 Checking test 037 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1819,14 +1819,14 @@ Checking test 037 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 183.895936
-The maximum resident set size (KB)                   = 1491416
+The total amount of wall time                        = 186.035475
+The maximum resident set size (KB)                   = 1482324
 
 Test 037 control_decomp_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_2threads_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_2threads_p8_intel
 Checking test 038 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1869,14 +1869,14 @@ Checking test 038 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 157.727857
-The maximum resident set size (KB)                   = 1572244
+The total amount of wall time                        = 161.267980
+The maximum resident set size (KB)                   = 1569240
 
 Test 038 control_2threads_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_lndp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_p8_lndp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_p8_lndp_intel
 Checking test 039 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1895,14 +1895,14 @@ Checking test 039 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-The total amount of wall time                        = 323.976599
-The maximum resident set size (KB)                   = 1492068
+The total amount of wall time                        = 323.041534
+The maximum resident set size (KB)                   = 1497404
 
 Test 039 control_p8_lndp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_rrtmgp_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_p8_rrtmgp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_p8_rrtmgp_intel
 Checking test 040 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1949,14 +1949,14 @@ Checking test 040 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 235.520945
-The maximum resident set size (KB)                   = 1548960
+The total amount of wall time                        = 236.756973
+The maximum resident set size (KB)                   = 1551744
 
 Test 040 control_p8_rrtmgp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_mynn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_p8_mynn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_p8_mynn_intel
 Checking test 041 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2003,14 +2003,14 @@ Checking test 041 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 184.679981
-The maximum resident set size (KB)                   = 1495304
+The total amount of wall time                        = 181.969692
+The maximum resident set size (KB)                   = 1495348
 
 Test 041 control_p8_mynn_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/merra2_thompson_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/merra2_thompson_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/merra2_thompson_intel
 Checking test 042 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2057,14 +2057,14 @@ Checking test 042 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 206.267519
-The maximum resident set size (KB)                   = 1499980
+The total amount of wall time                        = 204.786206
+The maximum resident set size (KB)                   = 1495580
 
 Test 042 merra2_thompson_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_control_intel
 Checking test 043 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2075,28 +2075,28 @@ Checking test 043 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 286.926906
-The maximum resident set size (KB)                   = 655472
+The total amount of wall time                        = 282.641880
+The maximum resident set size (KB)                   = 654428
 
 Test 043 regional_control_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_restart_intel
 Checking test 044 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 157.088071
-The maximum resident set size (KB)                   = 653088
+The total amount of wall time                        = 152.127370
+The maximum resident set size (KB)                   = 654588
 
 Test 044 regional_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_control_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_control_qr_intel
 Checking test 045 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2107,28 +2107,28 @@ Checking test 045 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 285.767071
-The maximum resident set size (KB)                   = 659272
+The total amount of wall time                        = 280.815528
+The maximum resident set size (KB)                   = 653860
 
 Test 045 regional_control_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_restart_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_restart_qr_intel
 Checking test 046 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 156.145969
-The maximum resident set size (KB)                   = 655124
+The total amount of wall time                        = 152.358308
+The maximum resident set size (KB)                   = 654520
 
 Test 046 regional_restart_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_decomp_intel
 Checking test 047 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2139,14 +2139,14 @@ Checking test 047 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 302.025512
-The maximum resident set size (KB)                   = 657204
+The total amount of wall time                        = 297.269801
+The maximum resident set size (KB)                   = 655240
 
 Test 047 regional_decomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_2threads_intel
 Checking test 048 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2157,14 +2157,14 @@ Checking test 048 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 175.661620
-The maximum resident set size (KB)                   = 698376
+The total amount of wall time                        = 172.487919
+The maximum resident set size (KB)                   = 696304
 
 Test 048 regional_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_noquilt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_noquilt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_noquilt_intel
 Checking test 049 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -2172,28 +2172,28 @@ Checking test 049 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-The total amount of wall time                        = 287.955393
-The maximum resident set size (KB)                   = 646140
+The total amount of wall time                        = 282.176839
+The maximum resident set size (KB)                   = 645364
 
 Test 049 regional_noquilt_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_netcdf_parallel_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_netcdf_parallel_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_netcdf_parallel_intel
 Checking test 050 regional_netcdf_parallel_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-The total amount of wall time                        = 285.565584
-The maximum resident set size (KB)                   = 652332
+The total amount of wall time                        = 280.910572
+The maximum resident set size (KB)                   = 651160
 
 Test 050 regional_netcdf_parallel_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_2dwrtdecomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_2dwrtdecomp_intel
 Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2204,14 +2204,14 @@ Checking test 051 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 282.259965
-The maximum resident set size (KB)                   = 655264
+The total amount of wall time                        = 284.580744
+The maximum resident set size (KB)                   = 652436
 
 Test 051 regional_2dwrtdecomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/fv3_regional_wofs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_wofs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_wofs_intel
 Checking test 052 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2222,14 +2222,14 @@ Checking test 052 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 386.589547
-The maximum resident set size (KB)                   = 343564
+The total amount of wall time                        = 376.018103
+The maximum resident set size (KB)                   = 341088
 
 Test 052 regional_wofs_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_control_intel
 Checking test 053 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2276,14 +2276,14 @@ Checking test 053 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 407.646451
-The maximum resident set size (KB)                   = 894388
+The total amount of wall time                        = 407.854328
+The maximum resident set size (KB)                   = 896644
 
 Test 053 rap_control_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_spp_sppt_shum_skeb_intel
 Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2294,14 +2294,14 @@ Checking test 054 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 245.403193
-The maximum resident set size (KB)                   = 988960
+The total amount of wall time                        = 240.410461
+The maximum resident set size (KB)                   = 991172
 
 Test 054 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_decomp_intel
 Checking test 055 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2348,14 +2348,14 @@ Checking test 055 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 423.211834
-The maximum resident set size (KB)                   = 896740
+The total amount of wall time                        = 421.332144
+The maximum resident set size (KB)                   = 898328
 
 Test 055 rap_decomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_2threads_intel
 Checking test 056 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2402,14 +2402,14 @@ Checking test 056 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 371.695631
-The maximum resident set size (KB)                   = 969576
+The total amount of wall time                        = 370.543610
+The maximum resident set size (KB)                   = 978868
 
 Test 056 rap_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_restart_intel
 Checking test 057 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2448,14 +2448,14 @@ Checking test 057 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 214.961158
-The maximum resident set size (KB)                   = 636428
+The total amount of wall time                        = 209.463201
+The maximum resident set size (KB)                   = 642496
 
 Test 057 rap_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_sfcdiff_intel
 Checking test 058 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2502,14 +2502,14 @@ Checking test 058 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 409.574792
-The maximum resident set size (KB)                   = 893912
+The total amount of wall time                        = 413.061144
+The maximum resident set size (KB)                   = 897320
 
 Test 058 rap_sfcdiff_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_sfcdiff_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_sfcdiff_decomp_intel
 Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2556,14 +2556,14 @@ Checking test 059 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 428.037906
-The maximum resident set size (KB)                   = 899548
+The total amount of wall time                        = 423.773442
+The maximum resident set size (KB)                   = 896288
 
 Test 059 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_sfcdiff_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_sfcdiff_restart_intel
 Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2602,14 +2602,14 @@ Checking test 060 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 308.549183
-The maximum resident set size (KB)                   = 645192
+The total amount of wall time                        = 301.616974
+The maximum resident set size (KB)                   = 646556
 
 Test 060 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_intel
 Checking test 061 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2656,14 +2656,14 @@ Checking test 061 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 397.183733
-The maximum resident set size (KB)                   = 891768
+The total amount of wall time                        = 396.050007
+The maximum resident set size (KB)                   = 894128
 
 Test 061 hrrr_control_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_qr_intel
 Checking test 062 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2710,14 +2710,14 @@ Checking test 062 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 392.710889
-The maximum resident set size (KB)                   = 902416
+The total amount of wall time                        = 388.222971
+The maximum resident set size (KB)                   = 900136
 
 Test 062 hrrr_control_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_decomp_intel
 Checking test 063 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2764,14 +2764,14 @@ Checking test 063 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 405.183464
-The maximum resident set size (KB)                   = 899704
+The total amount of wall time                        = 408.095651
+The maximum resident set size (KB)                   = 895844
 
 Test 063 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_2threads_intel
 Checking test 064 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2818,42 +2818,42 @@ Checking test 064 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 351.763175
-The maximum resident set size (KB)                   = 964452
+The total amount of wall time                        = 353.787610
+The maximum resident set size (KB)                   = 963824
 
 Test 064 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_restart_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_restart_intel
 Checking test 065 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 304.211773
-The maximum resident set size (KB)                   = 640632
+The total amount of wall time                        = 289.628021
+The maximum resident set size (KB)                   = 640472
 
 Test 065 hrrr_control_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_restart_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_restart_qr_intel
 Checking test 066 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 304.523137
-The maximum resident set size (KB)                   = 653696
+The total amount of wall time                        = 291.578859
+The maximum resident set size (KB)                   = 657364
 
 Test 066 hrrr_control_restart_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_v1beta_intel
 Checking test 067 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2900,14 +2900,14 @@ Checking test 067 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 403.543532
-The maximum resident set size (KB)                   = 892812
+The total amount of wall time                        = 402.486977
+The maximum resident set size (KB)                   = 896304
 
 Test 067 rrfs_v1beta_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_v1nssl_intel
 Checking test 068 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2922,14 +2922,14 @@ Checking test 068 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 467.070972
-The maximum resident set size (KB)                   = 582972
+The total amount of wall time                        = 467.846099
+The maximum resident set size (KB)                   = 577980
 
 Test 068 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_v1nssl_nohailnoccn_intel
 Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2944,14 +2944,14 @@ Checking test 069 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 458.664345
-The maximum resident set size (KB)                   = 575152
+The total amount of wall time                        = 457.943272
+The maximum resident set size (KB)                   = 573944
 
 Test 069 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_smoke_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_smoke_conus13km_hrrr_warm_intel
 Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2967,14 +2967,14 @@ Checking test 070 rrfs_smoke_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 152.840473
-The maximum resident set size (KB)                   = 798304
+The total amount of wall time                        = 154.136322
+The maximum resident set size (KB)                   = 795848
 
 Test 070 rrfs_smoke_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_smoke_conus13km_hrrr_warm_2threads_intel
 Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2983,14 +2983,14 @@ Checking test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 107.051924
-The maximum resident set size (KB)                   = 804824
+The total amount of wall time                        = 108.414753
+The maximum resident set size (KB)                   = 812440
 
 Test 071 rrfs_smoke_conus13km_hrrr_warm_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_conus13km_hrrr_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_conus13km_hrrr_warm_intel
 Checking test 072 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3006,14 +3006,14 @@ Checking test 072 rrfs_conus13km_hrrr_warm_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 139.840599
-The maximum resident set size (KB)                   = 780900
+The total amount of wall time                        = 139.908810
+The maximum resident set size (KB)                   = 783300
 
 Test 072 rrfs_conus13km_hrrr_warm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_radar_tten_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_smoke_conus13km_radar_tten_warm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_smoke_conus13km_radar_tten_warm_intel
 Checking test 073 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -3022,26 +3022,26 @@ Checking test 073 rrfs_smoke_conus13km_radar_tten_warm_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 157.804308
-The maximum resident set size (KB)                   = 805196
+The total amount of wall time                        = 158.304853
+The maximum resident set size (KB)                   = 802904
 
 Test 073 rrfs_smoke_conus13km_radar_tten_warm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel
 Checking test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 101.301961
-The maximum resident set size (KB)                   = 795932
+The total amount of wall time                        = 97.604199
+The maximum resident set size (KB)                   = 795168
 
 Test 074 rrfs_smoke_conus13km_hrrr_warm_restart_mismatch_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmg_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_csawmg_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_csawmg_intel
 Checking test 075 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3052,14 +3052,14 @@ Checking test 075 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 344.520958
-The maximum resident set size (KB)                   = 584292
+The total amount of wall time                        = 340.498652
+The maximum resident set size (KB)                   = 586600
 
 Test 075 control_csawmg_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_csawmgt_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_csawmgt_intel
 Checking test 076 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3070,14 +3070,14 @@ Checking test 076 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 340.754696
-The maximum resident set size (KB)                   = 587172
+The total amount of wall time                        = 335.148766
+The maximum resident set size (KB)                   = 584244
 
 Test 076 control_csawmgt_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_ras_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_ras_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_ras_intel
 Checking test 077 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3088,26 +3088,26 @@ Checking test 077 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-The total amount of wall time                        = 183.424775
-The maximum resident set size (KB)                   = 553300
+The total amount of wall time                        = 183.906679
+The maximum resident set size (KB)                   = 553964
 
 Test 077 control_ras_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wam_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_wam_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_wam_intel
 Checking test 078 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-The total amount of wall time                        = 119.562532
-The maximum resident set size (KB)                   = 332772
+The total amount of wall time                        = 117.952761
+The maximum resident set size (KB)                   = 275424
 
 Test 078 control_wam_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_p8_faster_intel
 Checking test 079 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3154,14 +3154,14 @@ Checking test 079 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 179.031893
-The maximum resident set size (KB)                   = 1495500
+The total amount of wall time                        = 174.180515
+The maximum resident set size (KB)                   = 1486232
 
 Test 079 control_p8_faster_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_control_faster_intel
 Checking test 080 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3172,56 +3172,56 @@ Checking test 080 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 274.217514
-The maximum resident set size (KB)                   = 654540
+The total amount of wall time                        = 273.739232
+The maximum resident set size (KB)                   = 650296
 
 Test 080 regional_control_faster_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_smoke_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_smoke_conus13km_hrrr_warm_debug_intel
 Checking test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 923.535292
-The maximum resident set size (KB)                   = 823108
+The total amount of wall time                        = 919.536409
+The maximum resident set size (KB)                   = 827000
 
 Test 081 rrfs_smoke_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_smoke_conus13km_hrrr_warm_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel
 Checking test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 536.514653
-The maximum resident set size (KB)                   = 832924
+The total amount of wall time                        = 532.629450
+The maximum resident set size (KB)                   = 835328
 
 Test 082 rrfs_smoke_conus13km_hrrr_warm_debug_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_conus13km_hrrr_warm_debugs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_conus13km_hrrr_warm_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_conus13km_hrrr_warm_debug_intel
 Checking test 083 rrfs_conus13km_hrrr_warm_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 825.580305
-The maximum resident set size (KB)                   = 811800
+The total amount of wall time                        = 828.138395
+The maximum resident set size (KB)                   = 808652
 
 Test 083 rrfs_conus13km_hrrr_warm_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_CubedSphereGrid_debug_intel
 Checking test 084 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3248,348 +3248,348 @@ Checking test 084 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 162.233731
-The maximum resident set size (KB)                   = 675168
+The total amount of wall time                        = 159.886257
+The maximum resident set size (KB)                   = 678524
 
 Test 084 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 085 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 161.937728
-The maximum resident set size (KB)                   = 678356
+The total amount of wall time                        = 159.333872
+The maximum resident set size (KB)                   = 678288
 
 Test 085 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_stochy_debug_intel
 Checking test 086 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 180.618202
-The maximum resident set size (KB)                   = 684520
+The total amount of wall time                        = 180.055380
+The maximum resident set size (KB)                   = 681860
 
 Test 086 control_stochy_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_lndp_debug_intel
 Checking test 087 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 162.853674
-The maximum resident set size (KB)                   = 685796
+The total amount of wall time                        = 162.564231
+The maximum resident set size (KB)                   = 687816
 
 Test 087 control_lndp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_csawmg_debug_intel
 Checking test 088 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 256.947642
-The maximum resident set size (KB)                   = 719660
+The total amount of wall time                        = 258.669557
+The maximum resident set size (KB)                   = 719196
 
 Test 088 control_csawmg_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_csawmgt_debug_intel
 Checking test 089 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 256.688826
-The maximum resident set size (KB)                   = 719776
+The total amount of wall time                        = 251.939506
+The maximum resident set size (KB)                   = 719628
 
 Test 089 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_ras_debug_intel
 Checking test 090 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.691265
-The maximum resident set size (KB)                   = 688568
+The total amount of wall time                        = 164.829990
+The maximum resident set size (KB)                   = 691040
 
 Test 090 control_ras_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_diag_debug_intel
 Checking test 091 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.319112
-The maximum resident set size (KB)                   = 735280
+The total amount of wall time                        = 165.364872
+The maximum resident set size (KB)                   = 737488
 
 Test 091 control_diag_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_debug_p8_intel
 Checking test 092 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 188.700133
-The maximum resident set size (KB)                   = 1501124
+The total amount of wall time                        = 186.422815
+The maximum resident set size (KB)                   = 1499948
 
 Test 092 control_debug_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_debug_intel
 Checking test 093 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1051.633437
-The maximum resident set size (KB)                   = 675364
+The total amount of wall time                        = 1051.444618
+The maximum resident set size (KB)                   = 674520
 
 Test 093 regional_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_control_debug_intel
 Checking test 094 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.610908
-The maximum resident set size (KB)                   = 1057020
+The total amount of wall time                        = 301.231038
+The maximum resident set size (KB)                   = 1057436
 
 Test 094 rap_control_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_debug_intel
 Checking test 095 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.988177
-The maximum resident set size (KB)                   = 1048980
+The total amount of wall time                        = 295.177150
+The maximum resident set size (KB)                   = 1049588
 
 Test 095 hrrr_control_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_unified_drag_suite_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_unified_drag_suite_debug_intel
 Checking test 096 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.784579
-The maximum resident set size (KB)                   = 1056448
+The total amount of wall time                        = 301.788461
+The maximum resident set size (KB)                   = 1054700
 
 Test 096 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_diag_debug_intel
 Checking test 097 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 312.558819
-The maximum resident set size (KB)                   = 1136280
+The total amount of wall time                        = 312.821864
+The maximum resident set size (KB)                   = 1136992
 
 Test 097 rap_diag_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_cires_ugwp_debug_intel
 Checking test 098 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 309.132203
-The maximum resident set size (KB)                   = 1053028
+The total amount of wall time                        = 309.176703
+The maximum resident set size (KB)                   = 1055796
 
 Test 098 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_unified_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_unified_ugwp_debug_intel
 Checking test 099 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 308.120586
-The maximum resident set size (KB)                   = 1054056
+The total amount of wall time                        = 307.965103
+The maximum resident set size (KB)                   = 1056164
 
 Test 099 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_lndp_debug_intel
 Checking test 100 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.642006
-The maximum resident set size (KB)                   = 1057476
+The total amount of wall time                        = 305.525764
+The maximum resident set size (KB)                   = 1056176
 
 Test 100 rap_lndp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_progcld_thompson_debug_intel
 Checking test 101 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.978742
-The maximum resident set size (KB)                   = 1056304
+The total amount of wall time                        = 301.272179
+The maximum resident set size (KB)                   = 1057108
 
 Test 101 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_noah_debug_intel
 Checking test 102 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.121683
-The maximum resident set size (KB)                   = 1055532
+The total amount of wall time                        = 295.717347
+The maximum resident set size (KB)                   = 1053688
 
 Test 102 rap_noah_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_sfcdiff_debug_intel
 Checking test 103 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.519749
-The maximum resident set size (KB)                   = 1054040
+The total amount of wall time                        = 300.389057
+The maximum resident set size (KB)                   = 1051960
 
 Test 103 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 490.759644
-The maximum resident set size (KB)                   = 1053096
+The total amount of wall time                        = 492.134380
+The maximum resident set size (KB)                   = 1057036
 
 Test 104 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rrfs_v1beta_debug_intel
 Checking test 105 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.302123
-The maximum resident set size (KB)                   = 1051540
+The total amount of wall time                        = 299.959937
+The maximum resident set size (KB)                   = 1052568
 
 Test 105 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_clm_lake_debug_intel
 Checking test 106 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 358.907726
-The maximum resident set size (KB)                   = 1056160
+The total amount of wall time                        = 358.903101
+The maximum resident set size (KB)                   = 1058736
 
 Test 106 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_flake_debug_intel
 Checking test 107 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.514216
-The maximum resident set size (KB)                   = 1052544
+The total amount of wall time                        = 302.503234
+The maximum resident set size (KB)                   = 1052512
 
 Test 107 rap_flake_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_wam_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_wam_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_wam_debug_intel
 Checking test 108 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-The total amount of wall time                        = 297.055193
-The maximum resident set size (KB)                   = 301712
+The total amount of wall time                        = 295.630021
+The maximum resident set size (KB)                   = 302308
 
 Test 108 control_wam_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -3600,14 +3600,14 @@ Checking test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 229.962320
-The maximum resident set size (KB)                   = 891320
+The total amount of wall time                        = 227.317858
+The maximum resident set size (KB)                   = 893936
 
 Test 109 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_control_dyn32_phy32_intel
 Checking test 110 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3654,14 +3654,14 @@ Checking test 110 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 340.917431
-The maximum resident set size (KB)                   = 776280
+The total amount of wall time                        = 340.937697
+The maximum resident set size (KB)                   = 778120
 
 Test 110 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_dyn32_phy32_intel
 Checking test 111 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3708,14 +3708,14 @@ Checking test 111 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 182.005259
-The maximum resident set size (KB)                   = 774116
+The total amount of wall time                        = 181.135104
+The maximum resident set size (KB)                   = 773936
 
 Test 111 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_qr_dyn32_phy32_intel
 Checking test 112 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3762,14 +3762,14 @@ Checking test 112 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 178.294411
-The maximum resident set size (KB)                   = 781236
+The total amount of wall time                        = 178.583609
+The maximum resident set size (KB)                   = 785116
 
 Test 112 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_2threads_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_2threads_dyn32_phy32_intel
 Checking test 113 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3816,14 +3816,14 @@ Checking test 113 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 309.529687
-The maximum resident set size (KB)                   = 831408
+The total amount of wall time                        = 307.821770
+The maximum resident set size (KB)                   = 830980
 
 Test 113 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 114 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3870,14 +3870,14 @@ Checking test 114 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 163.865826
-The maximum resident set size (KB)                   = 814764
+The total amount of wall time                        = 160.910002
+The maximum resident set size (KB)                   = 822468
 
 Test 114 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 115 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3924,14 +3924,14 @@ Checking test 115 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 188.492700
-The maximum resident set size (KB)                   = 773096
+The total amount of wall time                        = 188.170657
+The maximum resident set size (KB)                   = 774464
 
 Test 115 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_restart_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_restart_dyn32_phy32_intel
 Checking test 116 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3970,42 +3970,42 @@ Checking test 116 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 248.907493
-The maximum resident set size (KB)                   = 611020
+The total amount of wall time                        = 248.690634
+The maximum resident set size (KB)                   = 614828
 
 Test 116 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_restart_dyn32_phy32_intel
 Checking test 117 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 94.928544
-The maximum resident set size (KB)                   = 605672
+The total amount of wall time                        = 93.525081
+The maximum resident set size (KB)                   = 603848
 
 Test 117 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_qr_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_restart_qr_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_restart_qr_dyn32_phy32_intel
 Checking test 118 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 95.714219
-The maximum resident set size (KB)                   = 624008
+The total amount of wall time                        = 94.633601
+The maximum resident set size (KB)                   = 624040
 
 Test 118 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_control_dyn64_phy32_intel
 Checking test 119 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4052,81 +4052,81 @@ Checking test 119 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 232.537353
-The maximum resident set size (KB)                   = 799104
+The total amount of wall time                        = 230.967105
+The maximum resident set size (KB)                   = 796336
 
 Test 119 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_control_debug_dyn32_phy32_intel
 Checking test 120 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 294.951718
-The maximum resident set size (KB)                   = 940160
+The total amount of wall time                        = 294.684660
+The maximum resident set size (KB)                   = 939092
 
 Test 120 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hrrr_control_debug_dyn32_phy32_intel
 Checking test 121 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 289.546286
-The maximum resident set size (KB)                   = 942336
+The total amount of wall time                        = 289.807244
+The maximum resident set size (KB)                   = 941492
 
 Test 121 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/rap_control_dyn64_phy32_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/rap_control_dyn64_phy32_debug_intel
 Checking test 122 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 295.143015
-The maximum resident set size (KB)                   = 958436
+The total amount of wall time                        = 293.852073
+The maximum resident set size (KB)                   = 962416
 
 Test 122 rap_control_dyn64_phy32_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_atm_intel
 Checking test 123 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-The total amount of wall time                        = 260.340535
-The maximum resident set size (KB)                   = 825180
+The total amount of wall time                        = 257.005469
+The maximum resident set size (KB)                   = 816680
 
 Test 123 hafs_regional_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 124 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-The total amount of wall time                        = 330.949146
-The maximum resident set size (KB)                   = 1174984
+The total amount of wall time                        = 317.013457
+The maximum resident set size (KB)                   = 1179648
 
 Test 124 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_atm_ocn_intel
 Checking test 125 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4135,14 +4135,14 @@ Checking test 125 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 390.607142
-The maximum resident set size (KB)                   = 859288
+The total amount of wall time                        = 385.348131
+The maximum resident set size (KB)                   = 859424
 
 Test 125 hafs_regional_atm_ocn_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_atm_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_atm_wav_intel
 Checking test 126 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4151,14 +4151,14 @@ Checking test 126 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 710.429581
-The maximum resident set size (KB)                   = 890664
+The total amount of wall time                        = 708.770526
+The maximum resident set size (KB)                   = 890232
 
 Test 126 hafs_regional_atm_wav_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_atm_ocn_wav_intel
 Checking test 127 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4169,14 +4169,14 @@ Checking test 127 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-The total amount of wall time                        = 907.383295
-The maximum resident set size (KB)                   = 914560
+The total amount of wall time                        = 895.672952
+The maximum resident set size (KB)                   = 916184
 
 Test 127 hafs_regional_atm_ocn_wav_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_1nest_atm_intel
 Checking test 128 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4198,14 +4198,14 @@ Checking test 128 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 309.613992
-The maximum resident set size (KB)                   = 392544
+The total amount of wall time                        = 306.856725
+The maximum resident set size (KB)                   = 392824
 
 Test 128 hafs_regional_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_1nest_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_1nest_atm_qr_intel
 Checking test 129 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4227,14 +4227,14 @@ Checking test 129 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 334.792929
-The maximum resident set size (KB)                   = 368396
+The total amount of wall time                        = 330.271547
+The maximum resident set size (KB)                   = 370104
 
 Test 129 hafs_regional_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_telescopic_2nests_atm_intel
 Checking test 130 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4243,14 +4243,14 @@ Checking test 130 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-The total amount of wall time                        = 377.708885
-The maximum resident set size (KB)                   = 400968
+The total amount of wall time                        = 373.155919
+The maximum resident set size (KB)                   = 399024
 
 Test 130 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_global_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_global_1nest_atm_intel
 Checking test 131 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4297,14 +4297,14 @@ Checking test 131 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 164.114033
-The maximum resident set size (KB)                   = 286048
+The total amount of wall time                        = 161.820986
+The maximum resident set size (KB)                   = 265596
 
 Test 131 hafs_global_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_global_1nest_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_global_1nest_atm_qr_intel
 Checking test 132 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4351,14 +4351,14 @@ Checking test 132 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 171.783019
-The maximum resident set size (KB)                   = 272304
+The total amount of wall time                        = 169.867654
+The maximum resident set size (KB)                   = 280568
 
 Test 132 hafs_global_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_global_multiple_4nests_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_global_multiple_4nests_atm_intel
 Checking test 133 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4440,14 +4440,14 @@ Checking test 133 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 468.530992
-The maximum resident set size (KB)                   = 347916
+The total amount of wall time                        = 461.866823
+The maximum resident set size (KB)                   = 344176
 
 Test 133 hafs_global_multiple_4nests_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_multiple_4nests_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_global_multiple_4nests_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_global_multiple_4nests_atm_qr_intel
 Checking test 134 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4529,14 +4529,14 @@ Checking test 134 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc .........OK
 
-The total amount of wall time                        = 519.137100
-The maximum resident set size (KB)                   = 370652
+The total amount of wall time                        = 515.031714
+The maximum resident set size (KB)                   = 375748
 
 Test 134 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_specified_moving_1nest_atm_intel
 Checking test 135 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4545,14 +4545,14 @@ Checking test 135 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-The total amount of wall time                        = 208.440664
-The maximum resident set size (KB)                   = 406716
+The total amount of wall time                        = 207.974035
+The maximum resident set size (KB)                   = 404404
 
 Test 135 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_storm_following_1nest_atm_intel
 Checking test 136 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4574,14 +4574,14 @@ Checking test 136 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 196.721569
-The maximum resident set size (KB)                   = 407436
+The total amount of wall time                        = 193.868674
+The maximum resident set size (KB)                   = 405088
 
 Test 136 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_storm_following_1nest_atm_qr_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_storm_following_1nest_atm_qr_intel
 Checking test 137 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4603,14 +4603,14 @@ Checking test 137 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc .........OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc .........OK
 
-The total amount of wall time                        = 221.795844
-The maximum resident set size (KB)                   = 394936
+The total amount of wall time                        = 220.997409
+The maximum resident set size (KB)                   = 392276
 
 Test 137 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_storm_following_1nest_atm_ocn_intel
 Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4619,42 +4619,42 @@ Checking test 138 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-The total amount of wall time                        = 258.990814
-The maximum resident set size (KB)                   = 468784
+The total amount of wall time                        = 250.710564
+The maximum resident set size (KB)                   = 469392
 
 Test 138 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_global_storm_following_1nest_atm_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_global_storm_following_1nest_atm_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_global_storm_following_1nest_atm_intel
 Checking test 139 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-The total amount of wall time                        = 83.075798
-The maximum resident set size (KB)                   = 290116
+The total amount of wall time                        = 82.292540
+The maximum resident set size (KB)                   = 281200
 
 Test 139 hafs_global_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
 Checking test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-The total amount of wall time                        = 804.552200
-The maximum resident set size (KB)                   = 497176
+The total amount of wall time                        = 805.178274
+The maximum resident set size (KB)                   = 496364
 
 Test 140 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
 Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4665,14 +4665,14 @@ Checking test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-The total amount of wall time                        = 504.523331
-The maximum resident set size (KB)                   = 528580
+The total amount of wall time                        = 503.381793
+The maximum resident set size (KB)                   = 525396
 
 Test 141 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/control_p8_atmlnd_sbs_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/control_p8_atmlnd_sbs_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/control_p8_atmlnd_sbs_intel
 Checking test 142 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -4757,14 +4757,14 @@ Checking test 142 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc .........OK
 
-The total amount of wall time                        = 238.877178
-The maximum resident set size (KB)                   = 1545148
+The total amount of wall time                        = 239.370845
+The maximum resident set size (KB)                   = 1541856
 
 Test 142 control_p8_atmlnd_sbs_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/atmaero_control_p8_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/atmaero_control_p8_intel
 Checking test 143 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4808,14 +4808,14 @@ Checking test 143 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 247.945846
-The maximum resident set size (KB)                   = 2816168
+The total amount of wall time                        = 254.352473
+The maximum resident set size (KB)                   = 2815244
 
 Test 143 atmaero_control_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/atmaero_control_p8_rad_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/atmaero_control_p8_rad_intel
 Checking test 144 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4859,14 +4859,14 @@ Checking test 144 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 284.178533
-The maximum resident set size (KB)                   = 2878028
+The total amount of wall time                        = 287.336528
+The maximum resident set size (KB)                   = 2877076
 
 Test 144 atmaero_control_p8_rad_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/atmaero_control_p8_rad_micro_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/atmaero_control_p8_rad_micro_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/atmaero_control_p8_rad_micro_intel
 Checking test 145 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -4910,14 +4910,14 @@ Checking test 145 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 288.268497
-The maximum resident set size (KB)                   = 2887480
+The total amount of wall time                        = 288.484459
+The maximum resident set size (KB)                   = 2891288
 
 Test 145 atmaero_control_p8_rad_micro_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_atmaq_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_atmaq_intel
 Checking test 146 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -4933,14 +4933,14 @@ Checking test 146 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc .........OK
  Comparing RESTART/20190801.180000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 685.538203
-The maximum resident set size (KB)                   = 1257520
+The total amount of wall time                        = 682.365378
+The maximum resident set size (KB)                   = 1263044
 
 Test 146 regional_atmaq_intel PASS
 
 
 baseline dir = /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20230623/regional_atmaq_debug_intel
-working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_26513/regional_atmaq_debug_intel
+working dir  = /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_2091/regional_atmaq_debug_intel
 Checking test 147 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4954,10 +4954,12 @@ Checking test 147 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc .........OK
  Comparing RESTART/20190801.130000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1292.864519
-The maximum resident set size (KB)                   = 1296352
+The total amount of wall time                        = 1296.763529
+The maximum resident set size (KB)                   = 1297152
 
 Test 147 regional_atmaq_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
+Wed Jun 28 03:27:45 UTC 2023
+Elapsed time: 01h:10m:35s. Have a nice day!

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -4,13 +4,13 @@
 # Item 2: Compile number - must be sequential in rt.conf - use as a reference for compile failures
 # Item 3: Compiler to use in build (intel or gnu)
 # Item 4: CMAKE Options - Provide all CMAKE options for the build
-# Item 5: Machines to run on (- is used to ignore specified machines, + is used to only run on specified machines) 
-## -> EX: + hera orion gaea = compile will only run on hera orion and gaea machines 
+# Item 5: Machines to run on (- is used to ignore specified machines, + is used to only run on specified machines)
+## -> EX: + hera orion gaea = compile will only run on hera orion and gaea machines
 ## -> EX: - wcoss2 acorn = compile will NOT be run on wcoss2 or acorn
 # Item 6: [set as fv3]. Used to control the compile job only if FV3 was present, previously used to run a test w/o compiling code
 #
 # RUN Line ( Items separated by a | )
-## NOTE: The build resulting from the COMPILE line above the RUN line will be used to run the test 
+## NOTE: The build resulting from the COMPILE line above the RUN line will be used to run the test
 # Item 1: RUN - This tells rt.conf the following information is to be used in setting up a model run
 # Item 2: Test name. (Which test in the tests/tests directory should be sourced)
 # Item 3: Machines to run on (- is used to ignore specified machines, + is used to only run on specified machines).
@@ -20,11 +20,11 @@
 
 ### Intel Tests ###
 ### S2S tests ###
-COMPILE | 1 | intel | -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp | | fv3 |
+COMPILE | 1 | intel | -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | | fv3 |
 RUN | cpld_control_p8_mixedmode                         |                            | baseline |
 RUN | cpld_control_gfsv17                               |                            | baseline |
 
-COMPILE | 2 | intel | -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp | | fv3 |
+COMPILE | 2 | intel | -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | | fv3 |
 RUN | cpld_control_p8                                   |                            | baseline |
 RUN | cpld_restart_p8                                   |                            |          | cpld_control_p8
 RUN | cpld_control_qr_p8                                |                            |          |
@@ -43,7 +43,7 @@ COMPILE | 3 | intel | -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | | fv3 |
 RUN | cpld_control_noaero_p8                            |                            | baseline |
 RUN | cpld_control_nowave_noaero_p8                     |                            | baseline |
 
-COMPILE | 4 | intel | -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp | - wcoss2 acorn | fv3 |
+COMPILE | 4 | intel | -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | - wcoss2 acorn | fv3 |
 RUN | cpld_debug_p8                                     | - wcoss2 acorn             | baseline |
 
 COMPILE | 5 | intel | -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | - wcoss2 acorn | fv3 |
@@ -58,7 +58,7 @@ RUN | cpld_control_c48                                  |                       
 RUN | cpld_warmstart_c48                                |                            | baseline |
 RUN | cpld_restart_c48                                  |                            |          | cpld_warmstart_c48
 
-COMPILE | 8 | intel | -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp -DFASTER=ON | - cheyenne | fv3 |
+COMPILE | 8 | intel | -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON | - cheyenne | fv3 |
 RUN | cpld_control_p8_faster                            | - cheyenne                 | baseline |
 
 # Unstructured WW3 mesh
@@ -71,7 +71,7 @@ COMPILE | 10 | intel | -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=O
 RUN | cpld_debug_pdlib_p8                               | + hera orion cheyenne      | baseline |
 
 ### ATM tests ###
-COMPILE | 11 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON | | fv3 |
+COMPILE | 11 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON | | fv3 |
 RUN | control_flake                                     |                            | baseline |
 RUN | control_CubedSphereGrid                           |                            | baseline |
 RUN | control_CubedSphereGrid_parallel                  | - wcoss2 acorn             | baseline |
@@ -107,12 +107,12 @@ RUN | regional_netcdf_parallel                          | - acorn               
 RUN | regional_2dwrtdecomp                              |                            |          |
 RUN | regional_wofs                                     | - jet s4                   | baseline |
 
-COMPILE | 12 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DREQUIRE_IFI=ON | + acorn | fv3 |
+COMPILE | 12 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DREQUIRE_IFI=ON | + acorn | fv3 |
 RUN | regional_ifi_control                              | + acorn                    | baseline |
 RUN | regional_ifi_decomp                               | + acorn                    |          |
 RUN | regional_ifi_2threads                             | + acorn                    |          |
 
-COMPILE | 13 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_flake,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON | | fv3 |
+COMPILE | 13 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON | | fv3 |
 RUN | rap_control                                       |                            | baseline |
 RUN | regional_spp_sppt_shum_skeb                       |                            | baseline |
 RUN | rap_decomp                                        |                            |          |
@@ -138,7 +138,7 @@ RUN | rrfs_smoke_conus13km_radar_tten_warm              |                       
 # Just to make sure restart doesn't crash again:
 RUN | rrfs_conus13km_hrrr_warm_restart_mismatch         |                            | baseline | rrfs_conus13km_hrrr_warm
 
-COMPILE | 14 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp | | fv3 |
+COMPILE | 14 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras | | fv3 |
 RUN | control_csawmg                                    | - gaea.intel               | baseline |
 RUN | control_csawmgt                                   |                            | baseline |
 RUN | control_ras                                       |                            | baseline |
@@ -147,12 +147,12 @@ RUN | control_ras                                       |                       
 COMPILE | 15 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON | | fv3 |
 RUN | control_wam                                       |                            | baseline |
 
-COMPILE | 16 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0 -D32BIT=ON -DFASTER=ON | | fv3 |
+COMPILE | 16 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON | | fv3 |
 RUN | control_p8_faster                                 |                            | baseline |
 RUN | regional_control_faster                           |                            | baseline |
 
 ### DEBUG ATM tests ###
-COMPILE | 17 | intel | -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_HRRR_flake,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_HRRR,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta | | fv3 |
+COMPILE | 17 | intel | -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta | | fv3 |
 RUN | rrfs_smoke_conus13km_hrrr_warm_debug              |                            | baseline |
 RUN | rrfs_smoke_conus13km_hrrr_warm_debug_2threads     |                            |          |
 RUN | rrfs_conus13km_hrrr_warm_debug                    |                            | baseline |
@@ -187,7 +187,7 @@ COMPILE | 18 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DM
 RUN | control_wam_debug                                 |                            | baseline |
 
 ### 32-bit physics tests ###
-COMPILE | 19 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON | | fv3 |
+COMPILE | 19 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON | | fv3 |
 RUN | regional_spp_sppt_shum_skeb_dyn32_phy32           |                            | baseline |
 RUN | rap_control_dyn32_phy32                           |                            | baseline |
 RUN | hrrr_control_dyn32_phy32                          |                            | baseline |
@@ -200,11 +200,11 @@ RUN | hrrr_control_restart_dyn32_phy32                  |                       
 COMPILE | 20 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON | | fv3 |
 RUN | rap_control_dyn64_phy32                           |                            | baseline |
 
-COMPILE | 21 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON | | fv3 |
+COMPILE | 21 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON | | fv3 |
 RUN | rap_control_debug_dyn32_phy32                     |                            | baseline |
 RUN | hrrr_control_debug_dyn32_phy32                    |                            | baseline |
 
-COMPILE | 22 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -DCCPP_32BIT=ON -DDEBUG=ON | | fv3 |
+COMPILE | 22 | intel | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON | | fv3 |
 RUN | rap_control_dyn64_phy32_debug                     |                            | baseline |
 
 ### HAFS tests ###
@@ -227,10 +227,10 @@ RUN | hafs_regional_storm_following_1nest_atm_qr        | - jet s4 cheyenne     
 RUN | hafs_regional_storm_following_1nest_atm_ocn       | - jet s4                   | baseline |
 RUN | hafs_global_storm_following_1nest_atm             | - jet s4                   | baseline |
 
-COMPILE | 24 | intel | -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DDEBUG=ON | - jet s4 | fv3 |
+COMPILE | 24 | intel | -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON | - jet s4 | fv3 |
 RUN | hafs_regional_storm_following_1nest_atm_ocn_debug | - jet s4                   | baseline |
 
-COMPILE | 25 | intel | -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_thompson_noahmp_nonsst,FV3_HAFS_v1_thompson_noahmp,FV3_HAFS_v1_thompson_nonsst,FV3_HAFS_v1_thompson,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DFASTER=ON | -jet s4 | fv3 |
+COMPILE | 25 | intel | -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON | -jet s4 | fv3 |
 RUN | hafs_regional_storm_following_1nest_atm_ocn_wav   | - jet s4                   | baseline |
 
 COMPILE | 26 | intel | -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON | - wcoss2 | fv3 |
@@ -266,7 +266,7 @@ RUN | datm_cdeps_lnd_gswp3                              | - wcoss2              
 RUN | datm_cdeps_lnd_gswp3_rst                          | - wcoss2                   |          | datm_cdeps_lnd_gswp3
 
 ### ATM-LND tests, -D32BIT=ON has issue and NoahMP reuires r8 libraries ###
-COMPILE | 31 | intel | -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km | | fv3 |
+COMPILE | 31 | intel | -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km | | fv3 |
 RUN | control_p8_atmlnd_sbs                             |                            | baseline |
 
 ### ATM-WAV tests ###
@@ -355,7 +355,7 @@ RUN | control_wam_debug                                 | + hera cheyenne       
 
 
 ### 32-bit physics tests ###
-COMPILE | 42 | gnu | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_flake -D32BIT=ON -DCCPP_32BIT=ON | + hera cheyenne | fv3 |
+COMPILE | 42 | gnu | -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON | + hera cheyenne | fv3 |
 RUN | rap_control_dyn32_phy32                           | + hera cheyenne            | baseline |
 RUN | hrrr_control_dyn32_phy32                          | + hera cheyenne            | baseline |
 RUN | rap_2threads_dyn32_phy32                          | + hera cheyenne            |          |
@@ -375,13 +375,13 @@ COMPILE | 45 | gnu | -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON | + hera cheyenne | fv
 RUN | rap_control_dyn64_phy32_debug                     | + hera cheyenne            | baseline |
 
 ### S2S tests ###
-COMPILE | 46 | gnu | -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp | + hera cheyenne | fv3 |
+COMPILE | 46 | gnu | -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | + hera cheyenne | fv3 |
 RUN | cpld_control_p8                                   | + hera cheyenne            | baseline |
 
-COMPILE | 47 | gnu | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp | + hera cheyenne | fv3 |
+COMPILE | 47 | gnu | -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | + hera cheyenne | fv3 |
 RUN | cpld_control_nowave_noaero_p8                     | + hera cheyenne            | baseline |
 
-COMPILE | 48 | gnu | -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8,FV3_GFS_cpld_rasmgshocnsstnoahmp_ugwp | + hera cheyenne | fv3 |
+COMPILE | 48 | gnu | -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 | + hera cheyenne | fv3 |
 RUN | cpld_debug_p8                                     | + hera cheyenne            | baseline |
 
 # Unstructured WW3


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
This PR moves all unused ccpp suite definition files to a separate directory (suites_not_used). In FV3/ccpp/suites we currently have 101 suite definition files. Only 27 are actually used (tested). 

### Input data additions/changes
- [x] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Anticipated changes to regression tests:
- [x] No changes are expected to any regression test.
- [ ] Changes are expected to the following tests:
<!-- Please insert what RT's change and why you expect them to change -->

## Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [x] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [ ] none

### Library Updates/Changes
<!-- Library updates take time. If this PR needs updates to libraries, please make sure to accomplish the following tasks -->
- [x] Not Needed
- [ ] Create separate issue in [JCSDA/spack-stack](https://github.com/JCSDA/spack-stack) asking for update to library. Include library name, library version.
- [ ] Add issue link from JCSDA/spack-stack following this item
<!-- for example: "- JCSDA/spack-stack/issue/1757" -->

### Combined with PR's (If Applicable):

## Commit Queue Checklist:
<!-- 
Please complete all items in list. Make sure to attach logs from RT testing in comment, not in repository. Once all boxes are checked, please add the label "Ready for Commit Queue".
-->
- [x] Link PR's from all sub-components involved in section below
- [x] Confirm reviews completed in ALL sub-component PR's
- [x] Add all appropriate labels to this PR.
- [x] Run full RT suite on either Hera/Cheyenne AND attach log to a PR comment.
- [ ] Add list of any failed regression tests to "Anticipated changes to regression tests" section.

## Linked PR's and Issues:
Depends on NOAA-EMC/fv3atm/pull/665
Closes NOAA-EMC/fv3atm/issues/510

<!--
Please link dependent pull requests.
EXAMPLE: "- Depends on NOAA-EMC/fv3atm/pull/<pullrequest_number>"

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: "- Closes NOAA-EMC/fv3atm/issues/<issue_number>"

PLEASE MAKE SURE TO USE THE - with a space before the "Depends on" or "Closes" as they show up well on github.
-->

## Testing Day Checklist:
<!--
Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.
-->
- [x] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.

### Testing Log (for CM's):
- RDHPCS
  - [x] Hera
  - [x] Orion
  - [x] Jet
  - [x] Gaea
  - [x] Cheyenne
- WCOSS2
  - [x] Dogwood/Cactus
  - [x] Acorn
- CI
  - [x] Completed
- opnReqTest
  - [ ] N/A
  - [x] Log attached to comment
