### PR TITLE
WW3:  Fix Intel CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
   branch = develop
 [submodule "WW3"]
   path = WW3
-  url = https://github.com/NOAA-EMC/WW3
-  branch = dev/ufs-weather-model
+  #url = https://github.com/NOAA-EMC/WW3
+  #branch = dev/ufs-weather-model
+  url = https://github.com/MatthewMasarik-NOAA/WW3
+  branch = dev-ufs/bugfix/ci
 [submodule "stochastic_physics"]
   path = stochastic_physics
   url = https://github.com/NOAA-PSL/stochastic_physics

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
   branch = develop
 [submodule "WW3"]
   path = WW3
-  #url = https://github.com/NOAA-EMC/WW3
-  #branch = dev/ufs-weather-model
-  url = https://github.com/MatthewMasarik-NOAA/WW3
-  branch = dev-ufs/bugfix/ci
+  url = https://github.com/NOAA-EMC/WW3
+  branch = dev/ufs-weather-model
 [submodule "stochastic_physics"]
   path = stochastic_physics
   url = https://github.com/NOAA-PSL/stochastic_physics

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,74 +1,74 @@
-Fri Sep  8 07:33:39 UTC 2023
+Mon Sep 11 17:48:38 UTC 2023
 Start Regression test
 
-Testing UFSWM Hash: 2931b893c5c8b918c1ce9c31ffab55b7b633aa78
+Testing UFSWM Hash: 25af318a339cd3a91e04304f8efb002cfb4b40bb
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 ../AQM (v0.2.0-37-g37cbb7d)
  2aa6bfbb62ebeecd7da964b8074f6c3c41c7d1eb ../CDEPS-interface/CDEPS (cdeps0.4.17-38-g2aa6bfb)
  2ed3c05c3c515eb70af3a726ff392283af97c4a5 ../CICE-interface/CICE (CICE6.0.0-442-g2ed3c05)
  c24fb5999efafffaa393b886e21780ab7fd3aa08 ../CMEPS-interface/CMEPS (cmeps_v0.4.1-1404-gc24fb59)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 ../CMakeModules (v1.0.0-28-gcabd775)
- b4a691bb42f5e197ff36f97ae4a80590dd19213b ../FV3 (remotes/origin/feature/gf-spp)
+ 9b5825b7a6c0c07a3d936d0222917677209a07f0 ../FV3 (heads/develop)
  6ea78fd79037b31a1dcdd30d8a315f6558d963e4 ../GOCART (sdr_v2.1.2.6-106-g6ea78fd)
  35789c757766e07f688b4c0c7c5229816f224b09 ../HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  be40a41360b2eaed31ae86582aa57e1cf41241d5 ../MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9801-gbe40a4136)
  569e354ababbde7a7cd68647533769a5c966468d ../NOAHMP-interface/noahmp (v3.7.1-303-g569e354)
- 59c554a12df3a04e0402ce5f17bb32cbbac193b2 ../WW3 (6.07.1-341-g59c554a1)
- c0de6f80be40b3ed05bc85265190377716ea45d2 ../stochastic_physics (remotes/origin/feature/gf-spp)
-Compile atm_debug_dyn32_intel elapsed time 239 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_dyn32_debug_gnu elapsed time 165 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_dyn32_intel elapsed time 598 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atm_dyn32_phy32_debug_gnu elapsed time 168 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_dyn64_phy32_debug_gnu elapsed time 169 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_dyn64_phy32_gnu elapsed time 259 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atm_faster_dyn32_intel elapsed time 543 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atm_gnu elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atmaero_intel elapsed time 538 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atmaq_debug_intel elapsed time 188 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atmaq_faster_intel elapsed time 549 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atmaq_intel elapsed time 524 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atml_intel elapsed time 542 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile atmw_intel elapsed time 552 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+ ff2db7f07fdf39f4b26c1e56cd99d6021068a462 ../WW3 (6.07.1-342-gff2db7f0)
+ 1ee7cc9a8b5d5733b391127ca31059b497ecdea8 ../stochastic_physics (ufs-v2.0.0-181-g1ee7cc9)
+Compile atmaero_intel elapsed time 544 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atmaq_debug_intel elapsed time 186 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DDEBUG=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atmaq_faster_intel elapsed time 552 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -DFASTER=ON -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atmaq_intel elapsed time 535 seconds. -DAPP=ATMAQ -DCCPP_SUITES=FV3_GFS_v15p2 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 282 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_dyn32_debug_gnu elapsed time 161 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_dyn32_intel elapsed time 743 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km,FV3_WoFS_v0,FV3_GFS_v17_p8_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_dyn32_phy32_debug_gnu elapsed time 166 seconds. -DAPP=ATM -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_dyn64_phy32_debug_gnu elapsed time 164 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_dyn64_phy32_gnu elapsed time 262 seconds. -DAPP=ATM -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_faster_dyn32_intel elapsed time 575 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_gnu elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atml_intel elapsed time 547 seconds. -DAPP=ATML -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atmw_intel elapsed time 551 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile atmwm_intel elapsed time 557 seconds. -DAPP=ATMWM -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile csawmg_intel elapsed time 526 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile datm_cdeps_debug_intel elapsed time 107 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile datm_cdeps_faster_intel elapsed time 184 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile datm_cdeps_gnu elapsed time 113 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile datm_cdeps_intel elapsed time 183 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile datm_cdeps_land_intel elapsed time 53 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile hafs_all_intel elapsed time 585 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile hafsw_debug_intel elapsed time 196 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile hafsw_faster_intel elapsed time 598 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile csawmg_intel elapsed time 562 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_ras -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile datm_cdeps_debug_intel elapsed time 109 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile datm_cdeps_faster_intel elapsed time 185 seconds. -DAPP=NG-GODAS -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile datm_cdeps_gnu elapsed time 107 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile datm_cdeps_intel elapsed time 186 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile datm_cdeps_land_intel elapsed time 52 seconds. -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile hafs_all_intel elapsed time 570 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile hafsw_debug_intel elapsed time 203 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile hafsw_faster_intel elapsed time 601 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf_nonsst -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile hafsw_intel elapsed time 579 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v1_gfdlmp_tedmf,FV3_HAFS_v1_gfdlmp_tedmf_nonsst,FV3_HAFS_v1_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 190 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 661 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 772 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile rrfs_dyn32_phy32_gnu elapsed time 188 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 506 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 181 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 527 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_gnu elapsed time 199 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_HRRR_gf,FV3_HRRR_c3 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 564 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl,FV3_HRRR_gf,FV3_HRRR_c3 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile s2s_aoflux_intel elapsed time 576 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2s_gnu elapsed time 219 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2s_intel elapsed time 581 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2sw_debug_intel elapsed time 216 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile s2sw_intel elapsed time 614 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile rrfs_dyn32_phy32_intel elapsed time 553 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 187 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 551 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_gnu elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_HRRR_gf,FV3_HRRR_c3 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 726 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl,FV3_HRRR_gf,FV3_HRRR_c3 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile s2s_aoflux_intel elapsed time 639 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8_sfcocn -DCMEPS_AOFLUX=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2s_gnu elapsed time 218 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2s_intel elapsed time 735 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2swa_32bit_intel elapsed time 889 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2swa_debug_gnu elapsed time 125 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile s2swa_debug_intel elapsed time 358 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile s2swa_faster_intel elapsed time 1078 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2swa_gnu elapsed time 248 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2swa_intel elapsed time 944 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2sw_debug_intel elapsed time 442 seconds. -DAPP=S2SW -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile s2sw_intel elapsed time 806 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile s2sw_pdlib_debug_gnu elapsed time 117 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile s2sw_pdlib_debug_intel elapsed time 223 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile s2sw_pdlib_gnu elapsed time 234 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2sw_pdlib_intel elapsed time 889 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2swa_32bit_intel elapsed time 657 seconds. -DAPP=S2SWA -D32BIT=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2swa_debug_gnu elapsed time 129 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile s2swa_debug_intel elapsed time 246 seconds. -DAPP=S2SWA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile s2swa_faster_intel elapsed time 959 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2swa_gnu elapsed time 254 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile s2swa_intel elapsed time 667 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2sw_pdlib_debug_intel elapsed time 279 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile s2sw_pdlib_gnu elapsed time 236 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile s2sw_pdlib_intel elapsed time 984 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 Compile wam_debug_gnu elapsed time 91 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile wam_debug_intel elapsed time 175 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile wam_intel elapsed time 498 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile wam_debug_intel elapsed time 346 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile wam_intel elapsed time 556 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_mixedmode_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_p8_mixedmode_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_p8_mixedmode_intel
 Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -133,14 +133,14 @@ Checking test 001 cpld_control_p8_mixedmode_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 319.647859
-  0: The maximum resident set size (KB)                   = 3161460
+  0: The total amount of wall time                        = 486.856784
+  0: The maximum resident set size (KB)                   = 3159208
 
 Test 001 cpld_control_p8_mixedmode_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_gfsv17_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_gfsv17_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_gfsv17_intel
 Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -204,14 +204,14 @@ Checking test 002 cpld_control_gfsv17_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 219.883259
-  0: The maximum resident set size (KB)                   = 1675368
+  0: The total amount of wall time                        = 274.586038
+  0: The maximum resident set size (KB)                   = 1680264
 
 Test 002 cpld_control_gfsv17_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_p8_intel
 Checking test 003 cpld_control_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -276,14 +276,14 @@ Checking test 003 cpld_control_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 344.992958
-  0: The maximum resident set size (KB)                   = 3200792
+  0: The total amount of wall time                        = 385.615164
+  0: The maximum resident set size (KB)                   = 3194888
 
 Test 003 cpld_control_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_restart_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_restart_p8_intel
 Checking test 004 cpld_restart_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -336,14 +336,14 @@ Checking test 004 cpld_restart_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 194.945163
-  0: The maximum resident set size (KB)                   = 3253740
+  0: The total amount of wall time                        = 199.352471
+  0: The maximum resident set size (KB)                   = 3253576
 
 Test 004 cpld_restart_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_qr_p8_intel
 Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -408,14 +408,14 @@ Checking test 005 cpld_control_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 338.005174
-  0: The maximum resident set size (KB)                   = 3211572
+  0: The total amount of wall time                        = 358.155633
+  0: The maximum resident set size (KB)                   = 3210776
 
 Test 005 cpld_control_qr_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_restart_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_restart_qr_p8_intel
 Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -468,14 +468,14 @@ Checking test 006 cpld_restart_qr_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 200.470808
-  0: The maximum resident set size (KB)                   = 3093056
+  0: The total amount of wall time                        = 210.521062
+  0: The maximum resident set size (KB)                   = 3079572
 
 Test 006 cpld_restart_qr_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_2threads_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_2threads_p8_intel
 Checking test 007 cpld_2threads_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -528,14 +528,14 @@ Checking test 007 cpld_2threads_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 330.532919
-  0: The maximum resident set size (KB)                   = 3550592
+  0: The total amount of wall time                        = 338.377449
+  0: The maximum resident set size (KB)                   = 3553004
 
 Test 007 cpld_2threads_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_decomp_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_decomp_p8_intel
 Checking test 008 cpld_decomp_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -588,14 +588,14 @@ Checking test 008 cpld_decomp_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 342.589212
-  0: The maximum resident set size (KB)                   = 3190172
+  0: The total amount of wall time                        = 367.244194
+  0: The maximum resident set size (KB)                   = 3141296
 
 Test 008 cpld_decomp_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_mpi_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_mpi_p8_intel
 Checking test 009 cpld_mpi_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -648,14 +648,14 @@ Checking test 009 cpld_mpi_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 282.585219
-  0: The maximum resident set size (KB)                   = 3042444
+  0: The total amount of wall time                        = 301.326161
+  0: The maximum resident set size (KB)                   = 3056032
 
 Test 009 cpld_mpi_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_ciceC_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_ciceC_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_ciceC_p8_intel
 Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -720,14 +720,14 @@ Checking test 010 cpld_control_ciceC_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 341.596369
-  0: The maximum resident set size (KB)                   = 3199280
+  0: The total amount of wall time                        = 355.675750
+  0: The maximum resident set size (KB)                   = 3204732
 
 Test 010 cpld_control_ciceC_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_c192_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_c192_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_c192_p8_intel
 Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -780,14 +780,14 @@ Checking test 011 cpld_control_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 590.033620
-  0: The maximum resident set size (KB)                   = 3428516
+  0: The total amount of wall time                        = 593.759158
+  0: The maximum resident set size (KB)                   = 3413364
 
 Test 011 cpld_control_c192_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_c192_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_restart_c192_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_restart_c192_p8_intel
 Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing sfcf030.tile1.nc .........OK
  Comparing sfcf030.tile2.nc .........OK
@@ -840,14 +840,14 @@ Checking test 012 cpld_restart_c192_p8_intel results ....
  Comparing 20210323.120000.out_grd.ww3 .........OK
  Comparing 20210323.120000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 386.774225
-  0: The maximum resident set size (KB)                   = 3623036
+  0: The total amount of wall time                        = 394.532389
+  0: The maximum resident set size (KB)                   = 3624048
 
 Test 012 cpld_restart_c192_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_bmark_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_bmark_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_bmark_p8_intel
 Checking test 013 cpld_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -895,14 +895,14 @@ Checking test 013 cpld_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 636.778894
-   0: The maximum resident set size (KB)                   = 4102964
+   0: The total amount of wall time                        = 655.275963
+   0: The maximum resident set size (KB)                   = 4111076
 
 Test 013 cpld_bmark_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_bmark_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_restart_bmark_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_restart_bmark_p8_intel
 Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -950,14 +950,14 @@ Checking test 014 cpld_restart_bmark_p8_intel results ....
  Comparing 20130401.060000.out_pnt.ww3 .........OK
  Comparing 20130401.060000.out_grd.ww3 .........OK
 
-   0: The total amount of wall time                        = 528.294463
-   0: The maximum resident set size (KB)                   = 4358388
+   0: The total amount of wall time                        = 479.243797
+   0: The maximum resident set size (KB)                   = 4357060
 
 Test 014 cpld_restart_bmark_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_noaero_p8_intel
 Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1021,14 +1021,14 @@ Checking test 015 cpld_control_noaero_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 265.523780
-  0: The maximum resident set size (KB)                   = 1715404
+  0: The total amount of wall time                        = 374.257354
+  0: The maximum resident set size (KB)                   = 1709536
 
 Test 015 cpld_control_noaero_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_c96_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_nowave_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_nowave_noaero_p8_intel
 Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1090,14 +1090,14 @@ Checking test 016 cpld_control_nowave_noaero_p8_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 262.964650
-  0: The maximum resident set size (KB)                   = 1783324
+  0: The total amount of wall time                        = 288.082001
+  0: The maximum resident set size (KB)                   = 1766056
 
 Test 016 cpld_control_nowave_noaero_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_debug_p8_intel
 Checking test 017 cpld_debug_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1150,14 +1150,14 @@ Checking test 017 cpld_debug_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 515.605358
-  0: The maximum resident set size (KB)                   = 3236996
+  0: The total amount of wall time                        = 592.244110
+  0: The maximum resident set size (KB)                   = 3237740
 
 Test 017 cpld_debug_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_debug_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_debug_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_debug_noaero_p8_intel
 Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1209,14 +1209,14 @@ Checking test 018 cpld_debug_noaero_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 346.881015
-  0: The maximum resident set size (KB)                   = 1745524
+  0: The total amount of wall time                        = 409.384712
+  0: The maximum resident set size (KB)                   = 1714764
 
 Test 018 cpld_debug_noaero_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_noaero_p8_agrid_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_noaero_p8_agrid_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_noaero_p8_agrid_intel
 Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1278,14 +1278,14 @@ Checking test 019 cpld_control_noaero_p8_agrid_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 263.431175
-  0: The maximum resident set size (KB)                   = 1769740
+  0: The total amount of wall time                        = 278.648062
+  0: The maximum resident set size (KB)                   = 1764020
 
 Test 019 cpld_control_noaero_p8_agrid_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_c48_intel
 Checking test 020 cpld_control_c48_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1335,14 +1335,14 @@ Checking test 020 cpld_control_c48_intel results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 595.293713
- 0: The maximum resident set size (KB)                   = 2824688
+ 0: The total amount of wall time                        = 587.335205
+ 0: The maximum resident set size (KB)                   = 2823148
 
 Test 020 cpld_control_c48_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_p8_faster_intel
 Checking test 021 cpld_control_p8_faster_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1407,14 +1407,14 @@ Checking test 021 cpld_control_p8_faster_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 315.974096
-  0: The maximum resident set size (KB)                   = 3198568
+  0: The total amount of wall time                        = 338.600626
+  0: The maximum resident set size (KB)                   = 3189488
 
 Test 021 cpld_control_p8_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_pdlib_p8_intel
 Checking test 022 cpld_control_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1478,14 +1478,14 @@ Checking test 022 cpld_control_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1199.572012
-  0: The maximum resident set size (KB)                   = 1778836
+  0: The total amount of wall time                        = 1218.244409
+  0: The maximum resident set size (KB)                   = 1760260
 
 Test 022 cpld_control_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_restart_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_restart_pdlib_p8_intel
 Checking test 023 cpld_restart_pdlib_p8_intel results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -1537,14 +1537,14 @@ Checking test 023 cpld_restart_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 574.163958
-  0: The maximum resident set size (KB)                   = 1153944
+  0: The total amount of wall time                        = 559.052657
+  0: The maximum resident set size (KB)                   = 1139436
 
 Test 023 cpld_restart_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_mpi_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_mpi_pdlib_p8_intel
 Checking test 024 cpld_mpi_pdlib_p8_intel results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1608,14 +1608,14 @@ Checking test 024 cpld_mpi_pdlib_p8_intel results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1088.346696
-  0: The maximum resident set size (KB)                   = 1653044
+  0: The total amount of wall time                        = 1088.104670
+  0: The maximum resident set size (KB)                   = 1648372
 
 Test 024 cpld_mpi_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_debug_pdlib_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_debug_pdlib_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_debug_pdlib_p8_intel
 Checking test 025 cpld_debug_pdlib_p8_intel results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -1667,14 +1667,14 @@ Checking test 025 cpld_debug_pdlib_p8_intel results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1399.090050
-  0: The maximum resident set size (KB)                   = 1717820
+  0: The total amount of wall time                        = 1397.864051
+  0: The maximum resident set size (KB)                   = 1714480
 
 Test 025 cpld_debug_pdlib_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_flake_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_flake_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_flake_intel
 Checking test 026 control_flake_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1685,14 +1685,14 @@ Checking test 026 control_flake_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 187.909480
-  0: The maximum resident set size (KB)                   = 691852
+  0: The total amount of wall time                        = 197.426674
+  0: The maximum resident set size (KB)                   = 693848
 
 Test 026 control_flake_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_CubedSphereGrid_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_CubedSphereGrid_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_CubedSphereGrid_intel
 Checking test 027 control_CubedSphereGrid_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1719,16 +1719,16 @@ Checking test 027 control_CubedSphereGrid_intel results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 131.245521
-  0: The maximum resident set size (KB)                   = 638388
+  0: The total amount of wall time                        = 131.733383
+  0: The maximum resident set size (KB)                   = 639376
 
 Test 027 control_CubedSphereGrid_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_CubedSphereGrid_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_CubedSphereGrid_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_CubedSphereGrid_parallel_intel
 Checking test 028 control_CubedSphereGrid_parallel_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1741,14 +1741,14 @@ Checking test 028 control_CubedSphereGrid_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.571413
-  0: The maximum resident set size (KB)                   = 644424
+  0: The total amount of wall time                        = 139.128800
+  0: The maximum resident set size (KB)                   = 645020
 
 Test 028 control_CubedSphereGrid_parallel_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_latlon_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_latlon_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_latlon_intel
 Checking test 029 control_latlon_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1759,14 +1759,14 @@ Checking test 029 control_latlon_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 134.025848
-  0: The maximum resident set size (KB)                   = 635644
+  0: The total amount of wall time                        = 134.226518
+  0: The maximum resident set size (KB)                   = 633404
 
 Test 029 control_latlon_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_wrtGauss_netcdf_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_wrtGauss_netcdf_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_wrtGauss_netcdf_parallel_intel
 Checking test 030 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1777,14 +1777,14 @@ Checking test 030 control_wrtGauss_netcdf_parallel_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 137.767482
-  0: The maximum resident set size (KB)                   = 642648
+  0: The total amount of wall time                        = 135.019771
+  0: The maximum resident set size (KB)                   = 642124
 
 Test 030 control_wrtGauss_netcdf_parallel_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_c48_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_c48_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_c48_intel
 Checking test 031 control_c48_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1823,14 +1823,14 @@ Checking test 031 control_c48_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0: The total amount of wall time                        = 373.358187
-0: The maximum resident set size (KB)                   = 839504
+0: The total amount of wall time                        = 377.338959
+0: The maximum resident set size (KB)                   = 833160
 
 Test 031 control_c48_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_c192_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_c192_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_c192_intel
 Checking test 032 control_c192_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1841,14 +1841,14 @@ Checking test 032 control_c192_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 528.302443
-  0: The maximum resident set size (KB)                   = 784040
+  0: The total amount of wall time                        = 527.268901
+  0: The maximum resident set size (KB)                   = 785424
 
 Test 032 control_c192_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_c384_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_c384_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_c384_intel
 Checking test 033 control_c384_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1859,14 +1859,14 @@ Checking test 033 control_c384_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 527.530836
-  0: The maximum resident set size (KB)                   = 1381824
+  0: The total amount of wall time                        = 516.658607
+  0: The maximum resident set size (KB)                   = 1389852
 
 Test 033 control_c384_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_c384gdas_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_c384gdas_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_c384gdas_intel
 Checking test 034 control_c384gdas_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1909,14 +1909,14 @@ Checking test 034 control_c384gdas_intel results ....
  Comparing RESTART/20210322.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 463.261537
-  0: The maximum resident set size (KB)                   = 1485916
+  0: The total amount of wall time                        = 458.944585
+  0: The maximum resident set size (KB)                   = 1498732
 
 Test 034 control_c384gdas_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_stochy_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_stochy_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_stochy_intel
 Checking test 035 control_stochy_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1927,28 +1927,28 @@ Checking test 035 control_stochy_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 88.661022
-  0: The maximum resident set size (KB)                   = 647044
+  0: The total amount of wall time                        = 88.441697
+  0: The maximum resident set size (KB)                   = 648444
 
 Test 035 control_stochy_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_stochy_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_stochy_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_stochy_restart_intel
 Checking test 036 control_stochy_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 48.757636
-  0: The maximum resident set size (KB)                   = 556088
+  0: The total amount of wall time                        = 49.707817
+  0: The maximum resident set size (KB)                   = 553932
 
 Test 036 control_stochy_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_lndp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_lndp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_lndp_intel
 Checking test 037 control_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1959,14 +1959,14 @@ Checking test 037 control_lndp_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.968909
-  0: The maximum resident set size (KB)                   = 641844
+  0: The total amount of wall time                        = 81.678694
+  0: The maximum resident set size (KB)                   = 644852
 
 Test 037 control_lndp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_iovr4_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_iovr4_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_iovr4_intel
 Checking test 038 control_iovr4_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1981,14 +1981,14 @@ Checking test 038 control_iovr4_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.471509
-  0: The maximum resident set size (KB)                   = 639516
+  0: The total amount of wall time                        = 135.362904
+  0: The maximum resident set size (KB)                   = 647072
 
 Test 038 control_iovr4_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_iovr5_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_iovr5_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_iovr5_intel
 Checking test 039 control_iovr5_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2003,14 +2003,14 @@ Checking test 039 control_iovr5_intel results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 139.839672
-  0: The maximum resident set size (KB)                   = 645292
+  0: The total amount of wall time                        = 136.177426
+  0: The maximum resident set size (KB)                   = 641632
 
 Test 039 control_iovr5_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_p8_intel
 Checking test 040 control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2057,14 +2057,14 @@ Checking test 040 control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 170.805300
-  0: The maximum resident set size (KB)                   = 1609356
+  0: The total amount of wall time                        = 171.746127
+  0: The maximum resident set size (KB)                   = 1612096
 
 Test 040 control_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_restart_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_restart_p8_intel
 Checking test 041 control_restart_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2103,14 +2103,14 @@ Checking test 041 control_restart_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 92.599123
-  0: The maximum resident set size (KB)                   = 933132
+  0: The total amount of wall time                        = 90.240986
+  0: The maximum resident set size (KB)                   = 930364
 
 Test 041 control_restart_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_qr_p8_intel
 Checking test 042 control_qr_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2157,14 +2157,14 @@ Checking test 042 control_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 170.255938
-  0: The maximum resident set size (KB)                   = 1623312
+  0: The total amount of wall time                        = 172.857873
+  0: The maximum resident set size (KB)                   = 1614688
 
 Test 042 control_qr_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_restart_qr_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_restart_qr_p8_intel
 Checking test 043 control_restart_qr_p8_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2203,14 +2203,14 @@ Checking test 043 control_restart_qr_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 92.213087
-  0: The maximum resident set size (KB)                   = 885076
+  0: The total amount of wall time                        = 92.793138
+  0: The maximum resident set size (KB)                   = 883300
 
 Test 043 control_restart_qr_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_decomp_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_decomp_p8_intel
 Checking test 044 control_decomp_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2253,14 +2253,14 @@ Checking test 044 control_decomp_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 175.488643
-  0: The maximum resident set size (KB)                   = 1594272
+  0: The total amount of wall time                        = 179.344527
+  0: The maximum resident set size (KB)                   = 1586664
 
 Test 044 control_decomp_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_2threads_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_2threads_p8_intel
 Checking test 045 control_2threads_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2303,14 +2303,14 @@ Checking test 045 control_2threads_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 159.398011
-  0: The maximum resident set size (KB)                   = 1693960
+  0: The total amount of wall time                        = 164.688084
+  0: The maximum resident set size (KB)                   = 1695656
 
 Test 045 control_2threads_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_lndp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_p8_lndp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_p8_lndp_intel
 Checking test 046 control_p8_lndp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2329,14 +2329,14 @@ Checking test 046 control_p8_lndp_intel results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 315.205477
-  0: The maximum resident set size (KB)                   = 1607504
+  0: The total amount of wall time                        = 317.990229
+  0: The maximum resident set size (KB)                   = 1611288
 
 Test 046 control_p8_lndp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_rrtmgp_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_p8_rrtmgp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_p8_rrtmgp_intel
 Checking test 047 control_p8_rrtmgp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2383,14 +2383,14 @@ Checking test 047 control_p8_rrtmgp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 227.883734
-  0: The maximum resident set size (KB)                   = 1679696
+  0: The total amount of wall time                        = 234.126206
+  0: The maximum resident set size (KB)                   = 1656796
 
 Test 047 control_p8_rrtmgp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_mynn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_p8_mynn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_p8_mynn_intel
 Checking test 048 control_p8_mynn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2437,14 +2437,14 @@ Checking test 048 control_p8_mynn_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 172.431185
-  0: The maximum resident set size (KB)                   = 1625368
+  0: The total amount of wall time                        = 176.988259
+  0: The maximum resident set size (KB)                   = 1604660
 
 Test 048 control_p8_mynn_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/merra2_thompson_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/merra2_thompson_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/merra2_thompson_intel
 Checking test 049 merra2_thompson_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2491,14 +2491,14 @@ Checking test 049 merra2_thompson_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 193.051201
-  0: The maximum resident set size (KB)                   = 1633152
+  0: The total amount of wall time                        = 195.241845
+  0: The maximum resident set size (KB)                   = 1604120
 
 Test 049 merra2_thompson_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_control_intel
 Checking test 050 regional_control_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2509,28 +2509,28 @@ Checking test 050 regional_control_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 293.754409
-  0: The maximum resident set size (KB)                   = 1099836
+  0: The total amount of wall time                        = 293.685672
+  0: The maximum resident set size (KB)                   = 1095852
 
 Test 050 regional_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_restart_intel
 Checking test 051 regional_restart_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 153.135363
-  0: The maximum resident set size (KB)                   = 1089312
+  0: The total amount of wall time                        = 151.718416
+  0: The maximum resident set size (KB)                   = 1087548
 
 Test 051 regional_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_control_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_control_qr_intel
 Checking test 052 regional_control_qr_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2541,28 +2541,28 @@ Checking test 052 regional_control_qr_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 296.544107
-  0: The maximum resident set size (KB)                   = 1097708
+  0: The total amount of wall time                        = 293.848615
+  0: The maximum resident set size (KB)                   = 1098156
 
 Test 052 regional_control_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_restart_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_restart_qr_intel
 Checking test 053 regional_restart_qr_intel results ....
  Comparing dynf006.nc .........OK
  Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 150.431240
-  0: The maximum resident set size (KB)                   = 1091628
+  0: The total amount of wall time                        = 151.736326
+  0: The maximum resident set size (KB)                   = 1092936
 
 Test 053 regional_restart_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_decomp_intel
 Checking test 054 regional_decomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2573,14 +2573,14 @@ Checking test 054 regional_decomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 308.308720
-  0: The maximum resident set size (KB)                   = 1086056
+  0: The total amount of wall time                        = 309.275787
+  0: The maximum resident set size (KB)                   = 1084960
 
 Test 054 regional_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_2threads_intel
 Checking test 055 regional_2threads_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2591,14 +2591,14 @@ Checking test 055 regional_2threads_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 179.666506
-  0: The maximum resident set size (KB)                   = 1072852
+  0: The total amount of wall time                        = 178.772235
+  0: The maximum resident set size (KB)                   = 1082808
 
 Test 055 regional_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_noquilt_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_noquilt_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_noquilt_intel
 Checking test 056 regional_noquilt_intel results ....
  Comparing atmos_4xdaily.nc ............ALT CHECK......OK
  Comparing fv3_history2d.nc ............ALT CHECK......OK
@@ -2606,28 +2606,28 @@ Checking test 056 regional_noquilt_intel results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
-  0: The total amount of wall time                        = 292.012984
-  0: The maximum resident set size (KB)                   = 1364084
+  0: The total amount of wall time                        = 290.324794
+  0: The maximum resident set size (KB)                   = 1368172
 
 Test 056 regional_noquilt_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_netcdf_parallel_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_netcdf_parallel_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_netcdf_parallel_intel
 Checking test 057 regional_netcdf_parallel_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
- Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf000.nc .........OK
  Comparing phyf006.nc .........OK
 
-  0: The total amount of wall time                        = 293.171409
-  0: The maximum resident set size (KB)                   = 1096324
+  0: The total amount of wall time                        = 290.676262
+  0: The maximum resident set size (KB)                   = 1101680
 
 Test 057 regional_netcdf_parallel_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_2dwrtdecomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_2dwrtdecomp_intel
 Checking test 058 regional_2dwrtdecomp_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2638,14 +2638,14 @@ Checking test 058 regional_2dwrtdecomp_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 305.355964
-  0: The maximum resident set size (KB)                   = 1098756
+  0: The total amount of wall time                        = 298.068027
+  0: The maximum resident set size (KB)                   = 1098108
 
 Test 058 regional_2dwrtdecomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/fv3_regional_wofs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_wofs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_wofs_intel
 Checking test 059 regional_wofs_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -2656,14 +2656,14 @@ Checking test 059 regional_wofs_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 371.129310
-  0: The maximum resident set size (KB)                   = 915864
+  0: The total amount of wall time                        = 373.956405
+  0: The maximum resident set size (KB)                   = 922784
 
 Test 059 regional_wofs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_intel
 Checking test 060 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2710,14 +2710,14 @@ Checking test 060 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 445.968966
-  0: The maximum resident set size (KB)                   = 1235148
+  0: The total amount of wall time                        = 449.471680
+  0: The maximum resident set size (KB)                   = 1243024
 
 Test 060 rap_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_spp_sppt_shum_skeb_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_spp_sppt_shum_skeb_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_spp_sppt_shum_skeb_intel
 Checking test 061 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -2728,14 +2728,14 @@ Checking test 061 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 230.670377
-  0: The maximum resident set size (KB)                   = 1203780
+  0: The total amount of wall time                        = 231.713089
+  0: The maximum resident set size (KB)                   = 1206272
 
 Test 061 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_decomp_intel
 Checking test 062 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2782,14 +2782,14 @@ Checking test 062 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 465.038360
-  0: The maximum resident set size (KB)                   = 1168348
+  0: The total amount of wall time                        = 464.985290
+  0: The maximum resident set size (KB)                   = 1162984
 
 Test 062 rap_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_2threads_intel
 Checking test 063 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2836,14 +2836,14 @@ Checking test 063 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 416.891310
-  0: The maximum resident set size (KB)                   = 1323236
+  0: The total amount of wall time                        = 418.212614
+  0: The maximum resident set size (KB)                   = 1297564
 
 Test 063 rap_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_restart_intel
 Checking test 064 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2882,14 +2882,14 @@ Checking test 064 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 228.778261
-  0: The maximum resident set size (KB)                   = 1142280
+  0: The total amount of wall time                        = 228.444579
+  0: The maximum resident set size (KB)                   = 1143284
 
 Test 064 rap_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_sfcdiff_intel
 Checking test 065 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2936,14 +2936,14 @@ Checking test 065 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 445.006451
-  0: The maximum resident set size (KB)                   = 1237480
+  0: The total amount of wall time                        = 445.684216
+  0: The maximum resident set size (KB)                   = 1234476
 
 Test 065 rap_sfcdiff_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_sfcdiff_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_sfcdiff_decomp_intel
 Checking test 066 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2990,14 +2990,14 @@ Checking test 066 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 467.981319
-  0: The maximum resident set size (KB)                   = 1167908
+  0: The total amount of wall time                        = 470.534210
+  0: The maximum resident set size (KB)                   = 1165660
 
 Test 066 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_sfcdiff_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_sfcdiff_restart_intel
 Checking test 067 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -3036,14 +3036,14 @@ Checking test 067 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 335.775167
-  0: The maximum resident set size (KB)                   = 1169412
+  0: The total amount of wall time                        = 337.411111
+  0: The maximum resident set size (KB)                   = 1173144
 
 Test 067 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_intel
 Checking test 068 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3090,14 +3090,14 @@ Checking test 068 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 434.821597
-  0: The maximum resident set size (KB)                   = 1198304
+  0: The total amount of wall time                        = 430.609784
+  0: The maximum resident set size (KB)                   = 1184848
 
 Test 068 hrrr_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_qr_intel
 Checking test 069 hrrr_control_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3144,14 +3144,14 @@ Checking test 069 hrrr_control_qr_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 429.752279
-  0: The maximum resident set size (KB)                   = 1089832
+  0: The total amount of wall time                        = 426.043903
+  0: The maximum resident set size (KB)                   = 1078276
 
 Test 069 hrrr_control_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_decomp_intel
 Checking test 070 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3198,14 +3198,14 @@ Checking test 070 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 452.701546
-  0: The maximum resident set size (KB)                   = 1120336
+  0: The total amount of wall time                        = 446.883189
+  0: The maximum resident set size (KB)                   = 1116600
 
 Test 070 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_2threads_intel
 Checking test 071 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3252,42 +3252,42 @@ Checking test 071 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 400.608482
-  0: The maximum resident set size (KB)                   = 1136984
+  0: The total amount of wall time                        = 396.274862
+  0: The maximum resident set size (KB)                   = 1135156
 
 Test 071 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_intel
 Checking test 072 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 320.351754
-  0: The maximum resident set size (KB)                   = 1111356
+  0: The total amount of wall time                        = 322.007451
+  0: The maximum resident set size (KB)                   = 1114416
 
 Test 072 hrrr_control_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_qr_intel
 Checking test 073 hrrr_control_restart_qr_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 323.249599
-  0: The maximum resident set size (KB)                   = 1029376
+  0: The total amount of wall time                        = 323.564053
+  0: The maximum resident set size (KB)                   = 1013708
 
 Test 073 hrrr_control_restart_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rrfs_v1beta_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rrfs_v1beta_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rrfs_v1beta_intel
 Checking test 074 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3334,14 +3334,14 @@ Checking test 074 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 439.466742
-  0: The maximum resident set size (KB)                   = 1204684
+  0: The total amount of wall time                        = 438.575715
+  0: The maximum resident set size (KB)                   = 1210112
 
 Test 074 rrfs_v1beta_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rrfs_v1nssl_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rrfs_v1nssl_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rrfs_v1nssl_intel
 Checking test 075 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3356,14 +3356,14 @@ Checking test 075 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 521.428456
-  0: The maximum resident set size (KB)                   = 809808
+  0: The total amount of wall time                        = 520.002214
+  0: The maximum resident set size (KB)                   = 797416
 
 Test 075 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rrfs_v1nssl_nohailnoccn_intel
 Checking test 076 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3378,14 +3378,14 @@ Checking test 076 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 511.674812
-  0: The maximum resident set size (KB)                   = 914484
+  0: The total amount of wall time                        = 508.846006
+  0: The maximum resident set size (KB)                   = 911956
 
 Test 076 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_gf_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_gf_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_gf_intel
 Checking test 077 hrrr_gf_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3432,14 +3432,14 @@ Checking test 077 hrrr_gf_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 453.346815
-  0: The maximum resident set size (KB)                   = 1235736
+  0: The total amount of wall time                        = 445.745340
+  0: The maximum resident set size (KB)                   = 1236688
 
 Test 077 hrrr_gf_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_c3_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_c3_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_c3_intel
 Checking test 078 hrrr_c3_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -3486,14 +3486,14 @@ Checking test 078 hrrr_c3_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 451.920686
-  0: The maximum resident set size (KB)                   = 1233196
+  0: The total amount of wall time                        = 446.839047
+  0: The maximum resident set size (KB)                   = 1228324
 
 Test 078 hrrr_c3_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_csawmg_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_csawmg_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_csawmg_intel
 Checking test 079 control_csawmg_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3504,14 +3504,14 @@ Checking test 079 control_csawmg_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 350.509081
-  0: The maximum resident set size (KB)                   = 806844
+  0: The total amount of wall time                        = 362.928409
+  0: The maximum resident set size (KB)                   = 819812
 
 Test 079 control_csawmg_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_csawmgt_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_csawmgt_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_csawmgt_intel
 Checking test 080 control_csawmgt_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3522,14 +3522,14 @@ Checking test 080 control_csawmgt_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 339.477658
-  0: The maximum resident set size (KB)                   = 810104
+  0: The total amount of wall time                        = 350.491522
+  0: The maximum resident set size (KB)                   = 820008
 
 Test 080 control_csawmgt_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_ras_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_ras_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_ras_intel
 Checking test 081 control_ras_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3540,26 +3540,26 @@ Checking test 081 control_ras_intel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 188.137129
-  0: The maximum resident set size (KB)                   = 810520
+  0: The total amount of wall time                        = 194.391563
+  0: The maximum resident set size (KB)                   = 823952
 
 Test 081 control_ras_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_wam_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_wam_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_wam_intel
 Checking test 082 control_wam_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 112.182122
-  0: The maximum resident set size (KB)                   = 704396
+  0: The total amount of wall time                        = 135.351640
+  0: The maximum resident set size (KB)                   = 696008
 
 Test 082 control_wam_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_p8_faster_intel
 Checking test 083 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -3606,14 +3606,14 @@ Checking test 083 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 156.505669
-  0: The maximum resident set size (KB)                   = 1611304
+  0: The total amount of wall time                        = 154.540614
+  0: The maximum resident set size (KB)                   = 1611460
 
 Test 083 control_p8_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_control_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_control_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_control_faster_intel
 Checking test 084 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -3624,14 +3624,14 @@ Checking test 084 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 267.191348
-  0: The maximum resident set size (KB)                   = 1089948
+  0: The total amount of wall time                        = 268.434963
+  0: The maximum resident set size (KB)                   = 1091216
 
 Test 084 regional_control_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_CubedSphereGrid_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_CubedSphereGrid_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_CubedSphereGrid_debug_intel
 Checking test 085 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -3658,348 +3658,348 @@ Checking test 085 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 144.579727
-  0: The maximum resident set size (KB)                   = 800032
+  0: The total amount of wall time                        = 174.339293
+  0: The maximum resident set size (KB)                   = 797632
 
 Test 085 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 086 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 143.543474
-  0: The maximum resident set size (KB)                   = 802488
+  0: The total amount of wall time                        = 155.508408
+  0: The maximum resident set size (KB)                   = 802720
 
 Test 086 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_stochy_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_stochy_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_stochy_debug_intel
 Checking test 087 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.059495
-  0: The maximum resident set size (KB)                   = 807040
+  0: The total amount of wall time                        = 170.716174
+  0: The maximum resident set size (KB)                   = 809356
 
 Test 087 control_stochy_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_lndp_debug_intel
 Checking test 088 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.177132
-  0: The maximum resident set size (KB)                   = 810208
+  0: The total amount of wall time                        = 149.164304
+  0: The maximum resident set size (KB)                   = 803712
 
 Test 088 control_lndp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_csawmg_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_csawmg_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_csawmg_debug_intel
 Checking test 089 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.181276
-  0: The maximum resident set size (KB)                   = 849556
+  0: The total amount of wall time                        = 231.801374
+  0: The maximum resident set size (KB)                   = 849504
 
 Test 089 control_csawmg_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_csawmgt_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_csawmgt_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_csawmgt_debug_intel
 Checking test 090 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 220.577727
-  0: The maximum resident set size (KB)                   = 850180
+  0: The total amount of wall time                        = 226.151094
+  0: The maximum resident set size (KB)                   = 849236
 
 Test 090 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_ras_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_ras_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_ras_debug_intel
 Checking test 091 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.015761
-  0: The maximum resident set size (KB)                   = 817652
+  0: The total amount of wall time                        = 151.679452
+  0: The maximum resident set size (KB)                   = 809776
 
 Test 091 control_ras_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_diag_debug_intel
 Checking test 092 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.564094
-  0: The maximum resident set size (KB)                   = 858488
+  0: The total amount of wall time                        = 151.704191
+  0: The maximum resident set size (KB)                   = 852952
 
 Test 092 control_diag_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_debug_p8_intel
 Checking test 093 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.004417
-  0: The maximum resident set size (KB)                   = 1617548
+  0: The total amount of wall time                        = 177.266357
+  0: The maximum resident set size (KB)                   = 1594576
 
 Test 093 control_debug_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_debug_intel
 Checking test 094 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 992.883872
-  0: The maximum resident set size (KB)                   = 1110184
+  0: The total amount of wall time                        = 983.463403
+  0: The maximum resident set size (KB)                   = 1111592
 
 Test 094 regional_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_debug_intel
 Checking test 095 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 267.137747
-  0: The maximum resident set size (KB)                   = 1182868
+  0: The total amount of wall time                        = 270.275523
+  0: The maximum resident set size (KB)                   = 1192824
 
 Test 095 rap_control_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_debug_intel
 Checking test 096 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.238002
-  0: The maximum resident set size (KB)                   = 1181968
+  0: The total amount of wall time                        = 268.638898
+  0: The maximum resident set size (KB)                   = 1181408
 
 Test 096 hrrr_control_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_unified_drag_suite_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_unified_drag_suite_debug_intel
 Checking test 097 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.736338
-  0: The maximum resident set size (KB)                   = 1185256
+  0: The total amount of wall time                        = 275.455076
+  0: The maximum resident set size (KB)                   = 1182020
 
 Test 097 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_diag_debug_intel
 Checking test 098 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 295.590765
-  0: The maximum resident set size (KB)                   = 1269260
+  0: The total amount of wall time                        = 281.162264
+  0: The maximum resident set size (KB)                   = 1272764
 
 Test 098 rap_diag_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_cires_ugwp_debug_intel
 Checking test 099 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.504251
-  0: The maximum resident set size (KB)                   = 1193976
+  0: The total amount of wall time                        = 291.944874
+  0: The maximum resident set size (KB)                   = 1190364
 
 Test 099 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_unified_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_unified_ugwp_debug_intel
 Checking test 100 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.588470
-  0: The maximum resident set size (KB)                   = 1185836
+  0: The total amount of wall time                        = 291.564937
+  0: The maximum resident set size (KB)                   = 1187424
 
 Test 100 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_lndp_debug_intel
 Checking test 101 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.230800
-  0: The maximum resident set size (KB)                   = 1193832
+  0: The total amount of wall time                        = 291.073291
+  0: The maximum resident set size (KB)                   = 1183404
 
 Test 101 rap_lndp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_progcld_thompson_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_progcld_thompson_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_progcld_thompson_debug_intel
 Checking test 102 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 271.288321
-  0: The maximum resident set size (KB)                   = 1189072
+  0: The total amount of wall time                        = 290.674643
+  0: The maximum resident set size (KB)                   = 1186436
 
 Test 102 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_noah_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_noah_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_noah_debug_intel
 Checking test 103 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 269.225197
-  0: The maximum resident set size (KB)                   = 1186984
+  0: The total amount of wall time                        = 266.474969
+  0: The maximum resident set size (KB)                   = 1193568
 
 Test 103 rap_noah_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_sfcdiff_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_sfcdiff_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_sfcdiff_debug_intel
 Checking test 104 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.894780
-  0: The maximum resident set size (KB)                   = 1195296
+  0: The total amount of wall time                        = 277.732601
+  0: The maximum resident set size (KB)                   = 1185788
 
 Test 104 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 446.625487
-  0: The maximum resident set size (KB)                   = 1169764
+  0: The total amount of wall time                        = 453.321769
+  0: The maximum resident set size (KB)                   = 1178244
 
 Test 105 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rrfs_v1beta_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rrfs_v1beta_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rrfs_v1beta_debug_intel
 Checking test 106 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.982592
-  0: The maximum resident set size (KB)                   = 1182160
+  0: The total amount of wall time                        = 269.676546
+  0: The maximum resident set size (KB)                   = 1177320
 
 Test 106 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_clm_lake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_clm_lake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_clm_lake_debug_intel
 Checking test 107 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 327.150806
-  0: The maximum resident set size (KB)                   = 1191996
+  0: The total amount of wall time                        = 330.254071
+  0: The maximum resident set size (KB)                   = 1192768
 
 Test 107 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_flake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_flake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_flake_debug_intel
 Checking test 108 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.256859
-  0: The maximum resident set size (KB)                   = 1191668
+  0: The total amount of wall time                        = 272.924602
+  0: The maximum resident set size (KB)                   = 1190140
 
 Test 108 rap_flake_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_wam_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_wam_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_wam_debug_intel
 Checking test 109 control_wam_debug_intel results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 278.598481
-  0: The maximum resident set size (KB)                   = 585752
+  0: The total amount of wall time                        = 272.370909
+  0: The maximum resident set size (KB)                   = 593032
 
 Test 109 control_wam_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -4010,14 +4010,14 @@ Checking test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 217.112274
-  0: The maximum resident set size (KB)                   = 1109728
+  0: The total amount of wall time                        = 212.973845
+  0: The maximum resident set size (KB)                   = 1103648
 
 Test 110 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_dyn32_phy32_intel
 Checking test 111 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4064,14 +4064,14 @@ Checking test 111 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 373.570887
-  0: The maximum resident set size (KB)                   = 1111336
+  0: The total amount of wall time                        = 371.660263
+  0: The maximum resident set size (KB)                   = 1111280
 
 Test 111 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_dyn32_phy32_intel
 Checking test 112 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4118,14 +4118,14 @@ Checking test 112 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 194.233879
-  0: The maximum resident set size (KB)                   = 1035320
+  0: The total amount of wall time                        = 192.242203
+  0: The maximum resident set size (KB)                   = 1039980
 
 Test 112 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_qr_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_qr_dyn32_phy32_intel
 Checking test 113 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4172,14 +4172,14 @@ Checking test 113 hrrr_control_qr_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 192.851063
-  0: The maximum resident set size (KB)                   = 983576
+  0: The total amount of wall time                        = 190.351374
+  0: The maximum resident set size (KB)                   = 995216
 
 Test 113 hrrr_control_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_2threads_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_2threads_dyn32_phy32_intel
 Checking test 114 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4226,14 +4226,14 @@ Checking test 114 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 347.641527
-  0: The maximum resident set size (KB)                   = 1126024
+  0: The total amount of wall time                        = 346.143294
+  0: The maximum resident set size (KB)                   = 1128756
 
 Test 114 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 115 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4280,14 +4280,14 @@ Checking test 115 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 176.267302
-  0: The maximum resident set size (KB)                   = 974032
+  0: The total amount of wall time                        = 175.375626
+  0: The maximum resident set size (KB)                   = 976592
 
 Test 115 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 116 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4334,14 +4334,14 @@ Checking test 116 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 199.665401
-  0: The maximum resident set size (KB)                   = 978452
+  0: The total amount of wall time                        = 200.238531
+  0: The maximum resident set size (KB)                   = 968956
 
 Test 116 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_restart_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_restart_dyn32_phy32_intel
 Checking test 117 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -4380,42 +4380,42 @@ Checking test 117 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 275.047347
-  0: The maximum resident set size (KB)                   = 1058176
+  0: The total amount of wall time                        = 275.255382
+  0: The maximum resident set size (KB)                   = 1056640
 
 Test 117 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_dyn32_phy32_intel
 Checking test 118 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 98.980848
-  0: The maximum resident set size (KB)                   = 942160
+  0: The total amount of wall time                        = 100.234407
+  0: The maximum resident set size (KB)                   = 927732
 
 Test 118 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_qr_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_qr_dyn32_phy32_intel
 Checking test 119 hrrr_control_restart_qr_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 102.344947
-  0: The maximum resident set size (KB)                   = 893384
+  0: The total amount of wall time                        = 101.925090
+  0: The maximum resident set size (KB)                   = 879200
 
 Test 119 hrrr_control_restart_qr_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_control_intel
 Checking test 120 conus13km_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -4431,40 +4431,40 @@ Checking test 120 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 113.211275
-  0: The maximum resident set size (KB)                   = 1252640
+  0: The total amount of wall time                        = 113.319344
+  0: The maximum resident set size (KB)                   = 1254476
 
 Test 120 conus13km_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_2threads_intel
 Checking test 121 conus13km_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 45.560835
-  0: The maximum resident set size (KB)                   = 1170316
+  0: The total amount of wall time                        = 44.615043
+  0: The maximum resident set size (KB)                   = 1169908
 
 Test 121 conus13km_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_restart_mismatch_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_restart_mismatch_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_restart_mismatch_intel
 Checking test 122 conus13km_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 64.115022
-  0: The maximum resident set size (KB)                   = 1184956
+  0: The total amount of wall time                        = 62.965623
+  0: The maximum resident set size (KB)                   = 1182856
 
 Test 122 conus13km_restart_mismatch_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_dyn64_phy32_intel
 Checking test 123 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -4511,123 +4511,123 @@ Checking test 123 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 242.855530
-  0: The maximum resident set size (KB)                   = 1099860
+  0: The total amount of wall time                        = 243.070864
+  0: The maximum resident set size (KB)                   = 1101888
 
 Test 123 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_debug_dyn32_phy32_intel
 Checking test 124 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.654823
-  0: The maximum resident set size (KB)                   = 1063288
+  0: The total amount of wall time                        = 268.208989
+  0: The maximum resident set size (KB)                   = 1065240
 
 Test 124 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_debug_dyn32_phy32_intel
 Checking test 125 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 262.133780
-  0: The maximum resident set size (KB)                   = 1065168
+  0: The total amount of wall time                        = 261.843917
+  0: The maximum resident set size (KB)                   = 1069452
 
 Test 125 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_debug_intel
 Checking test 126 conus13km_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 844.014558
-  0: The maximum resident set size (KB)                   = 1268184
+  0: The total amount of wall time                        = 825.865380
+  0: The maximum resident set size (KB)                   = 1279200
 
 Test 126 conus13km_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_debug_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_debug_2threads_intel
 Checking test 127 conus13km_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 466.262558
-  0: The maximum resident set size (KB)                   = 1200352
+  0: The total amount of wall time                        = 463.507629
+  0: The maximum resident set size (KB)                   = 1202780
 
 Test 127 conus13km_debug_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_radar_tten_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_radar_tten_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_radar_tten_debug_intel
 Checking test 128 conus13km_radar_tten_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 849.348154
-  0: The maximum resident set size (KB)                   = 1341892
+  0: The total amount of wall time                        = 804.242420
+  0: The maximum resident set size (KB)                   = 1338968
 
 Test 128 conus13km_radar_tten_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_debug_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_dyn64_phy32_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_dyn64_phy32_debug_intel
 Checking test 129 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 275.882546
-  0: The maximum resident set size (KB)                   = 1110324
+  0: The total amount of wall time                        = 273.934883
+  0: The maximum resident set size (KB)                   = 1107056
 
 Test 129 rap_control_dyn64_phy32_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_atm_intel
 Checking test 130 hafs_regional_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 219.643161
-  0: The maximum resident set size (KB)                   = 1242188
+  0: The total amount of wall time                        = 215.063571
+  0: The maximum resident set size (KB)                   = 1241520
 
 Test 130 hafs_regional_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_atm_thompson_gfdlsf_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_atm_thompson_gfdlsf_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_atm_thompson_gfdlsf_intel
 Checking test 131 hafs_regional_atm_thompson_gfdlsf_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 349.566344
-  0: The maximum resident set size (KB)                   = 1579328
+  0: The total amount of wall time                        = 317.347869
+  0: The maximum resident set size (KB)                   = 1573968
 
 Test 131 hafs_regional_atm_thompson_gfdlsf_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_atm_ocn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_atm_ocn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_atm_ocn_intel
 Checking test 132 hafs_regional_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4636,14 +4636,14 @@ Checking test 132 hafs_regional_atm_ocn_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 373.530162
-  0: The maximum resident set size (KB)                   = 1412684
+  0: The total amount of wall time                        = 368.969651
+  0: The maximum resident set size (KB)                   = 1418060
 
 Test 132 hafs_regional_atm_ocn_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_atm_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_atm_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_atm_wav_intel
 Checking test 133 hafs_regional_atm_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4652,14 +4652,14 @@ Checking test 133 hafs_regional_atm_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 745.045283
-  0: The maximum resident set size (KB)                   = 1434356
+  0: The total amount of wall time                        = 741.061530
+  0: The maximum resident set size (KB)                   = 1446140
 
 Test 133 hafs_regional_atm_wav_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_atm_ocn_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_atm_ocn_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_atm_ocn_wav_intel
 Checking test 134 hafs_regional_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4670,14 +4670,14 @@ Checking test 134 hafs_regional_atm_ocn_wav_intel results ....
  Comparing ufs.hafs.ww3.r.2019-08-29-21600 .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 845.327704
-  0: The maximum resident set size (KB)                   = 1470564
+  0: The total amount of wall time                        = 840.498437
+  0: The maximum resident set size (KB)                   = 1459116
 
 Test 134 hafs_regional_atm_ocn_wav_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_1nest_atm_intel
 Checking test 135 hafs_regional_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4699,14 +4699,14 @@ Checking test 135 hafs_regional_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 294.250283
-  0: The maximum resident set size (KB)                   = 651424
+  0: The total amount of wall time                        = 294.915629
+  0: The maximum resident set size (KB)                   = 654356
 
 Test 135 hafs_regional_1nest_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_1nest_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_1nest_atm_qr_intel
 Checking test 136 hafs_regional_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4728,14 +4728,14 @@ Checking test 136 hafs_regional_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 312.695330
-  0: The maximum resident set size (KB)                   = 498412
+  0: The total amount of wall time                        = 305.053238
+  0: The maximum resident set size (KB)                   = 497740
 
 Test 136 hafs_regional_1nest_atm_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_telescopic_2nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_telescopic_2nests_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_telescopic_2nests_atm_intel
 Checking test 137 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4744,14 +4744,14 @@ Checking test 137 hafs_regional_telescopic_2nests_atm_intel results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 342.568989
-  0: The maximum resident set size (KB)                   = 661972
+  0: The total amount of wall time                        = 339.512129
+  0: The maximum resident set size (KB)                   = 667256
 
 Test 137 hafs_regional_telescopic_2nests_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_global_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_global_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_global_1nest_atm_intel
 Checking test 138 hafs_global_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4798,14 +4798,14 @@ Checking test 138 hafs_global_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 136.700349
-  0: The maximum resident set size (KB)                   = 399312
+  0: The total amount of wall time                        = 136.249048
+  0: The maximum resident set size (KB)                   = 400600
 
 Test 138 hafs_global_1nest_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_global_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_global_1nest_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_global_1nest_atm_qr_intel
 Checking test 139 hafs_global_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4852,14 +4852,14 @@ Checking test 139 hafs_global_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 142.591565
-  0: The maximum resident set size (KB)                   = 370496
+  0: The total amount of wall time                        = 141.152846
+  0: The maximum resident set size (KB)                   = 369996
 
 Test 139 hafs_global_1nest_atm_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_global_multiple_4nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_global_multiple_4nests_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_global_multiple_4nests_atm_intel
 Checking test 140 hafs_global_multiple_4nests_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -4941,14 +4941,14 @@ Checking test 140 hafs_global_multiple_4nests_atm_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 382.583560
-  0: The maximum resident set size (KB)                   = 472920
+  0: The total amount of wall time                        = 377.210304
+  0: The maximum resident set size (KB)                   = 479848
 
 Test 140 hafs_global_multiple_4nests_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_global_multiple_4nests_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_global_multiple_4nests_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_global_multiple_4nests_atm_qr_intel
 Checking test 141 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5030,14 +5030,14 @@ Checking test 141 hafs_global_multiple_4nests_atm_qr_intel results ....
  Comparing RESTART/fv_BC_sw.res.nest04.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest05.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 408.351940
-  0: The maximum resident set size (KB)                   = 476284
+  0: The total amount of wall time                        = 408.989333
+  0: The maximum resident set size (KB)                   = 467000
 
 Test 141 hafs_global_multiple_4nests_atm_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_specified_moving_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_specified_moving_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_specified_moving_1nest_atm_intel
 Checking test 142 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5046,14 +5046,14 @@ Checking test 142 hafs_regional_specified_moving_1nest_atm_intel results ....
  Comparing HURPRS.GrbF06 .........OK
  Comparing HURPRS.GrbF06.nest02 .........OK
 
-  0: The total amount of wall time                        = 191.500977
-  0: The maximum resident set size (KB)                   = 673420
+  0: The total amount of wall time                        = 190.358036
+  0: The maximum resident set size (KB)                   = 670364
 
 Test 142 hafs_regional_specified_moving_1nest_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_storm_following_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_storm_following_1nest_atm_intel
 Checking test 143 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5075,14 +5075,14 @@ Checking test 143 hafs_regional_storm_following_1nest_atm_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 178.875058
-  0: The maximum resident set size (KB)                   = 669464
+  0: The total amount of wall time                        = 177.619748
+  0: The maximum resident set size (KB)                   = 673456
 
 Test 143 hafs_regional_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_storm_following_1nest_atm_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_storm_following_1nest_atm_qr_intel
 Checking test 144 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5104,14 +5104,14 @@ Checking test 144 hafs_regional_storm_following_1nest_atm_qr_intel results ....
  Comparing RESTART/fv_BC_ne.res.nest02.nc ............ALT CHECK......OK
  Comparing RESTART/fv_BC_sw.res.nest02.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 197.093920
-  0: The maximum resident set size (KB)                   = 534308
+  0: The total amount of wall time                        = 192.099927
+  0: The maximum resident set size (KB)                   = 531908
 
 Test 144 hafs_regional_storm_following_1nest_atm_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_storm_following_1nest_atm_ocn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_storm_following_1nest_atm_ocn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_storm_following_1nest_atm_ocn_intel
 Checking test 145 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5120,42 +5120,42 @@ Checking test 145 hafs_regional_storm_following_1nest_atm_ocn_intel results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 219.005380
-  0: The maximum resident set size (KB)                   = 716392
+  0: The total amount of wall time                        = 219.051823
+  0: The maximum resident set size (KB)                   = 717412
 
 Test 145 hafs_regional_storm_following_1nest_atm_ocn_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_global_storm_following_1nest_atm_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_global_storm_following_1nest_atm_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_global_storm_following_1nest_atm_intel
 Checking test 146 hafs_global_storm_following_1nest_atm_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 54.393707
-  0: The maximum resident set size (KB)                   = 415796
+  0: The total amount of wall time                        = 54.169129
+  0: The maximum resident set size (KB)                   = 415664
 
 Test 146 hafs_global_storm_following_1nest_atm_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_storm_following_1nest_atm_ocn_debug_intel
 Checking test 147 hafs_regional_storm_following_1nest_atm_ocn_debug_intel results ....
  Comparing atmf001.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atm.nest02.f001.nc .........OK
  Comparing sfc.nest02.f001.nc .........OK
 
-  0: The total amount of wall time                        = 711.595242
-  0: The maximum resident set size (KB)                   = 731324
+  0: The total amount of wall time                        = 715.339731
+  0: The maximum resident set size (KB)                   = 726140
 
 Test 147 hafs_regional_storm_following_1nest_atm_ocn_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_storm_following_1nest_atm_ocn_wav_intel
 Checking test 148 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5166,14 +5166,14 @@ Checking test 148 hafs_regional_storm_following_1nest_atm_ocn_wav_intel results 
  Comparing 20200825.180000.out_grd.ww3 .........OK
  Comparing 20200825.180000.out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 478.193051
-  0: The maximum resident set size (KB)                   = 804696
+  0: The total amount of wall time                        = 475.323573
+  0: The maximum resident set size (KB)                   = 806196
 
 Test 148 hafs_regional_storm_following_1nest_atm_ocn_wav_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_docn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_docn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_docn_intel
 Checking test 149 hafs_regional_docn_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5181,14 +5181,14 @@ Checking test 149 hafs_regional_docn_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 335.569686
-  0: The maximum resident set size (KB)                   = 1399392
+  0: The total amount of wall time                        = 335.508816
+  0: The maximum resident set size (KB)                   = 1416096
 
 Test 149 hafs_regional_docn_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_docn_oisst_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_docn_oisst_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_docn_oisst_intel
 Checking test 150 hafs_regional_docn_oisst_intel results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -5196,131 +5196,131 @@ Checking test 150 hafs_regional_docn_oisst_intel results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 337.084125
-  0: The maximum resident set size (KB)                   = 1398712
+  0: The total amount of wall time                        = 334.281748
+  0: The maximum resident set size (KB)                   = 1385624
 
 Test 150 hafs_regional_docn_oisst_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hafs_regional_datm_cdeps_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hafs_regional_datm_cdeps_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hafs_regional_datm_cdeps_intel
 Checking test 151 hafs_regional_datm_cdeps_intel results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 963.493007
-  0: The maximum resident set size (KB)                   = 1155140
+  0: The total amount of wall time                        = 970.186099
+  0: The maximum resident set size (KB)                   = 1150900
 
 Test 151 hafs_regional_datm_cdeps_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_control_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_control_cfsr_intel
 Checking test 152 datm_cdeps_control_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 155.739391
- 0: The maximum resident set size (KB)                   = 1110340
+ 0: The total amount of wall time                        = 156.707916
+ 0: The maximum resident set size (KB)                   = 1112020
 
 Test 152 datm_cdeps_control_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_restart_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_restart_cfsr_intel
 Checking test 153 datm_cdeps_restart_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 92.699181
- 0: The maximum resident set size (KB)                   = 1068944
+ 0: The total amount of wall time                        = 92.018435
+ 0: The maximum resident set size (KB)                   = 1073432
 
 Test 153 datm_cdeps_restart_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_control_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_control_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_control_gefs_intel
 Checking test 154 datm_cdeps_control_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 149.378425
- 0: The maximum resident set size (KB)                   = 1000664
+ 0: The total amount of wall time                        = 149.498913
+ 0: The maximum resident set size (KB)                   = 996520
 
 Test 154 datm_cdeps_control_gefs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_iau_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_iau_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_iau_gefs_intel
 Checking test 155 datm_cdeps_iau_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 148.100403
- 0: The maximum resident set size (KB)                   = 1003472
+ 0: The total amount of wall time                        = 152.986072
+ 0: The maximum resident set size (KB)                   = 991364
 
 Test 155 datm_cdeps_iau_gefs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_stochy_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_stochy_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_stochy_gefs_intel
 Checking test 156 datm_cdeps_stochy_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 150.479189
- 0: The maximum resident set size (KB)                   = 1006564
+ 0: The total amount of wall time                        = 153.119200
+ 0: The maximum resident set size (KB)                   = 994736
 
 Test 156 datm_cdeps_stochy_gefs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_ciceC_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_ciceC_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_ciceC_cfsr_intel
 Checking test 157 datm_cdeps_ciceC_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.727039
- 0: The maximum resident set size (KB)                   = 1116336
+ 0: The total amount of wall time                        = 151.612349
+ 0: The maximum resident set size (KB)                   = 1113696
 
 Test 157 datm_cdeps_ciceC_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_bulk_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_bulk_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_bulk_cfsr_intel
 Checking test 158 datm_cdeps_bulk_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 154.216533
- 0: The maximum resident set size (KB)                   = 1110360
+ 0: The total amount of wall time                        = 152.771115
+ 0: The maximum resident set size (KB)                   = 1121188
 
 Test 158 datm_cdeps_bulk_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_bulk_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_bulk_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_bulk_gefs_intel
 Checking test 159 datm_cdeps_bulk_gefs_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 146.965744
- 0: The maximum resident set size (KB)                   = 1010832
+ 0: The total amount of wall time                        = 148.077663
+ 0: The maximum resident set size (KB)                   = 1006108
 
 Test 159 datm_cdeps_bulk_gefs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_mx025_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_mx025_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_mx025_cfsr_intel
 Checking test 160 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -5329,14 +5329,14 @@ Checking test 160 datm_cdeps_mx025_cfsr_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 412.063982
-  0: The maximum resident set size (KB)                   = 1042340
+  0: The total amount of wall time                        = 431.524999
+  0: The maximum resident set size (KB)                   = 1031836
 
 Test 160 datm_cdeps_mx025_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_mx025_gefs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_mx025_gefs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_mx025_gefs_intel
 Checking test 161 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/20111001.120000.MOM.res.nc .........OK
  Comparing RESTART/20111001.120000.MOM.res_1.nc .........OK
@@ -5345,77 +5345,77 @@ Checking test 161 datm_cdeps_mx025_gefs_intel results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS_NEW.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 409.188359
-  0: The maximum resident set size (KB)                   = 1014528
+  0: The total amount of wall time                        = 423.249913
+  0: The maximum resident set size (KB)                   = 1015784
 
 Test 161 datm_cdeps_mx025_gefs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_control_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_multiple_files_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_multiple_files_cfsr_intel
 Checking test 162 datm_cdeps_multiple_files_cfsr_intel results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 153.526721
- 0: The maximum resident set size (KB)                   = 1102636
+ 0: The total amount of wall time                        = 156.840582
+ 0: The maximum resident set size (KB)                   = 1108632
 
 Test 162 datm_cdeps_multiple_files_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_3072x1536_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_3072x1536_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_3072x1536_cfsr_intel
 Checking test 163 datm_cdeps_3072x1536_cfsr_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 233.529757
- 0: The maximum resident set size (KB)                   = 2461472
+ 0: The total amount of wall time                        = 224.982089
+ 0: The maximum resident set size (KB)                   = 2470068
 
 Test 163 datm_cdeps_3072x1536_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_gfs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_gfs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_gfs_intel
 Checking test 164 datm_cdeps_gfs_intel results ....
  Comparing RESTART/20210323.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 227.644074
- 0: The maximum resident set size (KB)                   = 2458900
+ 0: The total amount of wall time                        = 233.405048
+ 0: The maximum resident set size (KB)                   = 2395420
 
 Test 164 datm_cdeps_gfs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_debug_cfsr_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_debug_cfsr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_debug_cfsr_intel
 Checking test 165 datm_cdeps_debug_cfsr_intel results ....
  Comparing RESTART/20111001.060000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 363.582632
- 0: The maximum resident set size (KB)                   = 1032808
+ 0: The total amount of wall time                        = 365.056598
+ 0: The maximum resident set size (KB)                   = 1029736
 
 Test 165 datm_cdeps_debug_cfsr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_control_cfsr_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_control_cfsr_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_control_cfsr_faster_intel
 Checking test 166 datm_cdeps_control_cfsr_faster_intel results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 156.085763
- 0: The maximum resident set size (KB)                   = 1110232
+ 0: The total amount of wall time                        = 155.221204
+ 0: The maximum resident set size (KB)                   = 1108096
 
 Test 166 datm_cdeps_control_cfsr_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_lnd_gswp3_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_lnd_gswp3_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_lnd_gswp3_intel
 Checking test 167 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5424,14 +5424,14 @@ Checking test 167 datm_cdeps_lnd_gswp3_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 6.775042
-  0: The maximum resident set size (KB)                   = 253440
+  0: The total amount of wall time                        = 6.168721
+  0: The maximum resident set size (KB)                   = 255980
 
 Test 167 datm_cdeps_lnd_gswp3_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_lnd_gswp3_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_lnd_gswp3_rst_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_lnd_gswp3_rst_intel
 Checking test 168 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile1.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile2.nc .........OK
@@ -5440,14 +5440,14 @@ Checking test 168 datm_cdeps_lnd_gswp3_rst_intel results ....
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile5.nc .........OK
  Comparing ufs.cpld.lnd.out.2000-01-02-00000.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 10.751984
-  0: The maximum resident set size (KB)                   = 252240
+  0: The total amount of wall time                        = 10.396858
+  0: The maximum resident set size (KB)                   = 249592
 
 Test 168 datm_cdeps_lnd_gswp3_rst_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_atmlnd_sbs_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_p8_atmlnd_sbs_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_p8_atmlnd_sbs_intel
 Checking test 169 control_p8_atmlnd_sbs_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -5532,14 +5532,14 @@ Checking test 169 control_p8_atmlnd_sbs_intel results ....
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile5.nc ............ALT CHECK......OK
  Comparing ufs.cpld.lnd.out.2021-03-23-21600.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 208.761676
-  0: The maximum resident set size (KB)                   = 1613680
+  0: The total amount of wall time                        = 206.483271
+  0: The maximum resident set size (KB)                   = 1604492
 
 Test 169 control_p8_atmlnd_sbs_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/atmwav_control_noaero_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/atmwav_control_noaero_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/atmwav_control_noaero_p8_intel
 Checking test 170 atmwav_control_noaero_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5582,14 +5582,14 @@ Checking test 170 atmwav_control_noaero_p8_intel results ....
  Comparing 20210322.180000.out_grd.ww3 .........OK
  Comparing ufs.atmw.ww3.r.2021-03-22-64800 .........OK
 
-  0: The total amount of wall time                        = 95.775162
-  0: The maximum resident set size (KB)                   = 1653444
+  0: The total amount of wall time                        = 95.194032
+  0: The maximum resident set size (KB)                   = 1648480
 
 Test 170 atmwav_control_noaero_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_atmwav_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_atmwav_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_atmwav_intel
 Checking test 171 control_atmwav_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5633,14 +5633,14 @@ Checking test 171 control_atmwav_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc ............ALT CHECK......OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 87.629856
-  0: The maximum resident set size (KB)                   = 661972
+  0: The total amount of wall time                        = 87.721765
+  0: The maximum resident set size (KB)                   = 663508
 
 Test 171 control_atmwav_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/atmaero_control_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/atmaero_control_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/atmaero_control_p8_intel
 Checking test 172 atmaero_control_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5684,14 +5684,14 @@ Checking test 172 atmaero_control_p8_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 239.916957
-  0: The maximum resident set size (KB)                   = 2992436
+  0: The total amount of wall time                        = 235.255089
+  0: The maximum resident set size (KB)                   = 2943360
 
 Test 172 atmaero_control_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/atmaero_control_p8_rad_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/atmaero_control_p8_rad_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/atmaero_control_p8_rad_intel
 Checking test 173 atmaero_control_p8_rad_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5735,14 +5735,14 @@ Checking test 173 atmaero_control_p8_rad_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 290.953852
-  0: The maximum resident set size (KB)                   = 2998388
+  0: The total amount of wall time                        = 284.289960
+  0: The maximum resident set size (KB)                   = 3050744
 
 Test 173 atmaero_control_p8_rad_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/atmaero_control_p8_rad_micro_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/atmaero_control_p8_rad_micro_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/atmaero_control_p8_rad_micro_intel
 Checking test 174 atmaero_control_p8_rad_micro_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5786,14 +5786,14 @@ Checking test 174 atmaero_control_p8_rad_micro_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 287.968353
-  0: The maximum resident set size (KB)                   = 3067660
+  0: The total amount of wall time                        = 286.223736
+  0: The maximum resident set size (KB)                   = 3064612
 
 Test 174 atmaero_control_p8_rad_micro_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_atmaq_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_atmaq_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_atmaq_intel
 Checking test 175 regional_atmaq_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5809,14 +5809,14 @@ Checking test 175 regional_atmaq_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20190801.180000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 644.740778
-  0: The maximum resident set size (KB)                   = 5415528
+  0: The total amount of wall time                        = 642.069419
+  0: The maximum resident set size (KB)                   = 5441320
 
 Test 175 regional_atmaq_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_atmaq_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_atmaq_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_atmaq_debug_intel
 Checking test 176 regional_atmaq_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -5830,14 +5830,14 @@ Checking test 176 regional_atmaq_debug_intel results ....
  Comparing RESTART/20190801.130000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20190801.130000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1187.548658
-  0: The maximum resident set size (KB)                   = 4872524
+  0: The total amount of wall time                        = 1191.056955
+  0: The maximum resident set size (KB)                   = 4868468
 
 Test 176 regional_atmaq_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_atmaq_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_atmaq_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_atmaq_faster_intel
 Checking test 177 regional_atmaq_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -5853,14 +5853,14 @@ Checking test 177 regional_atmaq_faster_intel results ....
  Comparing RESTART/20190801.180000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20190801.180000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 550.529210
-  0: The maximum resident set size (KB)                   = 5414032
+  0: The total amount of wall time                        = 551.336384
+  0: The maximum resident set size (KB)                   = 5294756
 
 Test 177 regional_atmaq_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_c48_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_c48_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_c48_gnu
 Checking test 178 control_c48_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5899,14 +5899,14 @@ Checking test 178 control_c48_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-0: The total amount of wall time                        = 684.515921
-0: The maximum resident set size (KB)                   = 730992
+0: The total amount of wall time                        = 692.446658
+0: The maximum resident set size (KB)                   = 733176
 
 Test 178 control_c48_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_stochy_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_stochy_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_stochy_gnu
 Checking test 179 control_stochy_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -5917,14 +5917,14 @@ Checking test 179 control_stochy_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 223.270401
-  0: The maximum resident set size (KB)                   = 537056
+  0: The total amount of wall time                        = 234.566477
+  0: The maximum resident set size (KB)                   = 539400
 
 Test 179 control_stochy_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_ras_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_ras_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_ras_gnu
 Checking test 180 control_ras_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -5935,14 +5935,14 @@ Checking test 180 control_ras_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 287.137558
-  0: The maximum resident set size (KB)                   = 546852
+  0: The total amount of wall time                        = 284.155257
+  0: The maximum resident set size (KB)                   = 514180
 
 Test 180 control_ras_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_p8_gnu
 Checking test 181 control_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -5989,14 +5989,14 @@ Checking test 181 control_p8_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 299.113637
-  0: The maximum resident set size (KB)                   = 1289976
+  0: The total amount of wall time                        = 303.510349
+  0: The maximum resident set size (KB)                   = 1275892
 
 Test 181 control_p8_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_flake_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_flake_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_flake_gnu
 Checking test 182 control_flake_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -6007,14 +6007,14 @@ Checking test 182 control_flake_gnu results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 342.660433
-  0: The maximum resident set size (KB)                   = 588424
+  0: The total amount of wall time                        = 344.527551
+  0: The maximum resident set size (KB)                   = 582820
 
 Test 182 control_flake_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_gnu
 Checking test 183 rap_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -6061,14 +6061,14 @@ Checking test 183 rap_control_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 678.852434
-  0: The maximum resident set size (KB)                   = 854144
+  0: The total amount of wall time                        = 677.548298
+  0: The maximum resident set size (KB)                   = 854500
 
 Test 183 rap_control_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_decomp_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_decomp_gnu
 Checking test 184 rap_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -6115,14 +6115,14 @@ Checking test 184 rap_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 683.667656
-  0: The maximum resident set size (KB)                   = 856080
+  0: The total amount of wall time                        = 684.051524
+  0: The maximum resident set size (KB)                   = 852196
 
 Test 184 rap_decomp_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_2threads_gnu
 Checking test 185 rap_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -6169,14 +6169,14 @@ Checking test 185 rap_2threads_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 614.705971
-  0: The maximum resident set size (KB)                   = 955272
+  0: The total amount of wall time                        = 611.208321
+  0: The maximum resident set size (KB)                   = 959180
 
 Test 185 rap_2threads_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_restart_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_restart_gnu
 Checking test 186 rap_restart_gnu results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -6215,14 +6215,14 @@ Checking test 186 rap_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 354.819884
-  0: The maximum resident set size (KB)                   = 757128
+  0: The total amount of wall time                        = 344.412074
+  0: The maximum resident set size (KB)                   = 753792
 
 Test 186 rap_restart_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_sfcdiff_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_sfcdiff_gnu
 Checking test 187 rap_sfcdiff_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6269,14 +6269,14 @@ Checking test 187 rap_sfcdiff_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 686.816137
-  0: The maximum resident set size (KB)                   = 885536
+  0: The total amount of wall time                        = 675.590641
+  0: The maximum resident set size (KB)                   = 854292
 
 Test 187 rap_sfcdiff_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_sfcdiff_decomp_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_sfcdiff_decomp_gnu
 Checking test 188 rap_sfcdiff_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6323,14 +6323,14 @@ Checking test 188 rap_sfcdiff_decomp_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 695.527968
-  0: The maximum resident set size (KB)                   = 853592
+  0: The total amount of wall time                        = 686.812122
+  0: The maximum resident set size (KB)                   = 853340
 
 Test 188 rap_sfcdiff_decomp_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_sfcdiff_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_sfcdiff_restart_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_sfcdiff_restart_gnu
 Checking test 189 rap_sfcdiff_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -6369,14 +6369,14 @@ Checking test 189 rap_sfcdiff_restart_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 510.377557
-  0: The maximum resident set size (KB)                   = 765524
+  0: The total amount of wall time                        = 506.329549
+  0: The maximum resident set size (KB)                   = 762640
 
 Test 189 rap_sfcdiff_restart_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_gnu
 Checking test 190 hrrr_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6423,14 +6423,14 @@ Checking test 190 hrrr_control_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 662.786307
-  0: The maximum resident set size (KB)                   = 849976
+  0: The total amount of wall time                        = 652.220877
+  0: The maximum resident set size (KB)                   = 851684
 
 Test 190 hrrr_control_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_qr_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_qr_gnu
 Checking test 191 hrrr_control_qr_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6477,14 +6477,14 @@ Checking test 191 hrrr_control_qr_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 663.387939
-  0: The maximum resident set size (KB)                   = 864236
+  0: The total amount of wall time                        = 655.924945
+  0: The maximum resident set size (KB)                   = 861844
 
 Test 191 hrrr_control_qr_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_2threads_gnu
 Checking test 192 hrrr_control_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6531,14 +6531,14 @@ Checking test 192 hrrr_control_2threads_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 572.786955
-  0: The maximum resident set size (KB)                   = 960624
+  0: The total amount of wall time                        = 579.859612
+  0: The maximum resident set size (KB)                   = 954096
 
 Test 192 hrrr_control_2threads_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_decomp_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_decomp_gnu
 Checking test 193 hrrr_control_decomp_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6585,42 +6585,42 @@ Checking test 193 hrrr_control_decomp_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 658.948689
-  0: The maximum resident set size (KB)                   = 851396
+  0: The total amount of wall time                        = 664.447940
+  0: The maximum resident set size (KB)                   = 850880
 
 Test 193 hrrr_control_decomp_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_gnu
 Checking test 194 hrrr_control_restart_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 490.899180
-  0: The maximum resident set size (KB)                   = 710316
+  0: The total amount of wall time                        = 488.187184
+  0: The maximum resident set size (KB)                   = 710472
 
 Test 194 hrrr_control_restart_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_qr_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_qr_gnu
 Checking test 195 hrrr_control_restart_qr_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 494.811672
-  0: The maximum resident set size (KB)                   = 617632
+  0: The total amount of wall time                        = 499.225076
+  0: The maximum resident set size (KB)                   = 620020
 
 Test 195 hrrr_control_restart_qr_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rrfs_v1beta_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rrfs_v1beta_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rrfs_v1beta_gnu
 Checking test 196 rrfs_v1beta_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6667,14 +6667,14 @@ Checking test 196 rrfs_v1beta_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 668.842022
-  0: The maximum resident set size (KB)                   = 850708
+  0: The total amount of wall time                        = 666.930200
+  0: The maximum resident set size (KB)                   = 851128
 
 Test 196 rrfs_v1beta_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_gf_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_gf_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_gf_gnu
 Checking test 197 hrrr_gf_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6721,208 +6721,208 @@ Checking test 197 hrrr_gf_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 684.055937
-  0: The maximum resident set size (KB)                   = 850520
+  0: The total amount of wall time                        = 686.201887
+  0: The maximum resident set size (KB)                   = 850652
 
 Test 197 hrrr_gf_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_diag_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_diag_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_diag_debug_gnu
 Checking test 198 control_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 84.541758
-  0: The maximum resident set size (KB)                   = 553684
+  0: The total amount of wall time                        = 82.535496
+  0: The maximum resident set size (KB)                   = 584280
 
 Test 198 control_diag_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/regional_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/regional_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/regional_debug_gnu
 Checking test 199 regional_debug_gnu results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 438.003749
-  0: The maximum resident set size (KB)                   = 822276
+  0: The total amount of wall time                        = 436.510479
+  0: The maximum resident set size (KB)                   = 819364
 
 Test 199 regional_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_debug_gnu
 Checking test 200 rap_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 135.042262
-  0: The maximum resident set size (KB)                   = 867268
+  0: The total amount of wall time                        = 139.545747
+  0: The maximum resident set size (KB)                   = 863432
 
 Test 200 rap_control_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_debug_gnu
 Checking test 201 hrrr_control_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 134.165058
-  0: The maximum resident set size (KB)                   = 865460
+  0: The total amount of wall time                        = 135.461583
+  0: The maximum resident set size (KB)                   = 864424
 
 Test 201 hrrr_control_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_diag_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_diag_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_diag_debug_gnu
 Checking test 202 rap_diag_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.279654
-  0: The maximum resident set size (KB)                   = 949008
+  0: The total amount of wall time                        = 149.085946
+  0: The maximum resident set size (KB)                   = 948560
 
 Test 202 rap_diag_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_noah_sfcdiff_cires_ugwp_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_noah_sfcdiff_cires_ugwp_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_noah_sfcdiff_cires_ugwp_debug_gnu
 Checking test 203 rap_noah_sfcdiff_cires_ugwp_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.014164
-  0: The maximum resident set size (KB)                   = 862228
+  0: The total amount of wall time                        = 221.975133
+  0: The maximum resident set size (KB)                   = 865356
 
 Test 203 rap_noah_sfcdiff_cires_ugwp_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_progcld_thompson_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_progcld_thompson_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_progcld_thompson_debug_gnu
 Checking test 204 rap_progcld_thompson_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 140.425242
-  0: The maximum resident set size (KB)                   = 860216
+  0: The total amount of wall time                        = 137.458346
+  0: The maximum resident set size (KB)                   = 856728
 
 Test 204 rap_progcld_thompson_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rrfs_v1beta_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rrfs_v1beta_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rrfs_v1beta_debug_gnu
 Checking test 205 rrfs_v1beta_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 136.897665
-  0: The maximum resident set size (KB)                   = 896016
+  0: The total amount of wall time                        = 136.847287
+  0: The maximum resident set size (KB)                   = 862144
 
 Test 205 rrfs_v1beta_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_ras_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_ras_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_ras_debug_gnu
 Checking test 206 control_ras_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 79.516716
-  0: The maximum resident set size (KB)                   = 501080
+  0: The total amount of wall time                        = 80.296634
+  0: The maximum resident set size (KB)                   = 502028
 
 Test 206 control_ras_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_stochy_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_stochy_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_stochy_debug_gnu
 Checking test 207 control_stochy_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 118.471396
-  0: The maximum resident set size (KB)                   = 496392
+  0: The total amount of wall time                        = 120.016638
+  0: The maximum resident set size (KB)                   = 495748
 
 Test 207 control_stochy_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_debug_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_debug_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_debug_p8_gnu
 Checking test 208 control_debug_p8_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 88.659972
-  0: The maximum resident set size (KB)                   = 1287764
+  0: The total amount of wall time                        = 91.830165
+  0: The maximum resident set size (KB)                   = 1287704
 
 Test 208 control_debug_p8_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_flake_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_flake_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_flake_debug_gnu
 Checking test 209 rap_flake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 134.294770
-  0: The maximum resident set size (KB)                   = 867160
+  0: The total amount of wall time                        = 140.505809
+  0: The maximum resident set size (KB)                   = 865276
 
 Test 209 rap_flake_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_clm_lake_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_clm_lake_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_clm_lake_debug_gnu
 Checking test 210 rap_clm_lake_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 157.943220
-  0: The maximum resident set size (KB)                   = 867688
+  0: The total amount of wall time                        = 158.826327
+  0: The maximum resident set size (KB)                   = 861368
 
 Test 210 rap_clm_lake_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/control_wam_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/control_wam_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/control_wam_debug_gnu
 Checking test 211 control_wam_debug_gnu results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 135.519057
-  0: The maximum resident set size (KB)                   = 286676
+  0: The total amount of wall time                        = 132.855667
+  0: The maximum resident set size (KB)                   = 286184
 
 Test 211 control_wam_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_dyn32_phy32_gnu
 Checking test 212 rap_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -6969,14 +6969,14 @@ Checking test 212 rap_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 704.080628
-  0: The maximum resident set size (KB)                   = 747320
+  0: The total amount of wall time                        = 702.124283
+  0: The maximum resident set size (KB)                   = 747104
 
 Test 212 rap_control_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_dyn32_phy32_gnu
 Checking test 213 hrrr_control_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7023,14 +7023,14 @@ Checking test 213 hrrr_control_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 352.754734
-  0: The maximum resident set size (KB)                   = 743376
+  0: The total amount of wall time                        = 358.846863
+  0: The maximum resident set size (KB)                   = 744960
 
 Test 213 hrrr_control_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_qr_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_qr_dyn32_phy32_gnu
 Checking test 214 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7077,14 +7077,14 @@ Checking test 214 hrrr_control_qr_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 351.999446
-  0: The maximum resident set size (KB)                   = 751048
+  0: The total amount of wall time                        = 357.394800
+  0: The maximum resident set size (KB)                   = 750984
 
 Test 214 hrrr_control_qr_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_2threads_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_2threads_dyn32_phy32_gnu
 Checking test 215 rap_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7131,14 +7131,14 @@ Checking test 215 rap_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 624.696832
-  0: The maximum resident set size (KB)                   = 786160
+  0: The total amount of wall time                        = 623.411178
+  0: The maximum resident set size (KB)                   = 789104
 
 Test 215 rap_2threads_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_2threads_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_2threads_dyn32_phy32_gnu
 Checking test 216 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7185,14 +7185,14 @@ Checking test 216 hrrr_control_2threads_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 308.534661
-  0: The maximum resident set size (KB)                   = 791520
+  0: The total amount of wall time                        = 307.769536
+  0: The maximum resident set size (KB)                   = 792864
 
 Test 216 hrrr_control_2threads_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_decomp_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_decomp_dyn32_phy32_gnu
 Checking test 217 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7239,14 +7239,14 @@ Checking test 217 hrrr_control_decomp_dyn32_phy32_gnu results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 353.333521
-  0: The maximum resident set size (KB)                   = 742620
+  0: The total amount of wall time                        = 349.851416
+  0: The maximum resident set size (KB)                   = 743744
 
 Test 217 hrrr_control_decomp_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_restart_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_restart_dyn32_phy32_gnu
 Checking test 218 rap_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -7285,42 +7285,42 @@ Checking test 218 rap_restart_dyn32_phy32_gnu results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 520.450144
-  0: The maximum resident set size (KB)                   = 653564
+  0: The total amount of wall time                        = 523.404707
+  0: The maximum resident set size (KB)                   = 653972
 
 Test 218 rap_restart_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_dyn32_phy32_gnu
 Checking test 219 hrrr_control_restart_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 184.147277
-  0: The maximum resident set size (KB)                   = 616380
+  0: The total amount of wall time                        = 184.863507
+  0: The maximum resident set size (KB)                   = 615968
 
 Test 219 hrrr_control_restart_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_restart_qr_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_restart_qr_dyn32_phy32_gnu
 Checking test 220 hrrr_control_restart_qr_dyn32_phy32_gnu results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 186.132016
-  0: The maximum resident set size (KB)                   = 582516
+  0: The total amount of wall time                        = 186.397947
+  0: The maximum resident set size (KB)                   = 579520
 
 Test 220 hrrr_control_restart_qr_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_control_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_control_gnu
 Checking test 221 conus13km_control_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -7336,40 +7336,40 @@ Checking test 221 conus13km_control_gnu results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 241.453998
-  0: The maximum resident set size (KB)                   = 951940
+  0: The total amount of wall time                        = 244.179014
+  0: The maximum resident set size (KB)                   = 954660
 
 Test 221 conus13km_control_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_control_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_2threads_gnu
 Checking test 222 conus13km_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 104.882911
-  0: The maximum resident set size (KB)                   = 998812
+  0: The total amount of wall time                        = 103.775257
+  0: The maximum resident set size (KB)                   = 996324
 
 Test 222 conus13km_2threads_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_restart_mismatch_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_restart_mismatch_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_restart_mismatch_gnu
 Checking test 223 conus13km_restart_mismatch_gnu results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 126.879809
-  0: The maximum resident set size (KB)                   = 610540
+  0: The total amount of wall time                        = 128.710408
+  0: The maximum resident set size (KB)                   = 607896
 
 Test 223 conus13km_restart_mismatch_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_dyn64_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_dyn64_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_dyn64_phy32_gnu
 Checking test 224 rap_control_dyn64_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -7416,98 +7416,98 @@ Checking test 224 rap_control_dyn64_phy32_gnu results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc ............ALT CHECK......OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 410.420381
-  0: The maximum resident set size (KB)                   = 768404
+  0: The total amount of wall time                        = 405.647280
+  0: The maximum resident set size (KB)                   = 766636
 
 Test 224 rap_control_dyn64_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_debug_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_debug_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_debug_dyn32_phy32_gnu
 Checking test 225 rap_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 139.664874
-  0: The maximum resident set size (KB)                   = 755260
+  0: The total amount of wall time                        = 143.978471
+  0: The maximum resident set size (KB)                   = 758704
 
 Test 225 rap_control_debug_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/hrrr_control_debug_dyn32_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/hrrr_control_debug_dyn32_phy32_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/hrrr_control_debug_dyn32_phy32_gnu
 Checking test 226 hrrr_control_debug_dyn32_phy32_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 138.407514
-  0: The maximum resident set size (KB)                   = 758520
+  0: The total amount of wall time                        = 134.891759
+  0: The maximum resident set size (KB)                   = 755044
 
 Test 226 hrrr_control_debug_dyn32_phy32_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_debug_gnu
 Checking test 227 conus13km_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 422.110392
-  0: The maximum resident set size (KB)                   = 970056
+  0: The total amount of wall time                        = 414.033192
+  0: The maximum resident set size (KB)                   = 968828
 
 Test 227 conus13km_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_debug_2threads_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_debug_2threads_gnu
 Checking test 228 conus13km_debug_2threads_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.319213
-  0: The maximum resident set size (KB)                   = 1002856
+  0: The total amount of wall time                        = 254.673720
+  0: The maximum resident set size (KB)                   = 1013572
 
 Test 228 conus13km_debug_2threads_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/conus13km_radar_tten_debug_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/conus13km_radar_tten_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/conus13km_radar_tten_debug_gnu
 Checking test 229 conus13km_radar_tten_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 420.972162
-  0: The maximum resident set size (KB)                   = 1036164
+  0: The total amount of wall time                        = 418.145706
+  0: The maximum resident set size (KB)                   = 1036784
 
 Test 229 conus13km_radar_tten_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/rap_control_debug_dyn64_phy32_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/rap_control_dyn64_phy32_debug_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/rap_control_dyn64_phy32_debug_gnu
 Checking test 230 rap_control_dyn64_phy32_debug_gnu results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 142.519658
-  0: The maximum resident set size (KB)                   = 785480
+  0: The total amount of wall time                        = 143.119838
+  0: The maximum resident set size (KB)                   = 779476
 
 Test 230 rap_control_dyn64_phy32_debug_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_p8_gnu
 Checking test 231 cpld_control_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7572,14 +7572,14 @@ Checking test 231 cpld_control_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 634.413487
-  0: The maximum resident set size (KB)                   = 1512076
+  0: The total amount of wall time                        = 639.758811
+  0: The maximum resident set size (KB)                   = 1489944
 
 Test 231 cpld_control_p8_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_c96_noaero_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_nowave_noaero_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_nowave_noaero_p8_gnu
 Checking test 232 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7641,14 +7641,14 @@ Checking test 232 cpld_control_nowave_noaero_p8_gnu results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 415.905406
-  0: The maximum resident set size (KB)                   = 1400300
+  0: The total amount of wall time                        = 413.281659
+  0: The maximum resident set size (KB)                   = 1408360
 
 Test 232 cpld_control_nowave_noaero_p8_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_debug_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_debug_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_debug_p8_gnu
 Checking test 233 cpld_debug_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -7701,14 +7701,14 @@ Checking test 233 cpld_debug_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 365.717972
-  0: The maximum resident set size (KB)                   = 1514592
+  0: The total amount of wall time                        = 367.607109
+  0: The maximum resident set size (KB)                   = 1516920
 
 Test 233 cpld_debug_p8_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_control_pdlib_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_control_pdlib_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_control_pdlib_p8_gnu
 Checking test 234 cpld_control_pdlib_p8_gnu results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -7772,14 +7772,14 @@ Checking test 234 cpld_control_pdlib_p8_gnu results ....
  Comparing 20210323.060000.out_pnt.ww3 .........OK
  Comparing 20210323.060000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 1415.713704
-  0: The maximum resident set size (KB)                   = 1378408
+  0: The total amount of wall time                        = 1422.215073
+  0: The maximum resident set size (KB)                   = 1373904
 
 Test 234 cpld_control_pdlib_p8_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/cpld_debug_pdlib_p8_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/cpld_debug_pdlib_p8_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/cpld_debug_pdlib_p8_gnu
 Checking test 235 cpld_debug_pdlib_p8_gnu results ....
  Comparing sfcf003.tile1.nc .........OK
  Comparing sfcf003.tile2.nc .........OK
@@ -7831,25 +7831,25 @@ Checking test 235 cpld_debug_pdlib_p8_gnu results ....
  Comparing 20210322.090000.out_pnt.ww3 .........OK
  Comparing 20210322.090000.out_grd.ww3 .........OK
 
-  0: The total amount of wall time                        = 714.229331
-  0: The maximum resident set size (KB)                   = 1394908
+  0: The total amount of wall time                        = 706.501940
+  0: The maximum resident set size (KB)                   = 1393780
 
 Test 235 cpld_debug_pdlib_p8_gnu PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20230825/datm_cdeps_control_cfsr_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/role.epic/FV3_RT/rt_68425/datm_cdeps_control_cfsr_gnu
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_RT/rt_275523/datm_cdeps_control_cfsr_gnu
 Checking test 236 datm_cdeps_control_cfsr_gnu results ....
  Comparing RESTART/20111002.000000.MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 174.774031
- 0: The maximum resident set size (KB)                   = 685044
+ 0: The total amount of wall time                        = 170.135133
+ 0: The maximum resident set size (KB)                   = 688508
 
 Test 236 datm_cdeps_control_cfsr_gnu PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Sep  8 09:39:20 UTC 2023
-Elapsed time: 02h:05m:42s. Have a nice day!
+Mon Sep 11 20:58:48 UTC 2023
+Elapsed time: 03h:10m:11s. Have a nice day!


### PR DESCRIPTION
## PR Author Checklist:

- [x] I have linked PR's from all sub-components involved in section below. 
- [x] I am confirming reviews are completed in ALL sub-component PR's.
- [ ] I have run the full RT suite on either Hera/Cheyenne AND have attached the log to this PR below this line:
  - LOG:   _Please see note below in section, Regression Tests._
- [ ] I have added the list of all failed regression tests to "Anticipated changes" section.
- [x] I have filled out all sections of the template.

## Description
This PR applies a fix to the Intel Github CI workflow.  The GNU workflow is also updated at the same time.

## Linked Issues and Pull Requests
### Associated UFSWM Issue to close
- closes #1889 

### Subcomponent Pull Requests
- noaa-emc/ww3/pull/1069


### Blocking Dependencies
None.

### Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [x] WW3
- [ ] stochastic_physics
- [ ] none

## Anticipated Changes
### Input data
- [x] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Regression Tests:
- [x] No changes are expected to any regression test.
- [ ] Changes are expected to the following tests:

_Note:  The regression tests have not been run because the only changes this PR introduces are restricted to the Github CI workflow.  Regression tests would not exercise any of that code.  That said I can run them no problem if having the logs as proof is useful. Please let me know if so._

### Libraries
- [x] Not Needed
- [ ] Needed
  - [ ] Create separate issue in [JCSDA/spack-stack](https://github.com/JCSDA/spack-stack) asking for update to library. Include library name, library version.
  - [ ] Add issue link from JCSDA/spack-stack following this item 


<!-- THE FOLLOWING IS FOR CODE MANAGERS ONLY DO NOT FILL OUT -->
<details><summary>Code Managers Log</summary>

- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.
  - [ ] N/A

### Testing Log:
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Jet
  - [ ] Gaea
  - [ ] Cheyenne
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
</details>
