### PR TITLE
Preliminary cmake options files for Gaea C5, Derecho, Hercules to support SRW runs

### DIFF
--- a/cmake/configure_derecho.intel.cmake
+++ b/cmake/configure_derecho.intel.cmake
@@ -1,0 +1,1 @@
+set(PARALLEL_NETCDF ON  CACHE BOOL "Enable parallel NetCDF" FORCE)

--- a/cmake/configure_gaea_c5.intel.cmake
+++ b/cmake/configure_gaea_c5.intel.cmake
@@ -1,0 +1,2 @@
+set(PARALLEL_NETCDF ON CACHE BOOL "Enable parallel NetCDF" FORCE)
+set(AVX2            ON CACHE BOOL "Enable AVX2 instruction set" FORCE)

--- a/cmake/configure_hercules.intel.cmake
+++ b/cmake/configure_hercules.intel.cmake
@@ -1,0 +1,1 @@
+set(PARALLEL_NETCDF ON  CACHE BOOL "Enable parallel NetCDF" FORCE)


### PR DESCRIPTION

## PR Author Checklist:

## Description
This PR adds preliminary cmake configurations for new platforms Gaea, Derecho, Hercules. It will enable for the UFS-SRW to use and test these platforms for Atmospheric-only runs, while testing of UFS WM  supporting all of its components is still undergoing. 
SRW fundamental tests were successfully run on Derecho and Gaea C5.

## Linked Issues and Pull Requests
This addresses issues:
https://github.com/ufs-community/ufs-srweather-app/issues/884
https://github.com/ufs-community/ufs-srweather-app/issues/885
https://github.com/ufs-community/ufs-srweather-app/issues/886

Dependencies:
https://github.com/ufs-community/ufs-srweather-app/pull/894
https://github.com/ufs-community/ufs-srweather-app/pull/898
https://github.com/ufs-community/ufs-srweather-app/pull/911 (Still work-in-progress)

### Associated UFSWM Issue to close


### Subcomponent Pull Requests

### Blocking Dependencies

### Subcomponents involved:
- [x] none

## Anticipated Changes
### Input data
- [x] No changes are expected to input data.

### Regression Tests:
- [x] No changes are expected to any regression test.


### Libraries

- [x] Not Needed

<!-- THE FOLLOWING IS FOR CODE MANAGERS ONLY DO NOT FILL OUT -->
<details><summary>Code Managers Log</summary>

- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.
  - [ ] N/A

### Testing Log:
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Jet
  - [ ] Gaea
  - [ ] Cheyenne
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
</details>
