### PR TITLE
Correct documentation build failures & reflect switch to spack-stack

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,10 @@
 
 # Required
 version: 2
+build: 
+  os: ubuntu-20.04
+  tools: 
+    python: "3.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -18,6 +22,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: doc/UsersGuide/requirements.txt

--- a/doc/UsersGuide/source/AutomatedTesting.rst
+++ b/doc/UsersGuide/source/AutomatedTesting.rst
@@ -20,7 +20,7 @@ The UFS Weather Model (:term:`WM`) uses GitHub Actions (GHA), a GitHub-hosted co
 to perform CI/CD testing. Build jobs are done on GHA-provided virtual machines. Test jobs are 
 performed on the Amazon Web Services (AWS) cloud platform using a number of EC2 instances. 
 Builds and tests are carried out in a Docker container. The container includes a pre-installed version of the
-:term:`HPC-Stack`, which includes all prerequisite libraries. Input data needed to run the tests 
+:term:`spack-stack`, which includes all prerequisite libraries. Input data needed to run the tests 
 are stored as a separate Docker container.
 
 When a developer makes a pull request (PR) to the UFS WM repository, a code
@@ -31,14 +31,14 @@ The CI/CD workflow then executes the following steps:
       subcomponents are up to date with the top of the ``develop`` branch.
 
    #. If the check is successful, build jobs are started on GHA-provided virtual machines
-      by downloading the hpc-stack Docker container stored in Docker Hub.
+      by downloading the spack-stack Docker container stored in Docker Hub.
 
    #. Once all build jobs are successful, the created executable files are stored as
       artifacts in GHA.
 
    #. A number of AWS EC2 instances are started.
 
-   #. Test jobs are started on AWS after downloading the hpc-stack Docker container,
+   #. Test jobs are started on AWS after downloading the spack-stack Docker container,
       the executable file from the build job, and the input-data Docker container.
 
    #. When all tests are complete, EC2 instances are stopped. Test results are reported

--- a/doc/UsersGuide/source/BuildingAndRunning.rst
+++ b/doc/UsersGuide/source/BuildingAndRunning.rst
@@ -14,7 +14,7 @@ through NOAA and its affiliates. These systems are named (e.g., Hera, Orion, Che
 Level 3 & 4 systems include certain personal computers or non-NOAA-affiliated HPC systems. 
 The prerequisite software libraries for building the WM already exist in a centralized location on Level 1/preconfigured 
 systems, so users may skip directly to :ref:`getting the data <GetData>` and downloading the code. 
-On other systems, users will need to build the prerequisite libraries using :term:`HPC-Stack` or :term:`spack-stack`. 
+On other systems, users will need to build the prerequisite libraries using :term:`spack-stack` or :term:`HPC-Stack`. 
 
 =======================
 Prerequisite Libraries
@@ -22,7 +22,7 @@ Prerequisite Libraries
 
 The UFS WM requires a number of libraries.
 The WM uses two categories of libraries, which are available as a bundle via 
-:term:`HPC-Stack` or :term:`spack-stack`:
+:term:`spack-stack` or :term:`HPC-Stack`:
 
    #. :term:`NCEP` libraries (:term:`NCEPLIBS`): These are libraries developed for use with NOAA weather models.
       Most have an NCEPLIBS prefix in the repository (e.g., NCEPLIBS-bacio). Select tools from the UFS
@@ -34,11 +34,12 @@ The WM uses two categories of libraries, which are available as a bundle via
       instead. 
 
 .. note::
-   Currently, HPC-Stack is the software stack validated by the UFS WM for running :term:`regression tests <RT>`. 
-   However, UFS applications are shifting to spack-stack, which is a Spack-based 
-   method for installing UFS prerequisite software libraries. The spack-stack is currently 
-   used on NOAA Cloud platforms and in containers, while HPC-Stack is still used on NOAA
-   Research & Development HPC Systems (RDHPCS). 
+   Currently, spack-stack is the software stack validated by the UFS WM for running 
+   :term:`regression tests <RT>`. Spack-stack is a Spack-based method for installing UFS 
+   prerequisite software libraries. UFS applications and components are also shifting to 
+   spack-stack from HPC-Stack but are at various stages of this transition. 
+   Although users can still build and use HPC-Stack, the UFS WM no longer uses HPC-Stack 
+   for validation, and support for this option is being deprecated. 
 
 ----------------
 Common Modules
@@ -70,8 +71,8 @@ The most updated list of common modules can be viewed in ``ufs_common.lua``
 `here <https://github.com/ufs-community/ufs-weather-model/blob/develop/modulefiles/ufs_common.lua>`__.
 
 .. attention::
-   Documentation is available for installing `HPC-Stack <https://hpc-stack.readthedocs.io/en/latest/>`__ 
-   and `spack-stack <https://spack-stack.readthedocs.io/en/latest/>`__, respectively. 
+   Documentation is available for installing `spack-stack <https://spack-stack.readthedocs.io/en/latest/>`__
+   and `HPC-Stack <https://hpc-stack.readthedocs.io/en/latest/>`__, respectively. 
    One of these software stacks (or the libraries they contain) must be installed before running the UFS Weather Model. 
 
 .. _GetData:

--- a/doc/UsersGuide/source/CodeOverview.rst
+++ b/doc/UsersGuide/source/CodeOverview.rst
@@ -19,7 +19,7 @@ Four levels of support have been defined for :term:`UFS` applications, and the U
 
 Level 1 Systems
 ==================
-Preconfigured (Level 1) systems for the UFS WM already have the required external libraries available in a central location via :term:`HPC-Stack` or :term:`spack-stack`. The WM is expected to build and run out-of-the-box on these systems, and users can download the WM code without first installing prerequisite software. Additionally, regression test data is already available on these systems. In general, users must have access to these Level 1 systems in order to use them.
+Preconfigured (Level 1) systems for the UFS WM already have the required external libraries available in a central location via :term:`spack-stack`. The WM is expected to build and run out-of-the-box on these systems, and users can download the WM code without first installing prerequisite software. Additionally, regression test data is already available on these systems. In general, users must have access to these Level 1 systems in order to use them.
 
 Currently, Level 1 (or Tier-1) platforms for regression testing are: 
 

--- a/doc/UsersGuide/source/CodeOverview.rst
+++ b/doc/UsersGuide/source/CodeOverview.rst
@@ -24,11 +24,11 @@ Preconfigured (Level 1) systems for the UFS WM already have the required externa
 Currently, Level 1 (or Tier-1) platforms for regression testing are: 
 
    * WCOSS2 (Intel)
-   * Cheyenne (Intel/GNU compilers)
    * Gaea (Intel)
    * Hera (Intel/GNU compilers)
    * Jet (Intel)
    * Orion (Intel)
+   * Hercules (Intel/GNU compilers)
    * AWS Docker container (Intel)
 
 More information is available in the `UFS WM wiki <https://github.com/ufs-community/ufs-weather-model/wiki/Regression-Test-Policy-for-Weather-Model-Platforms-and-Compilers>`__. 

--- a/doc/UsersGuide/source/Glossary.rst
+++ b/doc/UsersGuide/source/Glossary.rst
@@ -120,11 +120,11 @@ Glossary
 
    NCEPLIBS
       The software libraries created and maintained by :term:`NCEP` that are required for running 
-      :term:`chgres_cube`, the UFS Weather Model, and the :term:`UPP`. They are included in the `HPC-Stack <https://github.com/NOAA-EMC/hpc-stack>`__ and in `spack-stack <https://github.com/NOAA-EMC/spack-stack>`__. 
+      :term:`chgres_cube`, the UFS Weather Model, and the :term:`UPP`. They are included in `spack-stack <https://github.com/NOAA-EMC/spack-stack>`__ and `HPC-Stack <https://github.com/NOAA-EMC/hpc-stack>`__. 
 
    NCEPLIBS-external
       A collection of third-party libraries required to build :term:`NCEPLIBS`, :term:`chgres_cube`, 
-      the UFS Weather Model, and the :term:`UPP`. They are included in the :term:`HPC-Stack` and in :term:`spack-stack`.  
+      the UFS Weather Model, and the :term:`UPP`. They are included in :term:`spack-stack` and :term:`HPC-Stack`.  
 
    NEMS
       The NOAA Environmental Modeling System is a common modeling framework whose purpose is 

--- a/doc/UsersGuide/source/conf.py
+++ b/doc/UsersGuide/source/conf.py
@@ -41,6 +41,7 @@ numfig = True
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_rtd_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
## PR Author Checklist:
- [ ] I have linked PR's from all sub-components involved in section below. (N/A)
- [ ] I am confirming reviews are completed in ALL sub-component PR's. (N/A)
- [ ] I have run the full RT suite on either Hera/Cheyenne AND have attached the log to this PR below this line:
  - LOG: N/A - No tests required for documentation updates.
- [ ] I have added the list of all failed regression tests to "Anticipated changes" section. (N/A)
- [X] I have filled out all sections of the template.

## Description
This PR updates the documentation with information about the WM switch to spack-stack. 
This PR also cures documentation build fails on ReadTheDocs. 
See the docs build from my fork here: https://gsp-wm.readthedocs.io/en/text-release-doc/
Build passed: ![image](https://github.com/ufs-community/ufs-weather-model/assets/96886803/217f5c43-bf81-4a12-9b55-b1142fa6f781)

## Linked Issues and Pull Requests
Closes Issue #1949 and #1951.

### Subcomponent Pull Requests
N/A

### Blocking Dependencies
N/A

### Subcomponents involved:
- [ ] AQM
- [ ] CDEPS
- [ ] CICE
- [ ] CMEPS
- [ ] CMakeModules
- [ ] FV3
- [ ] GOCART
- [ ] HYCOM
- [ ] MOM6
- [ ] NOAHMP
- [ ] WW3
- [ ] stochastic_physics
- [X] none

## Anticipated Changes
### Input data
- [X] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Regression Tests:
- [X] No changes are expected to any regression test.
- [ ] Changes are expected to the following tests:

None

### Libraries
- [X] Not Needed
- [ ] Needed
  - [ ] Create separate issue in [JCSDA/spack-stack](https://github.com/JCSDA/spack-stack) asking for update to library. Include library name, library version.
  - [ ] Add issue link from JCSDA/spack-stack following this item <!-- for example: "- JCSDA/spack-stack/issue/1757" -->


<!-- THE FOLLOWING IS FOR CODE MANAGERS ONLY DO NOT FILL OUT -->
<details><summary>Code Managers Log</summary>

- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR.
- [ ] Move new/updated input data on RDHPCS Hera and propagate input data changes to all supported systems.
  - [ ] N/A

### Testing Log:
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Hercules
  - [ ] Jet
  - [ ] Gaea
  - [ ] Cheyenne
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- CI
  - [ ] Completed
- opnReqTest
  - [ ] N/A
  - [ ] Log attached to comment
</details>
