### PR TITLE
Updates of ccpp-framework and ccpp-physics (merge ccpp-framework feature/capgen into main/20240308) Combined PR #2190

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = develop
+  #url = https://github.com/NOAA-EMC/fv3atm
+  #branch = develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = feature/ccpp_framework_merge_feature_capgen_into_main_20240308
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-EMC/fv3atm
-  #branch = develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = feature/ccpp_framework_merge_feature_capgen_into_main_20240308
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = develop
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/bl_date.conf
+++ b/tests/bl_date.conf
@@ -1,1 +1,1 @@
-export BL_DATE=20240312
+export BL_DATE=20240315

--- a/tests/ci/Jenkinsfile.combined
+++ b/tests/ci/Jenkinsfile.combined
@@ -258,6 +258,8 @@ pipeline {
     agent none
     environment {
         ACCNR = 'epic'
+        AWS_PROD_ACCOUNT_ID = credentials('AWS_PROD_ACCOUNT_ID')
+        AWS_PROD_SNS_TOPIC = credentials('AWS_PROD_SNS_TOPIC')
         GITHUB_TOKEN = credentials('GithubJenkinsNew')
         GIT_URL = 'https://github.com/ufs-community/ufs-weather-model.git'
     }
@@ -285,7 +287,7 @@ pipeline {
              node('built-in') {
                 echo 'This will run only if successful.'
                 sh '''
-                  aws sns publish --topic-arn "arn:aws:sns:us-east-1:211527314271:Jenkins-CICD-Notifications" --region us-east-1 --message '{"version":"1.0","source":"custom","content":{"description":":sunny: Jenkins build *'"$JOB_NAME"' '"$BUILD_NUMBER"'* with *PR-'"$CHANGE_ID"'*  *succeeded*"}}'
+                  aws sns publish --topic-arn "arn:aws:sns:us-east-1:${AWS_PROD_ACCOUNT_ID}:${AWS_PROD_SNS_TOPIC}" --region us-east-1 --message '{"version":"1.0","source":"custom","content":{"description":":sunny: Jenkins build *'"$JOB_NAME"' '"$BUILD_NUMBER"'* with *PR-'"$CHANGE_ID"'*  *succeeded*"}}'
                '''
              }
          }
@@ -293,7 +295,7 @@ pipeline {
              node('built-in') {
                 echo 'This will run only if the run was marked as unstable.'
                 sh '''
-                  aws sns publish --topic-arn "arn:aws:sns:us-east-1:211527314271:Jenkins-CICD-Notifications" --region us-east-1 --message '{"version":"1.0","source":"custom","content":{"description":":warning: Jenkins build *'"$JOB_NAME"' '"$BUILD_NUMBER"'* with *PR-'"$CHANGE_ID"'*  *failed!*"}}'
+                  aws sns publish --topic-arn "arn:aws:sns:us-east-1:${AWS_PROD_ACCOUNT_ID}:${AWS_PROD_SNS_TOPIC}" --region us-east-1 --message '{"version":"1.0","source":"custom","content":{"description":":warning: Jenkins build *'"$JOB_NAME"' '"$BUILD_NUMBER"'* with *PR-'"$CHANGE_ID"'*  *failed!*"}}'
                '''
              }
          }

--- a/tests/logs/OpnReqTests_control_p8_hera.log
+++ b/tests/logs/OpnReqTests_control_p8_hera.log
@@ -1,9 +1,9 @@
-Wed Mar 13 16:00:32 UTC 2024
+Fri Mar 15 14:30:32 UTC 2024
 Start Operation Requirement Test
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/control_p8_bit_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_226640/bit_base_bit_base
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_63946/bit_base_bit_base
 Checking test bit_base results ....
 Moving baseline bit_base files ....
  Moving sfcf000.nc .........OK
@@ -51,14 +51,14 @@ Moving baseline bit_base files ....
  Moving RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Moving RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.604077
-  0: The maximum resident set size (KB)                   = 1306700
+  0: The total amount of wall time                        = 280.403230
+  0: The maximum resident set size (KB)                   = 1301268
 
 Test bit_base PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/control_p8_dbg_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_226640/dbg_base_dbg_base
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_63946/dbg_base_dbg_base
 Checking test dbg_base results ....
 Moving baseline dbg_base files ....
  Moving sfcf000.nc .........OK
@@ -106,14 +106,14 @@ Moving baseline dbg_base files ....
  Moving RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Moving RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 929.248031
-  0: The maximum resident set size (KB)                   = 1291568
+  0: The total amount of wall time                        = 914.973019
+  0: The maximum resident set size (KB)                   = 1289712
 
 Test dbg_base PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/control_p8_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_226640/dcp_dcp
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_63946/dcp_dcp
 Checking test dcp results ....
  Comparing sfcf000.nc .....USING NCCMP......OK
  Comparing sfcf021.nc .....USING NCCMP......OK
@@ -160,14 +160,14 @@ Checking test dcp results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .....USING NCCMP......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .....USING NCCMP......OK
 
-  0: The total amount of wall time                        = 250.255270
-  0: The maximum resident set size (KB)                   = 1278404
+  0: The total amount of wall time                        = 254.193285
+  0: The maximum resident set size (KB)                   = 1277804
 
 Test dcp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/control_p8_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_226640/mpi_mpi
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_63946/mpi_mpi
 Checking test mpi results ....
  Comparing sfcf000.nc .....USING NCCMP......OK
  Comparing sfcf021.nc .....USING NCCMP......OK
@@ -214,14 +214,14 @@ Checking test mpi results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .....USING NCCMP......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .....USING NCCMP......OK
 
-  0: The total amount of wall time                        = 252.275080
-  0: The maximum resident set size (KB)                   = 1281536
+  0: The total amount of wall time                        = 250.421070
+  0: The maximum resident set size (KB)                   = 1278668
 
 Test mpi PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/control_p8_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_226640/rst_rst
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_63946/rst_rst
 Checking test rst results ....
  Comparing sfcf000.nc .....USING NCCMP......OK
  Comparing sfcf021.nc .....USING NCCMP......OK
@@ -268,14 +268,14 @@ Checking test rst results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .....USING NCCMP......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .....USING NCCMP......OK
 
-  0: The total amount of wall time                        = 257.921526
-  0: The maximum resident set size (KB)                   = 1278656
+  0: The total amount of wall time                        = 267.943348
+  0: The maximum resident set size (KB)                   = 1275920
 
 Test rst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/control_p8_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_226640/std_base_std_base
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_63946/std_base_std_base
 Checking test std_base results ....
 Moving baseline std_base files ....
  Moving sfcf000.nc .........OK
@@ -323,14 +323,14 @@ Moving baseline std_base files ....
  Moving RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Moving RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 248.830644
-  0: The maximum resident set size (KB)                   = 1281968
+  0: The total amount of wall time                        = 249.896889
+  0: The maximum resident set size (KB)                   = 1276116
 
 Test std_base PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/control_p8_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_226640/thr_thr
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_63946/thr_thr
 Checking test thr results ....
  Comparing sfcf000.nc .....USING NCCMP......OK
  Comparing sfcf021.nc .....USING NCCMP......OK
@@ -377,11 +377,11 @@ Checking test thr results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .....USING NCCMP......OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .....USING NCCMP......OK
 
-  0: The total amount of wall time                        = 250.246300
-  0: The maximum resident set size (KB)                   = 1282284
+  0: The total amount of wall time                        = 256.272146
+  0: The maximum resident set size (KB)                   = 1278636
 
 Test thr PASS
 
 OPERATION REQUIREMENT TEST WAS SUCCESSFUL
-Wed Mar 13 17:40:13 UTC 2024
-Elapsed time: 01h:39m:42s. Have a nice day!
+Fri Mar 15 15:51:09 UTC 2024
+Elapsed time: 01h:20m:37s. Have a nice day!

--- a/tests/logs/OpnReqTests_cpld_control_nowave_noaero_p8_hera.log
+++ b/tests/logs/OpnReqTests_cpld_control_nowave_noaero_p8_hera.log
@@ -1,9 +1,9 @@
-Wed Mar 13 18:29:02 UTC 2024
+Fri Mar 15 17:05:46 UTC 2024
 Start Operation Requirement Test
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/cpld_control_c96_noaero_p8_dbg_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_216513/dbg_base_dbg_base
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_183838/dbg_base_dbg_base
 Checking test dbg_base results ....
 Moving baseline dbg_base files ....
  Moving sfcf021.tile1.nc .........OK
@@ -66,14 +66,14 @@ Moving baseline dbg_base files ....
  Moving RESTART/iced.2021-03-23-21600.nc .........OK
  Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1390.651720
-  0: The maximum resident set size (KB)                   = 1411516
+  0: The total amount of wall time                        = 1356.631044
+  0: The maximum resident set size (KB)                   = 1411552
 
 Test dbg_base PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/cpld_control_c96_noaero_p8_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_216513/rst_rst
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_183838/rst_rst
 Checking test rst results ....
  Comparing sfcf021.tile1.nc .....USING NCCMP......OK
  Comparing sfcf021.tile2.nc .....USING NCCMP......OK
@@ -135,14 +135,14 @@ Checking test rst results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .....USING NCCMP......OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .....USING NCCMP......OK
 
-  0: The total amount of wall time                        = 388.568533
-  0: The maximum resident set size (KB)                   = 1404964
+  0: The total amount of wall time                        = 388.496545
+  0: The maximum resident set size (KB)                   = 1403852
 
 Test rst PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/cpld_control_c96_noaero_p8_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_216513/std_base_std_base
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_183838/std_base_std_base
 Checking test std_base results ....
 Moving baseline std_base files ....
  Moving sfcf021.tile1.nc .........OK
@@ -205,11 +205,11 @@ Moving baseline std_base files ....
  Moving RESTART/iced.2021-03-23-21600.nc .........OK
  Moving RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 429.798207
-  0: The maximum resident set size (KB)                   = 1403184
+  0: The total amount of wall time                        = 390.554898
+  0: The maximum resident set size (KB)                   = 1403928
 
 Test std_base PASS
 
 OPERATION REQUIREMENT TEST WAS SUCCESSFUL
-Wed Mar 13 19:38:16 UTC 2024
-Elapsed time: 01h:09m:15s. Have a nice day!
+Fri Mar 15 22:24:11 UTC 2024
+Elapsed time: 05h:18m:26s. Have a nice day!

--- a/tests/logs/OpnReqTests_regional_control_hera.log
+++ b/tests/logs/OpnReqTests_regional_control_hera.log
@@ -1,9 +1,9 @@
-Wed Mar 13 19:39:46 UTC 2024
+Fri Mar 15 16:17:17 UTC 2024
 Start Operation Requirement Test
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/regional_control_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_294049/dcp_dcp
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_135871/dcp_dcp
 Checking test dcp results ....
  Comparing dynf000.nc .....USING NCCMP......OK
  Comparing dynf006.nc .....USING NCCMP......OK
@@ -14,14 +14,14 @@ Checking test dcp results ....
  Comparing NATLEV.GrbF00 .....USING CMP......OK
  Comparing NATLEV.GrbF06 .....USING CMP......OK
 
-  0: The total amount of wall time                        = 518.481376
-  0: The maximum resident set size (KB)                   = 589344
+  0: The total amount of wall time                        = 511.975861
+  0: The maximum resident set size (KB)                   = 589832
 
 Test dcp PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/regional_control_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_294049/std_base_std_base
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_135871/std_base_std_base
 Checking test std_base results ....
 Moving baseline std_base files ....
  Moving dynf000.nc .........OK
@@ -33,14 +33,14 @@ Moving baseline std_base files ....
  Moving NATLEV.GrbF00 .........OK
  Moving NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 511.698032
-  0: The maximum resident set size (KB)                   = 588824
+  0: The total amount of wall time                        = 519.974209
+  0: The maximum resident set size (KB)                   = 589384
 
 Test std_base PASS
 
 
 baseline dir = /scratch1/NCEPDEV/stmp4/Zachary.Shrader/FV3_OPNREQ_TEST/OPNREQ_TEST/regional_control_std_base_gnu
-working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_294049/thr_thr
+working dir  = /scratch1/NCEPDEV/stmp2/Zachary.Shrader/FV3_OPNREQ_TEST/opnReqTest_135871/thr_thr
 Checking test thr results ....
  Comparing dynf000.nc .....USING NCCMP......OK
  Comparing dynf006.nc .....USING NCCMP......OK
@@ -51,11 +51,11 @@ Checking test thr results ....
  Comparing NATLEV.GrbF00 .....USING CMP......OK
  Comparing NATLEV.GrbF06 .....USING CMP......OK
 
-  0: The total amount of wall time                        = 514.740790
-  0: The maximum resident set size (KB)                   = 590320
+  0: The total amount of wall time                        = 532.386605
+  0: The maximum resident set size (KB)                   = 589932
 
 Test thr PASS
 
 OPERATION REQUIREMENT TEST WAS SUCCESSFUL
-Wed Mar 13 20:34:36 UTC 2024
-Elapsed time: 00h:54m:51s. Have a nice day!
+Fri Mar 15 17:01:36 UTC 2024
+Elapsed time: 00h:44m:20s. Have a nice day!

--- a/tests/logs/RegressionTests_derecho.log
+++ b/tests/logs/RegressionTests_derecho.log
@@ -1,7 +1,7 @@
 ====START OF DERECHO REGRESSION TESTING LOG====
 
 UFSWM hash used in testing:
-19159d93d74d6f3c37fdf74fb3475e000435f07e
+7076763c9cb076a4c05505b604424e438d686936
 
 Submodule hashes used in testing:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
@@ -11,10 +11,10 @@ Submodule hashes used in testing:
  f6ff8f7c4d4cb6feabe3651b13204cf43fc948e3 CICE-interface/CICE/icepack (Icepack1.1.0-182-gf6ff8f7)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  6663459e58a04e3bda2157d5891d227e3abc3c7a FV3/atmos_cubed_sphere (201912_public_release-386-g6663459)
- 221788f4e2539af797eb02efe42465b153533201 FV3/ccpp/framework (ccpp_transition_to_vlab_master_20190705-613-g221788f)
- bbdec2ffceeb0cda70aaaa4f44e619a5468e7be3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5134-gbbdec2ff)
+ 87e6d92e2ca48a55b66f8810f347b51c70c193c4 FV3/ccpp/framework (v0.1.0-1436-g87e6d92)
+ 2f15ae92802cae11fd0efb902439a084609984f3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5141-g2f15ae92)
  74a0e098b2163425e4b5466c2dfcf8ae26d560a5 FV3/ccpp/physics/physics/Radiation/RRTMGP/rte-rrtmgp (v1.6)
  945cb2cef5e8bd5949afd4f0fc35c4fb6e95a1bf FV3/upp (upp_v10.2.0-159-g945cb2c)
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e FV3/upp/sorc/libIFI.fd
@@ -32,7 +32,7 @@ Submodule hashes used in testing:
  7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
@@ -47,271 +47,271 @@ The first time is for the full script (prep+run+finalize).
 The second time is specifically for the run phase.
 Times/Memory will be empty for failed tests.
 
-BASELINE DIRECTORY: /glade/derecho/scratch/epicufsrt/ufs-weather-model/RT//NEMSfv3gfs/develop-20240312
-COMPARISON DIRECTORY: /glade/derecho/scratch/zshrader/FV3_RT/rt_114022
+BASELINE DIRECTORY: /glade/derecho/scratch/epicufsrt/ufs-weather-model/RT//NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /glade/derecho/scratch/epicufsrt/FV3_RT/rt_84275
 
 RT.SH OPTIONS USED:
 * (-a) - HPC PROJECT ACCOUNT: nral0032
 * (-l) - USE CONFIG FILE: rt.conf
 * (-e) - USE ECFLOW
 
-PASS -- COMPILE 's2swa_32bit_intel' [20:21, 19:19]
-PASS -- TEST 'cpld_control_p8_mixedmode_intel' [08:10, 04:57](3077 MB)
+PASS -- COMPILE 's2swa_32bit_intel' [20:30, 19:43]
+PASS -- TEST 'cpld_control_p8_mixedmode_intel' [09:40, 04:59](3074 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_intel' [21:22, 20:04]
-PASS -- TEST 'cpld_control_gfsv17_intel' [16:19, 13:50](1685 MB)
-PASS -- TEST 'cpld_control_gfsv17_iau_intel' [18:56, 15:11](1818 MB)
-PASS -- TEST 'cpld_restart_gfsv17_intel' [11:00, 07:13](951 MB)
-PASS -- TEST 'cpld_mpi_gfsv17_intel' [18:18, 15:49](1663 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_intel' [21:24, 21:05]
+PASS -- TEST 'cpld_control_gfsv17_intel' [16:59, 13:50](1686 MB)
+PASS -- TEST 'cpld_control_gfsv17_iau_intel' [19:29, 15:26](1823 MB)
+PASS -- TEST 'cpld_restart_gfsv17_intel' [11:23, 07:36](972 MB)
+PASS -- TEST 'cpld_mpi_gfsv17_intel' [19:12, 15:53](1654 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [09:17, 08:57]
-PASS -- TEST 'cpld_debug_gfsv17_intel' [24:14, 21:32](1695 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [10:21, 09:28]
+PASS -- TEST 'cpld_debug_gfsv17_intel' [24:30, 21:40](1693 MB)
 
-PASS -- COMPILE 's2swa_intel' [19:28, 19:04]
-PASS -- TEST 'cpld_control_p8_intel' [09:32, 05:37](3092 MB)
-PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [09:40, 05:36](3094 MB)
-PASS -- TEST 'cpld_restart_p8_intel' [06:51, 03:18](3151 MB)
-PASS -- TEST 'cpld_control_qr_p8_intel' [09:32, 05:37](3127 MB)
-PASS -- TEST 'cpld_restart_qr_p8_intel' [06:51, 03:20](3177 MB)
-PASS -- TEST 'cpld_decomp_p8_intel' [09:22, 05:29](3087 MB)
-PASS -- TEST 'cpld_mpi_p8_intel' [08:30, 04:33](3386 MB)
-PASS -- TEST 'cpld_control_ciceC_p8_intel' [09:45, 05:36](3099 MB)
-PASS -- TEST 'cpld_control_c192_p8_intel' [14:35, 08:46](3639 MB)
-PASS -- TEST 'cpld_restart_c192_p8_intel' [15:24, 05:53](3616 MB)
-PASS -- TEST 'cpld_bmark_p8_intel' [29:58, 09:54](4342 MB)
-PASS -- TEST 'cpld_restart_bmark_p8_intel' [27:00, 07:16](4650 MB)
-PASS -- TEST 'cpld_s2sa_p8_intel' [09:08, 05:22](3067 MB)
+PASS -- COMPILE 's2swa_intel' [20:30, 19:28]
+PASS -- TEST 'cpld_control_p8_intel' [09:47, 05:41](3091 MB)
+PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [10:02, 05:42](3088 MB)
+PASS -- TEST 'cpld_restart_p8_intel' [07:34, 03:20](3148 MB)
+PASS -- TEST 'cpld_control_qr_p8_intel' [09:48, 05:39](3128 MB)
+PASS -- TEST 'cpld_restart_qr_p8_intel' [07:34, 03:25](3177 MB)
+PASS -- TEST 'cpld_decomp_p8_intel' [09:29, 05:34](3092 MB)
+PASS -- TEST 'cpld_mpi_p8_intel' [08:35, 04:41](3396 MB)
+PASS -- TEST 'cpld_control_ciceC_p8_intel' [09:59, 05:43](3099 MB)
+PASS -- TEST 'cpld_control_c192_p8_intel' [15:50, 08:54](3636 MB)
+PASS -- TEST 'cpld_restart_c192_p8_intel' [17:44, 06:13](3618 MB)
+PASS -- TEST 'cpld_bmark_p8_intel' [34:56, 09:56](4341 MB)
+PASS -- TEST 'cpld_restart_bmark_p8_intel' [29:54, 07:53](4642 MB)
+PASS -- TEST 'cpld_s2sa_p8_intel' [09:09, 05:20](3063 MB)
 
-PASS -- COMPILE 's2sw_intel' [19:21, 18:23]
-PASS -- TEST 'cpld_control_noaero_p8_intel' [07:57, 04:13](1686 MB)
-PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [08:14, 04:14](1725 MB)
+PASS -- COMPILE 's2sw_intel' [19:30, 18:49]
+PASS -- TEST 'cpld_control_noaero_p8_intel' [07:06, 04:20](1685 MB)
+PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [07:15, 04:19](1726 MB)
 
-PASS -- COMPILE 's2swa_debug_intel' [09:15, 08:54]
-PASS -- TEST 'cpld_debug_p8_intel' [10:29, 07:43](3151 MB)
+PASS -- COMPILE 's2swa_debug_intel' [10:26, 09:27]
+PASS -- TEST 'cpld_debug_p8_intel' [12:14, 07:49](3147 MB)
 
-PASS -- COMPILE 's2sw_debug_intel' [09:15, 08:23]
-PASS -- TEST 'cpld_debug_noaero_p8_intel' [07:57, 05:14](1701 MB)
+PASS -- COMPILE 's2sw_debug_intel' [09:25, 08:43]
+PASS -- TEST 'cpld_debug_noaero_p8_intel' [08:01, 05:17](1702 MB)
 
-PASS -- COMPILE 's2s_aoflux_intel' [14:17, 13:53]
-PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [07:31, 04:16](1719 MB)
+PASS -- COMPILE 's2s_aoflux_intel' [15:29, 14:31]
+PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [07:36, 04:21](1720 MB)
 
-PASS -- COMPILE 's2s_intel' [14:17, 13:51]
-PASS -- TEST 'cpld_control_c48_intel' [08:19, 06:33](2664 MB)
+PASS -- COMPILE 's2s_intel' [15:29, 14:26]
+PASS -- TEST 'cpld_control_c48_intel' [08:24, 06:38](2669 MB)
 
-PASS -- COMPILE 's2swa_faster_intel' [23:22, 22:38]
-PASS -- TEST 'cpld_control_p8_faster_intel' [08:22, 05:30](3098 MB)
+PASS -- COMPILE 's2swa_faster_intel' [23:31, 22:57]
+PASS -- TEST 'cpld_control_p8_faster_intel' [09:12, 05:35](3098 MB)
 
-PASS -- COMPILE 's2sw_pdlib_intel' [19:26, 18:58]
-PASS -- TEST 'cpld_control_pdlib_p8_intel' [17:06, 14:01](1697 MB)
-PASS -- TEST 'cpld_restart_pdlib_p8_intel' [10:54, 07:19](1012 MB)
-PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [19:05, 16:03](1668 MB)
+PASS -- COMPILE 's2sw_pdlib_intel' [20:24, 19:33]
+PASS -- TEST 'cpld_control_pdlib_p8_intel' [17:41, 14:07](1701 MB)
+PASS -- TEST 'cpld_restart_pdlib_p8_intel' [10:48, 07:38](1011 MB)
+PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [19:17, 16:04](1664 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_intel' [09:20, 08:11]
-PASS -- TEST 'cpld_debug_pdlib_p8_intel' [25:01, 22:43](1709 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_intel' [10:20, 08:57]
+PASS -- TEST 'cpld_debug_pdlib_p8_intel' [25:45, 22:39](1718 MB)
 
-PASS -- COMPILE 'atm_dyn32_intel' [13:24, 12:20]
-PASS -- TEST 'control_flake_intel' [05:03, 03:26](670 MB)
-PASS -- TEST 'control_CubedSphereGrid_intel' [03:57, 02:05](1369 MB)
-PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [04:06, 02:11](621 MB)
-PASS -- TEST 'control_latlon_intel' [03:53, 02:07](618 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [03:59, 02:10](620 MB)
-PASS -- TEST 'control_c48_intel' [06:46, 05:17](737 MB)
-PASS -- TEST 'control_c48.v2.sfc_intel' [06:51, 05:15](734 MB)
-PASS -- TEST 'control_c192_intel' [09:41, 07:53](738 MB)
-PASS -- TEST 'control_c384_intel' [15:10, 08:13](1063 MB)
-PASS -- TEST 'control_c384gdas_intel' [17:32, 07:16](1198 MB)
+PASS -- COMPILE 'atm_dyn32_intel' [13:16, 12:33]
+PASS -- TEST 'control_flake_intel' [04:48, 03:29](669 MB)
+PASS -- TEST 'control_CubedSphereGrid_intel' [03:51, 02:04](618 MB)
+PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [03:59, 02:13](622 MB)
+PASS -- TEST 'control_latlon_intel' [03:48, 02:07](617 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [03:57, 02:09](623 MB)
+PASS -- TEST 'control_c48_intel' [06:56, 05:17](736 MB)
+PASS -- TEST 'control_c48.v2.sfc_intel' [06:57, 05:22](737 MB)
+PASS -- TEST 'control_c192_intel' [10:08, 07:53](740 MB)
+PASS -- TEST 'control_c384_intel' [16:33, 08:24](1060 MB)
+PASS -- TEST 'control_c384gdas_intel' [19:07, 07:33](1200 MB)
 PASS -- TEST 'control_stochy_intel' [02:47, 01:28](626 MB)
-PASS -- TEST 'control_stochy_restart_intel' [01:43, 00:54](438 MB)
-PASS -- TEST 'control_lndp_intel' [02:48, 01:25](623 MB)
-PASS -- TEST 'control_iovr4_intel' [03:59, 02:07](618 MB)
-PASS -- TEST 'control_iovr5_intel' [04:03, 02:08](620 MB)
-PASS -- TEST 'control_p8_intel' [04:46, 02:32](1591 MB)
-PASS -- TEST 'control_p8.v2.sfc_intel' [05:05, 02:29](1592 MB)
-PASS -- TEST 'control_p8_ugwpv1_intel' [04:59, 02:28](1595 MB)
-PASS -- TEST 'control_restart_p8_intel' [03:38, 01:25](796 MB)
-PASS -- TEST 'control_noqr_p8_intel' [04:47, 02:28](1589 MB)
-PASS -- TEST 'control_restart_noqr_p8_intel' [03:40, 01:23](801 MB)
-PASS -- TEST 'control_decomp_p8_intel' [04:43, 02:34](1589 MB)
-PASS -- TEST 'control_p8_lndp_intel' [06:44, 04:24](1601 MB)
-PASS -- TEST 'control_p8_rrtmgp_intel' [05:59, 03:17](1658 MB)
-PASS -- TEST 'control_p8_mynn_intel' [04:54, 02:33](1605 MB)
-PASS -- TEST 'merra2_thompson_intel' [06:03, 02:59](1608 MB)
-PASS -- TEST 'regional_control_intel' [06:16, 04:30](628 MB)
-PASS -- TEST 'regional_restart_intel' [04:06, 02:31](799 MB)
-PASS -- TEST 'regional_decomp_intel' [06:11, 04:43](630 MB)
-PASS -- TEST 'regional_noquilt_intel' [06:11, 04:26](1158 MB)
-PASS -- TEST 'regional_netcdf_parallel_intel' [06:07, 04:27](624 MB)
-PASS -- TEST 'regional_2dwrtdecomp_intel' [06:16, 04:28](633 MB)
-PASS -- TEST 'regional_wofs_intel' [08:13, 05:35](1600 MB)
+PASS -- TEST 'control_stochy_restart_intel' [02:39, 00:53](438 MB)
+PASS -- TEST 'control_lndp_intel' [02:47, 01:23](623 MB)
+PASS -- TEST 'control_iovr4_intel' [03:42, 02:08](622 MB)
+PASS -- TEST 'control_iovr5_intel' [03:48, 02:09](622 MB)
+PASS -- TEST 'control_p8_intel' [04:47, 02:31](1599 MB)
+PASS -- TEST 'control_p8.v2.sfc_intel' [04:52, 02:33](1596 MB)
+PASS -- TEST 'control_p8_ugwpv1_intel' [05:10, 02:31](1596 MB)
+PASS -- TEST 'control_restart_p8_intel' [03:43, 01:29](798 MB)
+PASS -- TEST 'control_noqr_p8_intel' [04:50, 02:33](1592 MB)
+PASS -- TEST 'control_restart_noqr_p8_intel' [03:53, 01:25](803 MB)
+PASS -- TEST 'control_decomp_p8_intel' [04:45, 02:37](1586 MB)
+PASS -- TEST 'control_p8_lndp_intel' [06:36, 04:24](1592 MB)
+PASS -- TEST 'control_p8_rrtmgp_intel' [05:51, 03:20](1658 MB)
+PASS -- TEST 'control_p8_mynn_intel' [04:54, 02:35](1601 MB)
+PASS -- TEST 'merra2_thompson_intel' [06:09, 03:04](1610 MB)
+PASS -- TEST 'regional_control_intel' [06:22, 04:31](632 MB)
+PASS -- TEST 'regional_restart_intel' [04:24, 02:36](800 MB)
+PASS -- TEST 'regional_decomp_intel' [06:23, 04:48](628 MB)
+PASS -- TEST 'regional_noquilt_intel' [06:16, 04:27](1159 MB)
+PASS -- TEST 'regional_netcdf_parallel_intel' [06:22, 04:32](625 MB)
+PASS -- TEST 'regional_2dwrtdecomp_intel' [06:19, 04:35](628 MB)
+PASS -- TEST 'regional_wofs_intel' [08:23, 05:42](1599 MB)
 
-PASS -- COMPILE 'rrfs_intel' [11:20, 10:46]
-PASS -- TEST 'rap_control_intel' [08:32, 06:07](1003 MB)
-PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [07:59, 03:44](1190 MB)
-PASS -- TEST 'rap_decomp_intel' [08:26, 06:23](1000 MB)
-PASS -- TEST 'rap_restart_intel' [05:24, 03:16](877 MB)
-PASS -- TEST 'rap_sfcdiff_intel' [08:19, 06:07](1002 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_intel' [08:16, 06:21](1002 MB)
-PASS -- TEST 'rap_sfcdiff_restart_intel' [06:16, 04:35](877 MB)
-PASS -- TEST 'hrrr_control_intel' [05:18, 03:12](997 MB)
-PASS -- TEST 'hrrr_control_decomp_intel' [05:19, 03:18](998 MB)
-PASS -- TEST 'hrrr_control_2threads_intel' [05:21, 02:48](1087 MB)
-PASS -- TEST 'hrrr_control_restart_intel' [02:56, 01:46](832 MB)
-PASS -- TEST 'rrfs_v1beta_intel' [08:13, 05:59](1369 MB)
-PASS -- TEST 'rrfs_v1nssl_intel' [08:51, 07:22](1955 MB)
-PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [08:43, 07:09](1947 MB)
+PASS -- COMPILE 'rrfs_intel' [12:22, 11:08]
+PASS -- TEST 'rap_control_intel' [08:47, 06:09](1003 MB)
+PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [09:22, 03:47](1196 MB)
+PASS -- TEST 'rap_decomp_intel' [08:54, 06:25](1003 MB)
+PASS -- TEST 'rap_restart_intel' [05:32, 03:15](882 MB)
+PASS -- TEST 'rap_sfcdiff_intel' [08:50, 06:06](1003 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_intel' [08:51, 06:26](1002 MB)
+PASS -- TEST 'rap_sfcdiff_restart_intel' [06:34, 04:36](882 MB)
+PASS -- TEST 'hrrr_control_intel' [05:36, 03:15](1001 MB)
+PASS -- TEST 'hrrr_control_decomp_intel' [05:33, 03:20](996 MB)
+PASS -- TEST 'hrrr_control_2threads_intel' [05:25, 02:48](1092 MB)
+PASS -- TEST 'hrrr_control_restart_intel' [03:08, 01:49](1405 MB)
+PASS -- TEST 'rrfs_v1beta_intel' [08:21, 05:59](1000 MB)
+PASS -- TEST 'rrfs_v1nssl_intel' [08:56, 07:25](1956 MB)
+PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [09:01, 07:10](1946 MB)
 
-PASS -- COMPILE 'csawmg_intel' [11:21, 10:05]
-PASS -- TEST 'control_csawmg_intel' [07:14, 05:52](692 MB)
-PASS -- TEST 'control_csawmgt_intel' [07:20, 05:47](692 MB)
-PASS -- TEST 'control_ras_intel' [03:41, 02:54](654 MB)
+PASS -- COMPILE 'csawmg_intel' [11:21, 10:16]
+PASS -- TEST 'control_csawmg_intel' [08:16, 05:53](691 MB)
+PASS -- TEST 'control_csawmgt_intel' [08:19, 05:48](690 MB)
+PASS -- TEST 'control_ras_intel' [04:53, 02:55](656 MB)
 
-PASS -- COMPILE 'wam_intel' [10:20, 09:30]
-PASS -- TEST 'control_wam_intel' [02:32, 01:53](379 MB)
+PASS -- COMPILE 'wam_intel' [10:19, 09:35]
+PASS -- TEST 'control_wam_intel' [03:38, 01:56](380 MB)
 
-PASS -- COMPILE 'atm_faster_dyn32_intel' [13:27, 12:20]
-PASS -- TEST 'control_p8_faster_intel' [04:44, 02:23](1600 MB)
-PASS -- TEST 'regional_control_faster_intel' [06:16, 04:19](625 MB)
+PASS -- COMPILE 'atm_faster_dyn32_intel' [13:23, 12:43]
+PASS -- TEST 'control_p8_faster_intel' [05:00, 02:29](1590 MB)
+PASS -- TEST 'regional_control_faster_intel' [06:16, 04:18](628 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_intel' [09:14, 08:27]
-PASS -- TEST 'control_CubedSphereGrid_debug_intel' [03:52, 02:33](793 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [04:45, 02:34](792 MB)
-PASS -- TEST 'control_stochy_debug_intel' [04:38, 02:50](798 MB)
-PASS -- TEST 'control_lndp_debug_intel' [03:43, 02:32](801 MB)
-PASS -- TEST 'control_csawmg_debug_intel' [05:25, 03:56](837 MB)
-PASS -- TEST 'control_csawmgt_debug_intel' [05:19, 03:53](836 MB)
-PASS -- TEST 'control_ras_debug_intel' [03:37, 02:38](806 MB)
-PASS -- TEST 'control_diag_debug_intel' [04:43, 02:39](851 MB)
-PASS -- TEST 'control_debug_p8_intel' [04:19, 02:37](1624 MB)
-PASS -- TEST 'regional_debug_intel' [18:09, 16:01](664 MB)
-PASS -- TEST 'rap_control_debug_intel' [05:44, 04:38](1180 MB)
-PASS -- TEST 'hrrr_control_debug_intel' [05:39, 04:33](1174 MB)
-PASS -- TEST 'hrrr_gf_debug_intel' [05:35, 04:36](1179 MB)
-PASS -- TEST 'hrrr_c3_debug_intel' [06:37, 04:47](1177 MB)
-PASS -- TEST 'rap_unified_drag_suite_debug_intel' [05:31, 04:40](1179 MB)
-PASS -- TEST 'rap_diag_debug_intel' [08:48, 04:54](1260 MB)
-PASS -- TEST 'rap_cires_ugwp_debug_intel' [06:42, 04:52](1175 MB)
-PASS -- TEST 'rap_unified_ugwp_debug_intel' [05:32, 04:45](1179 MB)
-PASS -- TEST 'rap_lndp_debug_intel' [05:39, 04:40](1365 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_intel' [05:50, 04:38](1178 MB)
-PASS -- TEST 'rap_noah_debug_intel' [05:43, 04:36](1180 MB)
-PASS -- TEST 'rap_sfcdiff_debug_intel' [05:48, 04:41](1174 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [08:33, 07:31](1177 MB)
-PASS -- TEST 'rrfs_v1beta_debug_intel' [05:36, 04:39](1172 MB)
-PASS -- TEST 'rap_clm_lake_debug_intel' [06:43, 05:27](1182 MB)
-PASS -- TEST 'rap_flake_debug_intel' [05:45, 04:40](1181 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [10:14, 07:57](1183 MB)
+PASS -- COMPILE 'atm_debug_dyn32_intel' [09:23, 08:37]
+PASS -- TEST 'control_CubedSphereGrid_debug_intel' [03:57, 02:39](792 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [03:54, 02:34](795 MB)
+PASS -- TEST 'control_stochy_debug_intel' [04:43, 02:51](798 MB)
+PASS -- TEST 'control_lndp_debug_intel' [03:50, 02:39](800 MB)
+PASS -- TEST 'control_csawmg_debug_intel' [06:21, 03:59](836 MB)
+PASS -- TEST 'control_csawmgt_debug_intel' [06:27, 04:01](838 MB)
+PASS -- TEST 'control_ras_debug_intel' [03:42, 02:39](808 MB)
+PASS -- TEST 'control_diag_debug_intel' [04:53, 02:44](853 MB)
+PASS -- TEST 'control_debug_p8_intel' [04:23, 02:43](1629 MB)
+PASS -- TEST 'regional_debug_intel' [17:30, 15:50](672 MB)
+PASS -- TEST 'rap_control_debug_intel' [05:48, 04:48](1180 MB)
+PASS -- TEST 'hrrr_control_debug_intel' [05:54, 04:31](1176 MB)
+PASS -- TEST 'hrrr_gf_debug_intel' [05:42, 04:41](1179 MB)
+PASS -- TEST 'hrrr_c3_debug_intel' [05:55, 04:46](1180 MB)
+PASS -- TEST 'rap_unified_drag_suite_debug_intel' [05:39, 04:38](1178 MB)
+PASS -- TEST 'rap_diag_debug_intel' [09:24, 04:53](1263 MB)
+PASS -- TEST 'rap_cires_ugwp_debug_intel' [06:50, 04:46](1179 MB)
+PASS -- TEST 'rap_unified_ugwp_debug_intel' [05:50, 04:46](1183 MB)
+PASS -- TEST 'rap_lndp_debug_intel' [06:48, 04:51](1179 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_intel' [05:51, 04:49](1182 MB)
+PASS -- TEST 'rap_noah_debug_intel' [05:51, 04:35](1179 MB)
+PASS -- TEST 'rap_sfcdiff_debug_intel' [06:42, 04:43](1180 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [08:53, 07:31](1176 MB)
+PASS -- TEST 'rrfs_v1beta_debug_intel' [05:51, 04:42](1177 MB)
+PASS -- TEST 'rap_clm_lake_debug_intel' [06:49, 05:27](1180 MB)
+PASS -- TEST 'rap_flake_debug_intel' [05:43, 04:39](1176 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [10:15, 07:53](1185 MB)
 
-PASS -- COMPILE 'wam_debug_intel' [06:20, 05:14]
-PASS -- TEST 'control_wam_debug_intel' [05:32, 04:37](419 MB)
+PASS -- COMPILE 'wam_debug_intel' [06:19, 05:17]
+PASS -- TEST 'control_wam_debug_intel' [05:46, 04:40](420 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [10:26, 09:30]
-PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [07:18, 03:31](1060 MB)
-PASS -- TEST 'rap_control_dyn32_phy32_intel' [07:13, 05:08](881 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [04:35, 02:46](880 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [05:21, 02:54](881 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_intel' [06:15, 03:54](794 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [02:51, 01:33](776 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [10:21, 09:42]
+PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [07:39, 03:37](1057 MB)
+PASS -- TEST 'rap_control_dyn32_phy32_intel' [07:24, 05:09](887 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [05:27, 02:47](881 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [04:38, 02:57](1405 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_intel' [06:19, 03:54](972 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [02:58, 01:36](775 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [12:26, 11:47]
-PASS -- TEST 'conus13km_control_intel' [04:08, 01:53](1081 MB)
-PASS -- TEST 'conus13km_2threads_intel' [04:11, 00:58](1081 MB)
-PASS -- TEST 'conus13km_restart_mismatch_intel' [04:09, 01:10](970 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [12:22, 11:50]
+PASS -- TEST 'conus13km_control_intel' [06:39, 01:59](1081 MB)
+PASS -- TEST 'conus13km_2threads_intel' [04:24, 01:05](1079 MB)
+PASS -- TEST 'conus13km_restart_mismatch_intel' [04:24, 01:11](973 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [10:25, 09:30]
-PASS -- TEST 'rap_control_dyn64_phy32_intel' [05:11, 03:38](906 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [10:21, 10:00]
+PASS -- TEST 'rap_control_dyn64_phy32_intel' [05:21, 03:42](908 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [06:18, 05:26]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [05:37, 04:40](1055 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [05:40, 04:23](1054 MB)
-PASS -- TEST 'conus13km_debug_intel' [16:34, 13:17](1131 MB)
-PASS -- TEST 'conus13km_debug_qr_intel' [16:23, 13:27](816 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_intel' [16:12, 13:18](1199 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [06:19, 05:44]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [05:47, 04:42](1057 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [05:37, 04:27](1055 MB)
+PASS -- TEST 'conus13km_debug_intel' [17:07, 13:29](1132 MB)
+PASS -- TEST 'conus13km_debug_qr_intel' [16:57, 13:49](819 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_intel' [16:48, 13:22](1200 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [06:24, 05:29]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [05:52, 04:34](1080 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [06:19, 05:30]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [05:41, 04:37](1084 MB)
 
-PASS -- COMPILE 'hafsw_intel' [16:29, 15:28]
-PASS -- TEST 'hafs_regional_atm_intel' [07:08, 04:34](718 MB)
-PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [07:27, 05:04](1064 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_intel' [09:31, 06:30](776 MB)
-PASS -- TEST 'hafs_regional_atm_wav_intel' [14:10, 10:55](793 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [15:13, 11:59](811 MB)
-PASS -- TEST 'hafs_regional_1nest_atm_intel' [06:49, 04:39](473 MB)
-PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [08:01, 05:47](494 MB)
-PASS -- TEST 'hafs_global_1nest_atm_intel' [04:17, 02:21](389 MB)
-PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [10:31, 06:18](459 MB)
-PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [05:18, 03:19](509 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [05:54, 03:06](508 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [05:41, 03:51](586 MB)
-PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [02:46, 01:16](423 MB)
-PASS -- TEST 'gnv1_nested_intel' [05:32, 03:26](781 MB)
+PASS -- COMPILE 'hafsw_intel' [16:23, 15:52]
+PASS -- TEST 'hafs_regional_atm_intel' [07:02, 04:42](712 MB)
+PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [07:24, 05:21](1071 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_intel' [09:41, 06:38](777 MB)
+PASS -- TEST 'hafs_regional_atm_wav_intel' [14:23, 11:05](795 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [15:53, 12:19](811 MB)
+PASS -- TEST 'hafs_regional_1nest_atm_intel' [06:50, 04:41](1405 MB)
+PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [08:11, 05:49](495 MB)
+PASS -- TEST 'hafs_global_1nest_atm_intel' [04:29, 02:25](384 MB)
+PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [11:08, 06:30](458 MB)
+PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [05:24, 03:22](509 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [05:42, 03:07](506 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [06:58, 03:53](579 MB)
+PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [02:42, 01:21](424 MB)
+PASS -- TEST 'gnv1_nested_intel' [06:00, 03:34](780 MB)
 
-PASS -- COMPILE 'hafsw_debug_intel' [07:24, 06:33]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [14:26, 12:01](608 MB)
+PASS -- COMPILE 'hafsw_debug_intel' [08:20, 07:04]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [14:35, 12:40](614 MB)
 
-PASS -- COMPILE 'hafsw_faster_intel' [20:23, 19:10]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [09:42, 07:15](633 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [09:49, 07:15](688 MB)
+PASS -- COMPILE 'hafsw_faster_intel' [20:24, 19:37]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [09:48, 07:16](630 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [10:41, 07:25](685 MB)
 
-PASS -- COMPILE 'hafs_mom6w_intel' [17:22, 16:13]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [07:56, 05:24](675 MB)
+PASS -- COMPILE 'hafs_mom6w_intel' [17:23, 16:29]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [08:21, 05:26](673 MB)
 
-PASS -- COMPILE 'hafs_all_intel' [14:21, 13:36]
-PASS -- TEST 'hafs_regional_docn_intel' [07:59, 05:39](752 MB)
-PASS -- TEST 'hafs_regional_docn_oisst_intel' [07:40, 05:40](735 MB)
-PASS -- TEST 'hafs_regional_datm_cdeps_intel' [18:24, 16:10](895 MB)
+PASS -- COMPILE 'hafs_all_intel' [15:16, 14:16]
+PASS -- TEST 'hafs_regional_docn_intel' [08:10, 05:43](750 MB)
+PASS -- TEST 'hafs_regional_docn_oisst_intel' [08:13, 05:44](735 MB)
+PASS -- TEST 'hafs_regional_datm_cdeps_intel' [18:34, 16:13](895 MB)
 
-PASS -- COMPILE 'datm_cdeps_intel' [08:19, 07:31]
-PASS -- TEST 'datm_cdeps_control_cfsr_intel' [03:41, 02:29](760 MB)
-PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [02:48, 01:34](748 MB)
-PASS -- TEST 'datm_cdeps_control_gefs_intel' [03:44, 02:22](924 MB)
-PASS -- TEST 'datm_cdeps_iau_gefs_intel' [03:37, 02:25](638 MB)
-PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [03:43, 02:26](639 MB)
-PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [03:37, 02:31](760 MB)
-PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [03:41, 02:30](761 MB)
-PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [03:33, 02:22](637 MB)
-PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [10:44, 05:45](686 MB)
-PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [10:48, 05:43](670 MB)
-PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [03:27, 02:28](760 MB)
-PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [04:59, 03:54](2016 MB)
-PASS -- TEST 'datm_cdeps_gfs_intel' [04:58, 03:55](2017 MB)
+PASS -- COMPILE 'datm_cdeps_intel' [08:19, 07:45]
+PASS -- TEST 'datm_cdeps_control_cfsr_intel' [03:46, 02:31](760 MB)
+PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [03:03, 01:36](748 MB)
+PASS -- TEST 'datm_cdeps_control_gefs_intel' [03:52, 02:24](640 MB)
+PASS -- TEST 'datm_cdeps_iau_gefs_intel' [03:53, 02:27](641 MB)
+PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [03:52, 02:29](638 MB)
+PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [03:50, 02:33](760 MB)
+PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [03:38, 02:33](761 MB)
+PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [03:41, 02:24](638 MB)
+PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [11:22, 05:54](687 MB)
+PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [11:21, 05:52](669 MB)
+PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [03:25, 02:31](761 MB)
+PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [06:05, 04:01](1957 MB)
+PASS -- TEST 'datm_cdeps_gfs_intel' [06:03, 03:59](2016 MB)
 
-PASS -- COMPILE 'datm_cdeps_debug_intel' [05:18, 04:41]
-PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [06:36, 05:09](746 MB)
+PASS -- COMPILE 'datm_cdeps_debug_intel' [06:18, 05:02]
+PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [06:43, 05:10](746 MB)
 
-PASS -- COMPILE 'datm_cdeps_faster_intel' [08:26, 07:28]
-PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [03:41, 02:28](748 MB)
+PASS -- COMPILE 'datm_cdeps_faster_intel' [08:19, 07:49]
+PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [03:50, 02:31](972 MB)
 
-PASS -- COMPILE 'datm_cdeps_land_intel' [03:12, 02:13]
-PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [02:48, 01:08](308 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_intel' [02:41, 01:03](451 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [01:37, 00:43](450 MB)
+PASS -- COMPILE 'datm_cdeps_land_intel' [03:12, 02:19]
+PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [03:03, 01:17](308 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_intel' [02:39, 01:10](450 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [01:51, 00:45](449 MB)
 
-PASS -- COMPILE 'atml_intel' [13:16, 12:28]
-PASS -- TEST 'control_p8_atmlnd_sbs_intel' [08:59, 06:25](1637 MB)
-PASS -- TEST 'control_p8_atmlnd_intel' [09:01, 06:14](1638 MB)
-PASS -- TEST 'control_restart_p8_atmlnd_intel' [05:28, 03:21](846 MB)
+PASS -- COMPILE 'atml_intel' [14:21, 12:59]
+PASS -- TEST 'control_p8_atmlnd_sbs_intel' [09:03, 06:40](1637 MB)
+PASS -- TEST 'control_p8_atmlnd_intel' [08:57, 06:45](1630 MB)
+PASS -- TEST 'control_restart_p8_atmlnd_intel' [05:10, 03:42](853 MB)
 
-PASS -- COMPILE 'atmw_intel' [13:20, 12:07]
-PASS -- TEST 'atmwav_control_noaero_p8_intel' [03:41, 01:34](1628 MB)
+PASS -- COMPILE 'atmw_intel' [13:27, 12:32]
+PASS -- TEST 'atmwav_control_noaero_p8_intel' [03:41, 01:37](1637 MB)
 
-PASS -- COMPILE 'atmwm_intel' [12:25, 12:04]
-PASS -- TEST 'control_atmwav_intel' [02:51, 01:28](636 MB)
+PASS -- COMPILE 'atmwm_intel' [13:26, 12:32]
+PASS -- TEST 'control_atmwav_intel' [03:17, 01:32](637 MB)
 
-PASS -- COMPILE 'atmaero_intel' [11:20, 10:38]
-PASS -- TEST 'atmaero_control_p8_intel' [06:13, 03:39](2947 MB)
-PASS -- TEST 'atmaero_control_p8_rad_intel' [07:07, 04:15](3001 MB)
-PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [06:24, 04:29](3009 MB)
+PASS -- COMPILE 'atmaero_intel' [12:26, 11:13]
+PASS -- TEST 'atmaero_control_p8_intel' [06:19, 03:43](2944 MB)
+PASS -- TEST 'atmaero_control_p8_rad_intel' [07:13, 04:19](2999 MB)
+PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [06:44, 04:35](3009 MB)
 
-PASS -- COMPILE 'atmaq_intel' [11:21, 10:42]
+PASS -- COMPILE 'atmaq_intel' [11:20, 10:57]
 
-PASS -- COMPILE 'atmaq_debug_intel' [06:18, 06:02]
-PASS -- TEST 'regional_atmaq_debug_intel' [26:41, 22:12](4528 MB)
+PASS -- COMPILE 'atmaq_debug_intel' [07:19, 06:27]
+PASS -- TEST 'regional_atmaq_debug_intel' [27:36, 22:37](4530 MB)
 
 SYNOPSIS:
-Starting Date/Time: 20240314 08:25:10
-Ending Date/Time: 20240314 09:53:23
-Total Time: 01h:29m:02s
+Starting Date/Time: 20240317 12:41:56
+Ending Date/Time: 20240317 14:13:29
+Total Time: 01h:32m:37s
 Compiles Completed: 39/39
 Tests Completed: 175/175
 

--- a/tests/logs/RegressionTests_gaea.log
+++ b/tests/logs/RegressionTests_gaea.log
@@ -1,7 +1,7 @@
 ====START OF GAEA REGRESSION TESTING LOG====
 
 UFSWM hash used in testing:
-c3745cd3e1ac1ebcc5578002003501f1a674414f
+0939a1dff2a2060b541eca9642a19c5ed1541f17
 
 Submodule hashes used in testing:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
@@ -11,10 +11,10 @@ Submodule hashes used in testing:
  f6ff8f7c4d4cb6feabe3651b13204cf43fc948e3 CICE-interface/CICE/icepack (Icepack1.1.0-182-gf6ff8f7)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  6663459e58a04e3bda2157d5891d227e3abc3c7a FV3/atmos_cubed_sphere (201912_public_release-386-g6663459)
- 221788f4e2539af797eb02efe42465b153533201 FV3/ccpp/framework (ccpp_transition_to_vlab_master_20190705-613-g221788f)
- bbdec2ffceeb0cda70aaaa4f44e619a5468e7be3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5134-gbbdec2ff)
+ 87e6d92e2ca48a55b66f8810f347b51c70c193c4 FV3/ccpp/framework (v0.1.0-1436-g87e6d92)
+ 2f15ae92802cae11fd0efb902439a084609984f3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5141-g2f15ae92)
  74a0e098b2163425e4b5466c2dfcf8ae26d560a5 FV3/ccpp/physics/physics/Radiation/RRTMGP/rte-rrtmgp (v1.6)
  945cb2cef5e8bd5949afd4f0fc35c4fb6e95a1bf FV3/upp (upp_v10.2.0-159-g945cb2c)
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e FV3/upp/sorc/libIFI.fd
@@ -32,7 +32,7 @@ Submodule hashes used in testing:
  7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
@@ -47,278 +47,278 @@ The first time is for the full script (prep+run+finalize).
 The second time is specifically for the run phase.
 Times/Memory will be empty for failed tests.
 
-BASELINE DIRECTORY: /gpfs/f5/epic/world-shared/UFS-WM_RT/NEMSfv3gfs/develop-20240312
-COMPARISON DIRECTORY: /gpfs/f5/epic/scratch/Zachary.Shrader/FV3_RT/rt_42607
+BASELINE DIRECTORY: /gpfs/f5/epic/world-shared/UFS-WM_RT/NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /gpfs/f5/epic/scratch/Fernando.Andrade-maldonado/FV3_RT/rt_17834
 
 RT.SH OPTIONS USED:
 * (-a) - HPC PROJECT ACCOUNT: epic
 * (-l) - USE CONFIG FILE: rt.conf
 * (-e) - USE ECFLOW
 
-PASS -- COMPILE 's2swa_32bit_intel' [22:11, 20:44]
-PASS -- TEST 'cpld_control_p8_mixedmode_intel' [14:16, 11:07](3071 MB)
+PASS -- COMPILE 's2swa_32bit_intel' [21:14, 19:10]
+PASS -- TEST 'cpld_control_p8_mixedmode_intel' [13:33, 07:50](3070 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_intel' [36:25, 34:46]
-PASS -- TEST 'cpld_control_gfsv17_intel' [17:41, 13:41](1700 MB)
-PASS -- TEST 'cpld_control_gfsv17_iau_intel' [19:41, 14:26](1812 MB)
-PASS -- TEST 'cpld_restart_gfsv17_intel' [10:17, 06:47](949 MB)
-PASS -- TEST 'cpld_mpi_gfsv17_intel' [19:23, 14:52](1668 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_intel' [24:15, 22:38]
+PASS -- TEST 'cpld_control_gfsv17_intel' [18:50, 13:55](1700 MB)
+PASS -- TEST 'cpld_control_gfsv17_iau_intel' [19:41, 14:17](1814 MB)
+PASS -- TEST 'cpld_restart_gfsv17_intel' [10:53, 06:51](952 MB)
+PASS -- TEST 'cpld_mpi_gfsv17_intel' [21:45, 15:14](1668 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [15:13, 14:00]
-PASS -- TEST 'cpld_debug_gfsv17_intel' [27:59, 24:41](1700 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [15:08, 13:36]
+PASS -- TEST 'cpld_debug_gfsv17_intel' [29:40, 25:20](1702 MB)
 
-PASS -- COMPILE 's2swa_intel' [21:10, 19:45]
-PASS -- TEST 'cpld_control_p8_intel' [17:10, 11:50](3097 MB)
-PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [16:51, 11:42](3096 MB)
-PASS -- TEST 'cpld_restart_p8_intel' [08:37, 05:55](3155 MB)
-PASS -- TEST 'cpld_control_qr_p8_intel' [16:37, 11:58](3123 MB)
-PASS -- TEST 'cpld_restart_qr_p8_intel' [08:50, 05:27](3176 MB)
-PASS -- TEST 'cpld_2threads_p8_intel' [14:03, 06:37](3414 MB)
-PASS -- TEST 'cpld_decomp_p8_intel' [15:52, 12:06](3097 MB)
-PASS -- TEST 'cpld_mpi_p8_intel' [15:52, 11:14](3019 MB)
-PASS -- TEST 'cpld_control_ciceC_p8_intel' [17:21, 11:41](3097 MB)
-PASS -- TEST 'cpld_control_c192_p8_intel' [18:48, 14:01](3271 MB)
-PASS -- TEST 'cpld_restart_c192_p8_intel' [14:01, 07:17](3600 MB)
-PASS -- TEST 'cpld_bmark_p8_intel' [21:00, 13:08](4036 MB)
-PASS -- TEST 'cpld_restart_bmark_p8_intel' [17:33, 09:16](4345 MB)
-PASS -- TEST 'cpld_s2sa_p8_intel' [12:25, 08:18](3066 MB)
+PASS -- COMPILE 's2swa_intel' [21:14, 19:22]
+PASS -- TEST 'cpld_control_p8_intel' [14:40, 08:09](3099 MB)
+PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [14:51, 08:15](3099 MB)
+PASS -- TEST 'cpld_restart_p8_intel' [09:26, 05:12](3157 MB)
+PASS -- TEST 'cpld_control_qr_p8_intel' [14:31, 08:19](3125 MB)
+PASS -- TEST 'cpld_restart_qr_p8_intel' [09:27, 05:07](3178 MB)
+PASS -- TEST 'cpld_2threads_p8_intel' [11:48, 06:42](3413 MB)
+PASS -- TEST 'cpld_decomp_p8_intel' [14:10, 08:16](3099 MB)
+PASS -- TEST 'cpld_mpi_p8_intel' [12:59, 07:28](3022 MB)
+PASS -- TEST 'cpld_control_ciceC_p8_intel' [14:50, 08:17](3099 MB)
+PASS -- TEST 'cpld_control_c192_p8_intel' [16:33, 10:16](3272 MB)
+PASS -- TEST 'cpld_restart_c192_p8_intel' [12:41, 07:29](3603 MB)
+PASS -- TEST 'cpld_bmark_p8_intel' [23:23, 13:35](4041 MB)
+PASS -- TEST 'cpld_restart_bmark_p8_intel' [18:51, 09:25](4345 MB)
+PASS -- TEST 'cpld_s2sa_p8_intel' [13:09, 08:05](3068 MB)
 
-PASS -- COMPILE 's2sw_intel' [19:09, 17:47]
-PASS -- TEST 'cpld_control_noaero_p8_intel' [07:45, 05:01](1682 MB)
-PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [08:48, 05:26](1730 MB)
+PASS -- COMPILE 's2sw_intel' [20:11, 18:20]
+PASS -- TEST 'cpld_control_noaero_p8_intel' [12:32, 05:40](1682 MB)
+PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [12:32, 06:01](1730 MB)
 
-PASS -- COMPILE 's2swa_debug_intel' [16:09, 14:33]
-PASS -- TEST 'cpld_debug_p8_intel' [12:51, 10:04](3131 MB)
+PASS -- COMPILE 's2swa_debug_intel' [15:08, 13:28]
+PASS -- TEST 'cpld_debug_p8_intel' [17:24, 10:23](3132 MB)
 
-PASS -- COMPILE 's2sw_debug_intel' [16:09, 14:20]
-PASS -- TEST 'cpld_debug_noaero_p8_intel' [09:40, 06:07](1698 MB)
+PASS -- COMPILE 's2sw_debug_intel' [14:12, 12:51]
+PASS -- TEST 'cpld_debug_noaero_p8_intel' [09:43, 06:01](1700 MB)
 
-PASS -- COMPILE 's2s_aoflux_intel' [18:13, 16:03]
-PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [08:50, 05:30](1731 MB)
+PASS -- COMPILE 's2s_aoflux_intel' [17:09, 15:33]
+PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [12:00, 05:23](1733 MB)
 
-PASS -- COMPILE 's2s_intel' [18:13, 16:40]
-PASS -- TEST 'cpld_control_c48_intel' [09:23, 06:55](2661 MB)
+PASS -- COMPILE 's2s_intel' [18:13, 16:10]
+PASS -- TEST 'cpld_control_c48_intel' [10:55, 06:53](2661 MB)
 
-PASS -- COMPILE 's2swa_faster_intel' [25:15, 23:59]
-PASS -- TEST 'cpld_control_p8_faster_intel' [15:01, 11:40](3099 MB)
+PASS -- COMPILE 's2swa_faster_intel' [24:15, 22:32]
+PASS -- TEST 'cpld_control_p8_faster_intel' [13:29, 08:12](3099 MB)
 
-PASS -- COMPILE 's2sw_pdlib_intel' [24:14, 22:26]
-PASS -- TEST 'cpld_control_pdlib_p8_intel' [19:48, 15:12](1704 MB)
-PASS -- TEST 'cpld_restart_pdlib_p8_intel' [11:25, 07:47](1001 MB)
-PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [20:49, 17:27](1680 MB)
+PASS -- COMPILE 's2sw_pdlib_intel' [24:52, 22:28]
+PASS -- TEST 'cpld_control_pdlib_p8_intel' [19:52, 15:22](1702 MB)
+PASS -- TEST 'cpld_restart_pdlib_p8_intel' [12:19, 08:17](998 MB)
+PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [21:45, 17:35](1677 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_intel' [14:13, 12:36]
-PASS -- TEST 'cpld_debug_pdlib_p8_intel' [30:38, 27:08](1714 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_intel' [15:11, 13:31]
+PASS -- TEST 'cpld_debug_pdlib_p8_intel' [33:34, 27:07](1709 MB)
 
-PASS -- COMPILE 'atm_dyn32_intel' [20:15, 18:06]
-PASS -- TEST 'control_flake_intel' [06:14, 03:40](675 MB)
-PASS -- TEST 'control_CubedSphereGrid_intel' [06:04, 02:37](620 MB)
-PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [05:55, 02:38](627 MB)
-PASS -- TEST 'control_latlon_intel' [05:51, 02:33](622 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [05:51, 02:34](623 MB)
-PASS -- TEST 'control_c48_intel' [08:27, 05:38](727 MB)
-PASS -- TEST 'control_c48.v2.sfc_intel' [08:38, 05:42](727 MB)
-PASS -- TEST 'control_c192_intel' [11:16, 08:55](739 MB)
-PASS -- TEST 'control_c384_intel' [20:02, 16:21](1042 MB)
-PASS -- TEST 'control_c384gdas_intel' [20:02, 14:17](1184 MB)
-PASS -- TEST 'control_stochy_intel' [04:02, 01:59](626 MB)
-PASS -- TEST 'control_stochy_restart_intel' [03:58, 01:01](430 MB)
-PASS -- TEST 'control_lndp_intel' [04:03, 01:51](628 MB)
-PASS -- TEST 'control_iovr4_intel' [05:52, 02:34](623 MB)
-PASS -- TEST 'control_iovr5_intel' [05:52, 02:38](622 MB)
-PASS -- TEST 'control_p8_intel' [08:10, 04:11](1605 MB)
-PASS -- TEST 'control_p8.v2.sfc_intel' [07:24, 04:02](1608 MB)
-PASS -- TEST 'control_p8_ugwpv1_intel' [06:40, 03:58](1609 MB)
-PASS -- TEST 'control_restart_p8_intel' [05:11, 02:07](790 MB)
-PASS -- TEST 'control_noqr_p8_intel' [06:32, 03:48](1595 MB)
-PASS -- TEST 'control_restart_noqr_p8_intel' [04:15, 01:44](792 MB)
-PASS -- TEST 'control_decomp_p8_intel' [06:13, 03:24](1594 MB)
-PASS -- TEST 'control_2threads_p8_intel' [05:12, 02:44](1685 MB)
-PASS -- TEST 'control_p8_lndp_intel' [09:24, 05:43](1606 MB)
-PASS -- TEST 'control_p8_rrtmgp_intel' [07:28, 04:13](1657 MB)
-PASS -- TEST 'control_p8_mynn_intel' [06:23, 03:19](1615 MB)
-PASS -- TEST 'merra2_thompson_intel' [06:21, 03:57](1616 MB)
-PASS -- TEST 'regional_control_intel' [06:59, 04:40](615 MB)
-PASS -- TEST 'regional_restart_intel' [04:40, 02:52](785 MB)
-PASS -- TEST 'regional_decomp_intel' [06:57, 04:50](615 MB)
-PASS -- TEST 'regional_2threads_intel' [04:50, 02:54](758 MB)
-PASS -- TEST 'regional_noquilt_intel' [06:49, 04:35](1153 MB)
-PASS -- TEST 'regional_netcdf_parallel_intel' [06:55, 04:56](615 MB)
-PASS -- TEST 'regional_2dwrtdecomp_intel' [06:45, 04:43](614 MB)
-PASS -- TEST 'regional_wofs_intel' [08:50, 06:09](1591 MB)
+PASS -- COMPILE 'atm_dyn32_intel' [23:10, 21:09]
+PASS -- TEST 'control_flake_intel' [05:52, 03:45](675 MB)
+PASS -- TEST 'control_CubedSphereGrid_intel' [04:52, 02:55](619 MB)
+PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [04:51, 02:39](627 MB)
+PASS -- TEST 'control_latlon_intel' [04:35, 02:50](623 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [04:51, 02:38](623 MB)
+PASS -- TEST 'control_c48_intel' [08:11, 05:38](727 MB)
+PASS -- TEST 'control_c48.v2.sfc_intel' [08:11, 05:40](721 MB)
+PASS -- TEST 'control_c192_intel' [12:08, 09:16](739 MB)
+PASS -- TEST 'control_c384_intel' [20:04, 16:24](1042 MB)
+PASS -- TEST 'control_c384gdas_intel' [19:12, 14:12](1187 MB)
+PASS -- TEST 'control_stochy_intel' [05:27, 02:12](626 MB)
+PASS -- TEST 'control_stochy_restart_intel' [03:41, 01:10](430 MB)
+PASS -- TEST 'control_lndp_intel' [03:35, 01:49](628 MB)
+PASS -- TEST 'control_iovr4_intel' [04:50, 02:51](623 MB)
+PASS -- TEST 'control_iovr5_intel' [04:50, 02:49](623 MB)
+PASS -- TEST 'control_p8_intel' [06:57, 03:29](1606 MB)
+PASS -- TEST 'control_p8.v2.sfc_intel' [07:30, 03:28](1608 MB)
+PASS -- TEST 'control_p8_ugwpv1_intel' [07:07, 03:25](1609 MB)
+PASS -- TEST 'control_restart_p8_intel' [04:34, 02:00](789 MB)
+PASS -- TEST 'control_noqr_p8_intel' [07:06, 03:43](1596 MB)
+PASS -- TEST 'control_restart_noqr_p8_intel' [04:24, 01:46](792 MB)
+PASS -- TEST 'control_decomp_p8_intel' [06:54, 03:30](1594 MB)
+PASS -- TEST 'control_2threads_p8_intel' [05:51, 02:57](1687 MB)
+PASS -- TEST 'control_p8_lndp_intel' [08:33, 05:32](1607 MB)
+PASS -- TEST 'control_p8_rrtmgp_intel' [08:00, 04:19](1657 MB)
+PASS -- TEST 'control_p8_mynn_intel' [07:20, 03:53](1615 MB)
+PASS -- TEST 'merra2_thompson_intel' [06:51, 04:02](1615 MB)
+PASS -- TEST 'regional_control_intel' [07:07, 04:35](615 MB)
+PASS -- TEST 'regional_restart_intel' [06:49, 02:58](789 MB)
+PASS -- TEST 'regional_decomp_intel' [07:04, 04:51](615 MB)
+PASS -- TEST 'regional_2threads_intel' [05:58, 03:21](756 MB)
+PASS -- TEST 'regional_noquilt_intel' [07:01, 04:57](1153 MB)
+PASS -- TEST 'regional_netcdf_parallel_intel' [08:09, 05:09](615 MB)
+PASS -- TEST 'regional_2dwrtdecomp_intel' [07:06, 04:51](615 MB)
+PASS -- TEST 'regional_wofs_intel' [08:06, 06:05](1591 MB)
 
-PASS -- COMPILE 'rrfs_intel' [16:16, 14:22]
-PASS -- TEST 'rap_control_intel' [10:08, 07:02](1009 MB)
-PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [06:09, 03:56](1187 MB)
-PASS -- TEST 'rap_decomp_intel' [09:57, 07:21](1009 MB)
-PASS -- TEST 'rap_2threads_intel' [09:51, 06:12](1098 MB)
-PASS -- TEST 'rap_restart_intel' [06:05, 03:26](880 MB)
-PASS -- TEST 'rap_sfcdiff_intel' [09:45, 06:40](1007 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_intel' [09:45, 07:03](1005 MB)
-PASS -- TEST 'rap_sfcdiff_restart_intel' [08:04, 05:11](880 MB)
-PASS -- TEST 'hrrr_control_intel' [06:08, 03:49](1005 MB)
-PASS -- TEST 'hrrr_control_decomp_intel' [06:04, 03:57](1006 MB)
-PASS -- TEST 'hrrr_control_2threads_intel' [05:58, 03:06](1087 MB)
-PASS -- TEST 'hrrr_control_restart_intel' [03:30, 01:58](837 MB)
-PASS -- TEST 'rrfs_v1beta_intel' [09:08, 06:42](1003 MB)
-PASS -- TEST 'rrfs_v1nssl_intel' [10:53, 08:15](1967 MB)
-PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [09:50, 08:05](1950 MB)
+PASS -- COMPILE 'rrfs_intel' [16:21, 14:30]
+PASS -- TEST 'rap_control_intel' [09:54, 06:57](1010 MB)
+PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [06:56, 04:02](1187 MB)
+PASS -- TEST 'rap_decomp_intel' [09:54, 07:00](1009 MB)
+PASS -- TEST 'rap_2threads_intel' [09:54, 06:13](1095 MB)
+PASS -- TEST 'rap_restart_intel' [06:19, 03:27](880 MB)
+PASS -- TEST 'rap_sfcdiff_intel' [09:54, 06:57](1007 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_intel' [11:55, 07:15](1005 MB)
+PASS -- TEST 'rap_sfcdiff_restart_intel' [08:15, 05:22](880 MB)
+PASS -- TEST 'hrrr_control_intel' [06:48, 03:59](1004 MB)
+PASS -- TEST 'hrrr_control_decomp_intel' [06:48, 04:01](1006 MB)
+PASS -- TEST 'hrrr_control_2threads_intel' [06:48, 03:05](1084 MB)
+PASS -- TEST 'hrrr_control_restart_intel' [03:41, 01:58](838 MB)
+PASS -- TEST 'rrfs_v1beta_intel' [09:54, 06:48](1003 MB)
+PASS -- TEST 'rrfs_v1nssl_intel' [11:30, 08:15](1969 MB)
+PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [10:28, 07:50](1948 MB)
 
-PASS -- COMPILE 'csawmg_intel' [18:13, 16:06]
-PASS -- TEST 'control_csawmg_intel' [08:49, 06:41](695 MB)
-PASS -- TEST 'control_csawmgt_intel' [08:44, 06:30](694 MB)
-PASS -- TEST 'control_ras_intel' [05:33, 03:25](656 MB)
+PASS -- COMPILE 'csawmg_intel' [15:48, 13:45]
+PASS -- TEST 'control_csawmg_intel' [09:51, 06:43](695 MB)
+PASS -- TEST 'control_csawmgt_intel' [09:51, 06:36](691 MB)
+PASS -- TEST 'control_ras_intel' [06:03, 03:26](657 MB)
 
-PASS -- COMPILE 'wam_intel' [17:15, 15:08]
+PASS -- COMPILE 'wam_intel' [21:19, 19:23]
 PASS -- TEST 'control_wam_intel' [04:32, 02:12](369 MB)
 
-PASS -- COMPILE 'atm_faster_dyn32_intel' [23:15, 20:55]
-PASS -- TEST 'control_p8_faster_intel' [07:34, 03:16](1607 MB)
-PASS -- TEST 'regional_control_faster_intel' [06:48, 04:26](614 MB)
+PASS -- COMPILE 'atm_faster_dyn32_intel' [28:18, 26:05]
+PASS -- TEST 'control_p8_faster_intel' [06:32, 03:38](1608 MB)
+PASS -- TEST 'regional_control_faster_intel' [07:01, 04:35](614 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_intel' [18:09, 15:47]
-PASS -- TEST 'control_CubedSphereGrid_debug_intel' [05:30, 02:48](779 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [05:09, 02:50](782 MB)
-PASS -- TEST 'control_stochy_debug_intel' [05:30, 03:13](786 MB)
-PASS -- TEST 'control_lndp_debug_intel' [04:22, 02:50](790 MB)
-PASS -- TEST 'control_csawmg_debug_intel' [06:47, 04:35](825 MB)
-PASS -- TEST 'control_csawmgt_debug_intel' [07:01, 04:26](825 MB)
-PASS -- TEST 'control_ras_debug_intel' [05:27, 03:02](796 MB)
-PASS -- TEST 'control_diag_debug_intel' [05:44, 03:16](844 MB)
-PASS -- TEST 'control_debug_p8_intel' [05:37, 03:50](1622 MB)
-PASS -- TEST 'regional_debug_intel' [18:55, 16:41](635 MB)
-PASS -- TEST 'rap_control_debug_intel' [07:28, 05:33](1167 MB)
-PASS -- TEST 'hrrr_control_debug_intel' [07:32, 05:43](1165 MB)
-PASS -- TEST 'hrrr_gf_debug_intel' [07:31, 05:25](1168 MB)
-PASS -- TEST 'hrrr_c3_debug_intel' [07:31, 05:33](1167 MB)
-PASS -- TEST 'rap_unified_drag_suite_debug_intel' [07:34, 05:30](1167 MB)
-PASS -- TEST 'rap_diag_debug_intel' [09:03, 05:34](1253 MB)
-PASS -- TEST 'rap_cires_ugwp_debug_intel' [07:54, 05:06](1167 MB)
-PASS -- TEST 'rap_unified_ugwp_debug_intel' [07:44, 05:13](1168 MB)
-PASS -- TEST 'rap_lndp_debug_intel' [06:38, 05:03](1169 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_intel' [07:39, 05:10](1167 MB)
-PASS -- TEST 'rap_noah_debug_intel' [06:28, 05:01](1167 MB)
-PASS -- TEST 'rap_sfcdiff_debug_intel' [06:34, 05:03](1166 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [09:32, 07:51](1166 MB)
-PASS -- TEST 'rrfs_v1beta_debug_intel' [06:33, 04:56](1163 MB)
-PASS -- TEST 'rap_clm_lake_debug_intel' [08:41, 06:15](1169 MB)
-PASS -- TEST 'rap_flake_debug_intel' [06:39, 05:03](1167 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [11:14, 08:23](1172 MB)
+PASS -- COMPILE 'atm_debug_dyn32_intel' [35:20, 33:26]
+PASS -- TEST 'control_CubedSphereGrid_debug_intel' [05:13, 02:50](777 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [05:01, 02:47](781 MB)
+PASS -- TEST 'control_stochy_debug_intel' [05:35, 03:09](784 MB)
+PASS -- TEST 'control_lndp_debug_intel' [04:52, 02:51](788 MB)
+PASS -- TEST 'control_csawmg_debug_intel' [06:54, 04:33](824 MB)
+PASS -- TEST 'control_csawmgt_debug_intel' [06:54, 04:25](825 MB)
+PASS -- TEST 'control_ras_debug_intel' [04:42, 02:51](794 MB)
+PASS -- TEST 'control_diag_debug_intel' [05:41, 03:03](843 MB)
+PASS -- TEST 'control_debug_p8_intel' [05:54, 03:49](1618 MB)
+PASS -- TEST 'regional_debug_intel' [18:56, 16:11](632 MB)
+PASS -- TEST 'rap_control_debug_intel' [07:34, 05:35](1165 MB)
+PASS -- TEST 'hrrr_control_debug_intel' [07:33, 05:36](1164 MB)
+PASS -- TEST 'hrrr_gf_debug_intel' [07:34, 05:30](1169 MB)
+PASS -- TEST 'hrrr_c3_debug_intel' [07:32, 05:35](1166 MB)
+PASS -- TEST 'rap_unified_drag_suite_debug_intel' [07:38, 05:30](1166 MB)
+PASS -- TEST 'rap_diag_debug_intel' [07:58, 05:14](1250 MB)
+PASS -- TEST 'rap_cires_ugwp_debug_intel' [07:51, 05:15](1168 MB)
+PASS -- TEST 'rap_unified_ugwp_debug_intel' [07:52, 05:20](1167 MB)
+PASS -- TEST 'rap_lndp_debug_intel' [07:39, 05:19](1168 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_intel' [07:36, 05:06](1166 MB)
+PASS -- TEST 'rap_noah_debug_intel' [06:42, 05:02](1166 MB)
+PASS -- TEST 'rap_sfcdiff_debug_intel' [07:38, 05:19](1166 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [10:36, 08:13](1166 MB)
+PASS -- TEST 'rrfs_v1beta_debug_intel' [07:36, 05:01](1162 MB)
+PASS -- TEST 'rap_clm_lake_debug_intel' [08:46, 05:51](1168 MB)
+PASS -- TEST 'rap_flake_debug_intel' [07:36, 05:05](1166 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [11:08, 08:30](1169 MB)
 
-PASS -- COMPILE 'wam_debug_intel' [15:09, 13:16]
-PASS -- TEST 'control_wam_debug_intel' [06:40, 04:55](397 MB)
+PASS -- COMPILE 'wam_debug_intel' [32:17, 30:01]
+PASS -- TEST 'control_wam_debug_intel' [06:24, 04:46](396 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [15:15, 13:56]
-PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [06:08, 03:49](1054 MB)
-PASS -- TEST 'rap_control_dyn32_phy32_intel' [09:17, 06:20](888 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [06:06, 03:28](884 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [07:58, 05:27](945 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [05:00, 02:48](941 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [06:08, 03:43](887 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_intel' [07:03, 04:10](784 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [03:33, 01:43](764 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [14:09, 12:23]
+PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [06:18, 03:53](1049 MB)
+PASS -- TEST 'rap_control_dyn32_phy32_intel' [08:12, 05:50](888 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [05:57, 03:32](885 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [07:55, 05:32](945 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [05:06, 02:48](936 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [06:00, 03:45](886 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_intel' [07:48, 04:12](782 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [04:19, 02:03](765 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [14:11, 12:33]
-PASS -- TEST 'conus13km_control_intel' [05:00, 02:02](1095 MB)
-PASS -- TEST 'conus13km_2threads_intel' [04:22, 01:18](1075 MB)
-PASS -- TEST 'conus13km_restart_mismatch_intel' [03:54, 01:21](974 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [17:18, 15:35]
+PASS -- TEST 'conus13km_control_intel' [05:08, 02:10](1095 MB)
+PASS -- TEST 'conus13km_2threads_intel' [04:39, 01:06](1072 MB)
+PASS -- TEST 'conus13km_restart_mismatch_intel' [04:22, 01:23](974 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [15:15, 13:16]
-PASS -- TEST 'rap_control_dyn64_phy32_intel' [07:07, 04:22](904 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [14:18, 12:51]
+PASS -- TEST 'rap_control_dyn64_phy32_intel' [07:12, 04:26](904 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [11:13, 09:15]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [06:32, 05:00](1048 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [06:32, 04:59](1048 MB)
-PASS -- TEST 'conus13km_debug_intel' [16:55, 14:09](1130 MB)
-PASS -- TEST 'conus13km_debug_qr_intel' [16:53, 14:30](805 MB)
-PASS -- TEST 'conus13km_debug_2threads_intel' [10:40, 08:17](1112 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_intel' [15:42, 14:03](1196 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [10:14, 08:53]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [07:33, 05:00](1048 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [07:35, 04:59](1048 MB)
+PASS -- TEST 'conus13km_debug_intel' [17:54, 14:04](1129 MB)
+PASS -- TEST 'conus13km_debug_qr_intel' [17:00, 14:12](804 MB)
+PASS -- TEST 'conus13km_debug_2threads_intel' [10:49, 08:28](1110 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_intel' [16:53, 14:30](1195 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [11:13, 09:19]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [06:35, 04:56](1066 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [12:08, 09:56]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [08:04, 05:07](1067 MB)
 
-PASS -- COMPILE 'hafsw_intel' [19:14, 17:54]
-PASS -- TEST 'hafs_regional_atm_intel' [08:46, 05:17](707 MB)
-PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [07:01, 04:28](1055 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_intel' [10:37, 07:53](752 MB)
-PASS -- TEST 'hafs_regional_atm_wav_intel' [14:21, 11:46](788 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [16:17, 12:57](796 MB)
-PASS -- TEST 'hafs_regional_1nest_atm_intel' [08:23, 05:26](473 MB)
-PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [09:37, 06:41](499 MB)
-PASS -- TEST 'hafs_global_1nest_atm_intel' [06:04, 02:54](373 MB)
-PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [14:03, 08:07](443 MB)
-PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [06:00, 03:50](509 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [06:14, 03:39](507 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [07:24, 04:42](575 MB)
-PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [04:45, 02:49](401 MB)
-PASS -- TEST 'gnv1_nested_intel' [07:24, 04:21](764 MB)
+PASS -- COMPILE 'hafsw_intel' [19:13, 17:13]
+PASS -- TEST 'hafs_regional_atm_intel' [08:23, 05:17](706 MB)
+PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [07:10, 04:34](1061 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_intel' [11:42, 07:54](753 MB)
+PASS -- TEST 'hafs_regional_atm_wav_intel' [15:25, 11:46](785 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [16:51, 13:16](793 MB)
+PASS -- TEST 'hafs_regional_1nest_atm_intel' [08:28, 05:30](475 MB)
+PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [10:41, 06:51](497 MB)
+PASS -- TEST 'hafs_global_1nest_atm_intel' [06:20, 02:57](372 MB)
+PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [12:57, 08:09](432 MB)
+PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [06:59, 03:53](509 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [06:08, 03:32](512 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [07:16, 04:54](575 MB)
+PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [03:43, 02:01](401 MB)
+PASS -- TEST 'gnv1_nested_intel' [07:31, 04:24](768 MB)
 
-PASS -- COMPILE 'hafsw_debug_intel' [15:13, 13:22]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [17:58, 12:50](584 MB)
+PASS -- COMPILE 'hafsw_debug_intel' [13:10, 11:53]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [16:48, 13:03](582 MB)
 
-PASS -- COMPILE 'hafsw_faster_intel' [21:19, 19:29]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [11:50, 07:58](616 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [11:59, 07:54](786 MB)
+PASS -- COMPILE 'hafsw_faster_intel' [23:13, 21:42]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [11:51, 08:26](615 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [12:16, 08:12](785 MB)
 
-PASS -- COMPILE 'hafs_mom6w_intel' [20:15, 18:33]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [09:44, 06:03](786 MB)
+PASS -- COMPILE 'hafs_mom6w_intel' [19:11, 17:52]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [09:20, 06:29](786 MB)
 
-PASS -- COMPILE 'hafs_all_intel' [19:13, 17:07]
-PASS -- TEST 'hafs_regional_docn_intel' [11:02, 06:10](747 MB)
-PASS -- TEST 'hafs_regional_docn_oisst_intel' [09:58, 06:12](730 MB)
-PASS -- TEST 'hafs_regional_datm_cdeps_intel' [24:24, 21:56](893 MB)
+PASS -- COMPILE 'hafs_all_intel' [18:12, 16:00]
+PASS -- TEST 'hafs_regional_docn_intel' [09:14, 06:18](747 MB)
+PASS -- TEST 'hafs_regional_docn_oisst_intel' [10:19, 06:18](729 MB)
+PASS -- TEST 'hafs_regional_datm_cdeps_intel' [22:51, 20:09](893 MB)
 
-PASS -- COMPILE 'datm_cdeps_intel' [13:16, 11:29]
-PASS -- TEST 'datm_cdeps_control_cfsr_intel' [04:24, 02:36](759 MB)
-PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [03:25, 01:34](747 MB)
-PASS -- TEST 'datm_cdeps_control_gefs_intel' [04:23, 02:25](637 MB)
-PASS -- TEST 'datm_cdeps_iau_gefs_intel' [04:21, 02:36](635 MB)
-PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [04:21, 02:38](635 MB)
-PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [04:22, 02:36](758 MB)
-PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [04:22, 02:35](758 MB)
-PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [04:30, 02:26](637 MB)
-PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [09:00, 06:18](693 MB)
-PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [08:01, 06:10](675 MB)
-PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [04:20, 02:35](758 MB)
-PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [06:35, 04:36](2013 MB)
-PASS -- TEST 'datm_cdeps_gfs_intel' [06:32, 04:42](2013 MB)
+PASS -- COMPILE 'datm_cdeps_intel' [13:12, 11:38]
+PASS -- TEST 'datm_cdeps_control_cfsr_intel' [05:20, 02:36](758 MB)
+PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [03:22, 01:34](747 MB)
+PASS -- TEST 'datm_cdeps_control_gefs_intel' [05:10, 02:28](635 MB)
+PASS -- TEST 'datm_cdeps_iau_gefs_intel' [04:44, 02:28](639 MB)
+PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [04:26, 02:31](639 MB)
+PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [04:25, 02:36](758 MB)
+PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [04:25, 02:34](745 MB)
+PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [04:27, 02:26](635 MB)
+PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [09:25, 06:14](692 MB)
+PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [08:57, 06:08](675 MB)
+PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [04:22, 02:34](759 MB)
+PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [06:23, 04:34](2012 MB)
+PASS -- TEST 'datm_cdeps_gfs_intel' [07:04, 04:36](2013 MB)
 
-PASS -- COMPILE 'datm_cdeps_debug_intel' [11:13, 09:40]
-PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [07:24, 05:39](740 MB)
+PASS -- COMPILE 'datm_cdeps_debug_intel' [09:07, 07:13]
+PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [07:28, 05:30](739 MB)
 
-PASS -- COMPILE 'datm_cdeps_faster_intel' [16:13, 13:46]
-PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [04:25, 02:34](756 MB)
+PASS -- COMPILE 'datm_cdeps_faster_intel' [14:12, 12:51]
+PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [04:23, 02:33](756 MB)
 
-PASS -- COMPILE 'datm_cdeps_land_intel' [07:17, 04:50]
-PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [05:21, 02:30](310 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_intel' [03:52, 01:37](456 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [03:29, 01:02](456 MB)
+PASS -- COMPILE 'datm_cdeps_land_intel' [06:11, 03:51]
+PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [04:53, 02:17](310 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_intel' [03:54, 01:35](456 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [03:46, 01:40](456 MB)
 
-PASS -- COMPILE 'atml_intel' [18:21, 16:21]
-PASS -- TEST 'control_p8_atmlnd_sbs_intel' [16:20, 11:27](1640 MB)
-PASS -- TEST 'control_p8_atmlnd_intel' [12:03, 08:49](1640 MB)
-PASS -- TEST 'control_restart_p8_atmlnd_intel' [05:51, 03:56](835 MB)
+PASS -- COMPILE 'atml_intel' [58:25, 57:11]
+PASS -- TEST 'control_p8_atmlnd_sbs_intel' [11:07, 07:47](1640 MB)
+PASS -- TEST 'control_p8_atmlnd_intel' [11:07, 07:47](1640 MB)
+PASS -- TEST 'control_restart_p8_atmlnd_intel' [08:08, 05:47](835 MB)
 
-PASS -- COMPILE 'atmw_intel' [18:12, 16:35]
-PASS -- TEST 'atmwav_control_noaero_p8_intel' [05:02, 02:23](1647 MB)
+PASS -- COMPILE 'atmw_intel' [17:13, 15:22]
+PASS -- TEST 'atmwav_control_noaero_p8_intel' [06:06, 02:22](1649 MB)
 
-PASS -- COMPILE 'atmwm_intel' [16:10, 14:45]
-PASS -- TEST 'control_atmwav_intel' [04:00, 01:56](640 MB)
+PASS -- COMPILE 'atmwm_intel' [16:10, 14:49]
+PASS -- TEST 'control_atmwav_intel' [05:43, 02:04](640 MB)
 
-PASS -- COMPILE 'atmaero_intel' [17:10, 14:51]
-PASS -- TEST 'atmaero_control_p8_intel' [12:18, 09:05](2944 MB)
-PASS -- TEST 'atmaero_control_p8_rad_intel' [13:54, 09:06](3012 MB)
-PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [13:23, 09:08](3019 MB)
+PASS -- COMPILE 'atmaero_intel' [16:12, 14:38]
+PASS -- TEST 'atmaero_control_p8_intel' [08:26, 05:58](2944 MB)
+PASS -- TEST 'atmaero_control_p8_rad_intel' [09:29, 06:28](3013 MB)
+PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [09:18, 06:48](3019 MB)
 
-PASS -- COMPILE 'atmaq_intel' [17:14, 15:16]
+PASS -- COMPILE 'atmaq_intel' [17:11, 15:12]
 
-PASS -- COMPILE 'atmaq_debug_intel' [13:18, 11:05]
-PASS -- TEST 'regional_atmaq_debug_intel' [22:59, 19:38](4485 MB)
+PASS -- COMPILE 'atmaq_debug_intel' [13:18, 11:28]
+PASS -- TEST 'regional_atmaq_debug_intel' [21:41, 18:22](4482 MB)
 
 SYNOPSIS:
-Starting Date/Time: 20240314 08:29:02
-Ending Date/Time: 20240314 10:21:41
-Total Time: 01h:53m:35s
+Starting Date/Time: 20240315 14:58:48
+Ending Date/Time: 20240315 17:15:28
+Total Time: 02h:17m:20s
 Compiles Completed: 39/39
 Tests Completed: 182/182
 

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,7 +1,7 @@
 ====START OF HERA REGRESSION TESTING LOG====
 
 UFSWM hash used in testing:
-0d7aa189232097602b4a7b5cdab9caad9aba58ad
+1345562a9e6c858e0b80292dab11cd23a0da902e
 
 Submodule hashes used in testing:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
@@ -9,7 +9,7 @@ Submodule hashes used in testing:
  7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-1412-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
@@ -24,375 +24,375 @@ The first time is for the full script (prep+run+finalize).
 The second time is specifically for the run phase.
 Times/Memory will be empty for failed tests.
 
-BASELINE DIRECTORY: /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20240312
-COMPARISON DIRECTORY: /scratch1/NCEPDEV/stmp2/Fernando.Andrade-maldonado/FV3_RT/rt_21606
+BASELINE DIRECTORY: /scratch2/NAGAPE/epic/UFS-WM_RT/NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /scratch1/NCEPDEV/stmp2/Fernando.Andrade-maldonado/FV3_RT/rt_5454
 
 RT.SH OPTIONS USED:
 * (-a) - HPC PROJECT ACCOUNT: nems
 * (-l) - USE CONFIG FILE: rt.conf
 * (-e) - USE ECFLOW
 
-PASS -- COMPILE 's2swa_32bit_intel' [14:10, 12:33]
-PASS -- TEST 'cpld_control_p8_mixedmode_intel' [14:52, 05:21](3107 MB)
+PASS -- COMPILE 's2swa_32bit_intel' [14:08, 12:06]
+PASS -- TEST 'cpld_control_p8_mixedmode_intel' [09:26, 05:29](3102 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_intel' [17:11, 15:47]
-PASS -- TEST 'cpld_control_gfsv17_intel' [26:36, 17:24](1737 MB)
-PASS -- TEST 'cpld_control_gfsv17_iau_intel' [24:42, 17:02](2016 MB)
-PASS -- TEST 'cpld_restart_gfsv17_intel' [15:39, 07:46](1076 MB)
-PASS -- TEST 'cpld_mpi_gfsv17_intel' [28:36, 19:36](1635 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_intel' [18:10, 16:01]
+PASS -- TEST 'cpld_control_gfsv17_intel' [20:04, 16:11](1707 MB)
+PASS -- TEST 'cpld_control_gfsv17_iau_intel' [19:16, 16:48](2010 MB)
+PASS -- TEST 'cpld_restart_gfsv17_intel' [10:07, 07:35](1112 MB)
+PASS -- TEST 'cpld_mpi_gfsv17_intel' [21:00, 18:08](1633 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [06:11, 05:04]
-PASS -- TEST 'cpld_debug_gfsv17_intel' [25:31, 22:32](1673 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [07:07, 04:23]
+PASS -- TEST 'cpld_debug_gfsv17_intel' [28:01, 22:23](1671 MB)
 
-PASS -- COMPILE 's2swa_intel' [14:10, 12:27]
-PASS -- TEST 'cpld_control_p8_intel' [15:54, 05:39](3186 MB)
-PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [16:05, 05:43](3173 MB)
-PASS -- TEST 'cpld_restart_p8_intel' [07:49, 03:59](3241 MB)
-PASS -- TEST 'cpld_control_qr_p8_intel' [15:54, 05:47](3209 MB)
-PASS -- TEST 'cpld_restart_qr_p8_intel' [07:49, 04:15](3252 MB)
-PASS -- TEST 'cpld_2threads_p8_intel' [14:43, 05:26](3538 MB)
-PASS -- TEST 'cpld_decomp_p8_intel' [15:54, 05:46](3172 MB)
-PASS -- TEST 'cpld_mpi_p8_intel' [07:43, 04:49](3044 MB)
-PASS -- TEST 'cpld_control_ciceC_p8_intel' [16:07, 05:40](3166 MB)
-PASS -- TEST 'cpld_control_c192_p8_intel' [14:48, 09:47](3320 MB)
-PASS -- TEST 'cpld_restart_c192_p8_intel' [12:46, 06:56](3602 MB)
-PASS -- TEST 'cpld_bmark_p8_intel' [25:55, 09:51](4102 MB)
-PASS -- TEST 'cpld_restart_bmark_p8_intel' [22:46, 06:58](4341 MB)
-PASS -- TEST 'cpld_s2sa_p8_intel' [14:49, 05:20](3129 MB)
+PASS -- COMPILE 's2swa_intel' [14:09, 12:14]
+PASS -- TEST 'cpld_control_p8_intel' [09:28, 05:43](3189 MB)
+PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [09:39, 05:50](3148 MB)
+PASS -- TEST 'cpld_restart_p8_intel' [07:28, 03:17](3240 MB)
+PASS -- TEST 'cpld_control_qr_p8_intel' [09:28, 05:48](3214 MB)
+PASS -- TEST 'cpld_restart_qr_p8_intel' [06:26, 03:21](3251 MB)
+PASS -- TEST 'cpld_2threads_p8_intel' [09:24, 05:28](3534 MB)
+PASS -- TEST 'cpld_decomp_p8_intel' [09:24, 05:50](3178 MB)
+PASS -- TEST 'cpld_mpi_p8_intel' [08:27, 04:42](3049 MB)
+PASS -- TEST 'cpld_control_ciceC_p8_intel' [09:36, 05:43](3186 MB)
+PASS -- TEST 'cpld_control_c192_p8_intel' [14:22, 09:47](3279 MB)
+PASS -- TEST 'cpld_restart_c192_p8_intel' [10:41, 05:54](3566 MB)
+PASS -- TEST 'cpld_bmark_p8_intel' [18:57, 09:56](4097 MB)
+PASS -- TEST 'cpld_restart_bmark_p8_intel' [16:15, 06:40](4327 MB)
+PASS -- TEST 'cpld_s2sa_p8_intel' [09:29, 05:27](3154 MB)
 
-PASS -- COMPILE 's2sw_intel' [13:10, 11:35]
-PASS -- TEST 'cpld_control_noaero_p8_intel' [07:14, 04:31](1714 MB)
-PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [07:32, 04:26](1766 MB)
+PASS -- COMPILE 's2sw_intel' [14:08, 11:42]
+PASS -- TEST 'cpld_control_noaero_p8_intel' [08:14, 04:38](1701 MB)
+PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [08:24, 04:22](1765 MB)
 
-PASS -- COMPILE 's2swa_debug_intel' [06:09, 04:53]
-PASS -- TEST 'cpld_debug_p8_intel' [11:30, 08:19](3195 MB)
+PASS -- COMPILE 's2swa_debug_intel' [07:07, 04:23]
+PASS -- TEST 'cpld_debug_p8_intel' [15:08, 08:04](3238 MB)
 
-PASS -- COMPILE 's2sw_debug_intel' [06:09, 04:02]
-PASS -- TEST 'cpld_debug_noaero_p8_intel' [08:55, 05:33](1718 MB)
+PASS -- COMPILE 's2sw_debug_intel' [06:07, 03:59]
+PASS -- TEST 'cpld_debug_noaero_p8_intel' [13:04, 05:36](1749 MB)
 
-PASS -- COMPILE 's2s_aoflux_intel' [13:11, 11:10]
-PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [07:21, 04:28](1766 MB)
+PASS -- COMPILE 's2s_aoflux_intel' [13:09, 10:42]
+PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [08:02, 04:26](1760 MB)
 
-PASS -- COMPILE 's2s_intel' [12:12, 10:59]
-PASS -- TEST 'cpld_control_c48_intel' [11:54, 09:17](2817 MB)
+PASS -- COMPILE 's2s_intel' [13:08, 10:44]
+PASS -- TEST 'cpld_control_c48_intel' [11:41, 09:25](2833 MB)
 
-PASS -- COMPILE 's2swa_faster_intel' [18:15, 16:13]
-PASS -- TEST 'cpld_control_p8_faster_intel' [15:18, 05:22](3191 MB)
+PASS -- COMPILE 's2swa_faster_intel' [19:10, 16:17]
+PASS -- TEST 'cpld_control_p8_faster_intel' [09:13, 05:18](3195 MB)
 
-PASS -- COMPILE 's2sw_pdlib_intel' [17:10, 15:12]
-PASS -- TEST 'cpld_control_pdlib_p8_intel' [20:24, 17:11](1778 MB)
-PASS -- TEST 'cpld_restart_pdlib_p8_intel' [14:52, 07:43](1164 MB)
-PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [26:14, 18:45](1663 MB)
+PASS -- COMPILE 's2sw_pdlib_intel' [17:10, 15:10]
+PASS -- TEST 'cpld_control_pdlib_p8_intel' [20:09, 16:17](1759 MB)
+PASS -- TEST 'cpld_restart_pdlib_p8_intel' [10:14, 07:38](1140 MB)
+PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [21:02, 18:34](1661 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_intel' [06:06, 04:12]
-PASS -- TEST 'cpld_debug_pdlib_p8_intel' [29:33, 26:09](1667 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_intel' [07:07, 04:05]
+PASS -- TEST 'cpld_debug_pdlib_p8_intel' [28:22, 24:47](1686 MB)
 
-PASS -- COMPILE 'atm_dyn32_intel' [12:08, 10:45]
-PASS -- TEST 'control_flake_intel' [11:29, 03:18](689 MB)
-PASS -- TEST 'control_CubedSphereGrid_intel' [10:32, 02:27](649 MB)
-PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [10:35, 02:30](652 MB)
-PASS -- TEST 'control_latlon_intel' [10:27, 02:28](641 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [10:36, 02:28](632 MB)
-PASS -- TEST 'control_c48_intel' [15:05, 06:20](870 MB)
-PASS -- TEST 'control_c48.v2.sfc_intel' [15:04, 06:22](874 MB)
-PASS -- TEST 'control_c192_intel' [17:48, 09:38](833 MB)
-PASS -- TEST 'control_c384_intel' [16:49, 09:48](1275 MB)
-PASS -- TEST 'control_c384gdas_intel' [16:34, 08:56](1358 MB)
-PASS -- TEST 'control_stochy_intel' [07:26, 01:36](647 MB)
-PASS -- TEST 'control_stochy_restart_intel' [02:29, 00:59](497 MB)
-PASS -- TEST 'control_lndp_intel' [06:22, 01:36](635 MB)
-PASS -- TEST 'control_iovr4_intel' [05:06, 02:26](642 MB)
-PASS -- TEST 'control_iovr5_intel' [04:35, 02:27](644 MB)
-PASS -- TEST 'control_p8_intel' [06:24, 03:41](1614 MB)
-PASS -- TEST 'control_p8.v2.sfc_intel' [08:20, 03:31](1622 MB)
-PASS -- TEST 'control_p8_ugwpv1_intel' [08:19, 03:28](1608 MB)
-PASS -- TEST 'control_restart_p8_intel' [04:47, 01:37](888 MB)
-PASS -- TEST 'control_noqr_p8_intel' [08:16, 03:35](1605 MB)
-PASS -- TEST 'control_restart_noqr_p8_intel' [05:16, 02:15](923 MB)
-PASS -- TEST 'control_decomp_p8_intel' [09:08, 03:11](1605 MB)
-PASS -- TEST 'control_2threads_p8_intel' [09:07, 02:56](1703 MB)
-PASS -- TEST 'control_p8_lndp_intel' [11:22, 05:21](1614 MB)
-PASS -- TEST 'control_p8_rrtmgp_intel' [10:01, 03:53](1645 MB)
-PASS -- TEST 'control_p8_mynn_intel' [08:13, 03:15](1597 MB)
-PASS -- TEST 'merra2_thompson_intel' [10:02, 03:34](1613 MB)
-PASS -- TEST 'regional_control_intel' [10:01, 05:08](819 MB)
-PASS -- TEST 'regional_restart_intel' [06:47, 04:45](1017 MB)
-PASS -- TEST 'regional_decomp_intel' [08:50, 05:24](842 MB)
-PASS -- TEST 'regional_2threads_intel' [06:37, 03:12](826 MB)
-PASS -- TEST 'regional_noquilt_intel' [07:56, 05:01](1362 MB)
-PASS -- TEST 'regional_netcdf_parallel_intel' [07:58, 05:47](853 MB)
-PASS -- TEST 'regional_2dwrtdecomp_intel' [08:46, 05:50](850 MB)
-PASS -- TEST 'regional_wofs_intel' [09:52, 07:31](1910 MB)
+PASS -- COMPILE 'atm_dyn32_intel' [13:08, 10:31]
+PASS -- TEST 'control_flake_intel' [07:22, 03:25](689 MB)
+PASS -- TEST 'control_CubedSphereGrid_intel' [06:24, 02:22](643 MB)
+PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [04:25, 02:32](651 MB)
+PASS -- TEST 'control_latlon_intel' [05:21, 02:23](647 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [04:26, 02:26](623 MB)
+PASS -- TEST 'control_c48_intel' [11:24, 06:13](872 MB)
+PASS -- TEST 'control_c48.v2.sfc_intel' [11:24, 06:13](874 MB)
+PASS -- TEST 'control_c192_intel' [10:39, 08:59](851 MB)
+PASS -- TEST 'control_c384_intel' [13:29, 08:59](1274 MB)
+PASS -- TEST 'control_c384gdas_intel' [13:53, 07:56](1385 MB)
+PASS -- TEST 'control_stochy_intel' [05:19, 01:38](639 MB)
+PASS -- TEST 'control_stochy_restart_intel' [03:22, 00:58](497 MB)
+PASS -- TEST 'control_lndp_intel' [04:17, 01:34](650 MB)
+PASS -- TEST 'control_iovr4_intel' [05:21, 02:27](617 MB)
+PASS -- TEST 'control_iovr5_intel' [05:20, 02:26](620 MB)
+PASS -- TEST 'control_p8_intel' [06:02, 02:58](1616 MB)
+PASS -- TEST 'control_p8.v2.sfc_intel' [07:06, 02:56](1599 MB)
+PASS -- TEST 'control_p8_ugwpv1_intel' [06:59, 02:48](1620 MB)
+PASS -- TEST 'control_restart_p8_intel' [04:47, 01:38](859 MB)
+PASS -- TEST 'control_noqr_p8_intel' [06:57, 02:52](1603 MB)
+PASS -- TEST 'control_restart_noqr_p8_intel' [04:55, 01:37](925 MB)
+PASS -- TEST 'control_decomp_p8_intel' [06:54, 02:58](1605 MB)
+PASS -- TEST 'control_2threads_p8_intel' [05:49, 02:43](1707 MB)
+PASS -- TEST 'control_p8_lndp_intel' [08:48, 05:09](1617 MB)
+PASS -- TEST 'control_p8_rrtmgp_intel' [06:51, 03:48](1647 MB)
+PASS -- TEST 'control_p8_mynn_intel' [05:54, 02:58](1621 MB)
+PASS -- TEST 'merra2_thompson_intel' [05:53, 03:26](1615 MB)
+PASS -- TEST 'regional_control_intel' [07:35, 05:06](849 MB)
+PASS -- TEST 'regional_restart_intel' [05:38, 02:45](1006 MB)
+PASS -- TEST 'regional_decomp_intel' [07:39, 05:31](815 MB)
+PASS -- TEST 'regional_2threads_intel' [05:44, 03:10](847 MB)
+PASS -- TEST 'regional_noquilt_intel' [07:40, 05:02](1361 MB)
+PASS -- TEST 'regional_netcdf_parallel_intel' [07:43, 05:03](851 MB)
+PASS -- TEST 'regional_2dwrtdecomp_intel' [07:38, 05:09](829 MB)
+PASS -- TEST 'regional_wofs_intel' [10:41, 06:38](1882 MB)
 
-PASS -- COMPILE 'rrfs_intel' [11:10, 09:49]
-PASS -- TEST 'rap_control_intel' [12:08, 09:20](1084 MB)
-PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [07:10, 04:52](1280 MB)
-PASS -- TEST 'rap_decomp_intel' [12:00, 09:28](1023 MB)
-PASS -- TEST 'rap_2threads_intel' [11:54, 09:20](1172 MB)
-PASS -- TEST 'rap_restart_intel' [07:55, 04:07](1093 MB)
-PASS -- TEST 'rap_sfcdiff_intel' [11:57, 09:17](1108 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_intel' [11:57, 09:52](1040 MB)
-PASS -- TEST 'rap_sfcdiff_restart_intel' [08:53, 05:54](1130 MB)
-PASS -- TEST 'hrrr_control_intel' [06:48, 04:51](1024 MB)
-PASS -- TEST 'hrrr_control_decomp_intel' [07:48, 05:07](989 MB)
-PASS -- TEST 'hrrr_control_2threads_intel' [07:39, 05:17](1115 MB)
-PASS -- TEST 'hrrr_control_restart_intel' [08:38, 02:18](982 MB)
-PASS -- TEST 'rrfs_v1beta_intel' [11:54, 09:31](1090 MB)
-PASS -- TEST 'rrfs_v1nssl_intel' [12:36, 10:43](1957 MB)
-PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [12:34, 10:31](2063 MB)
+PASS -- COMPILE 'rrfs_intel' [13:07, 09:45]
+PASS -- TEST 'rap_control_intel' [10:34, 07:44](1089 MB)
+PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [07:09, 04:09](1290 MB)
+PASS -- TEST 'rap_decomp_intel' [11:35, 08:04](1022 MB)
+PASS -- TEST 'rap_2threads_intel' [09:39, 07:17](1184 MB)
+PASS -- TEST 'rap_restart_intel' [05:40, 03:59](1096 MB)
+PASS -- TEST 'rap_sfcdiff_intel' [10:42, 07:42](1099 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_intel' [10:35, 08:06](1028 MB)
+PASS -- TEST 'rap_sfcdiff_restart_intel' [08:41, 05:46](1104 MB)
+PASS -- TEST 'hrrr_control_intel' [07:33, 03:58](994 MB)
+PASS -- TEST 'hrrr_control_decomp_intel' [07:32, 04:08](1027 MB)
+PASS -- TEST 'hrrr_control_2threads_intel' [06:36, 03:36](1109 MB)
+PASS -- TEST 'hrrr_control_restart_intel' [04:24, 02:09](996 MB)
+PASS -- TEST 'rrfs_v1beta_intel' [10:43, 07:33](1087 MB)
+PASS -- TEST 'rrfs_v1nssl_intel' [11:26, 09:06](1988 MB)
+PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [11:31, 08:52](2059 MB)
 
-PASS -- COMPILE 'csawmg_intel' [11:10, 09:45]
-PASS -- TEST 'control_csawmg_intel' [09:49, 07:43](745 MB)
-PASS -- TEST 'control_csawmgt_intel' [09:48, 07:22](734 MB)
-PASS -- TEST 'control_ras_intel' [06:27, 03:54](722 MB)
+PASS -- COMPILE 'csawmg_intel' [13:07, 09:30]
+PASS -- TEST 'control_csawmg_intel' [08:39, 06:11](707 MB)
+PASS -- TEST 'control_csawmgt_intel' [08:43, 05:55](716 MB)
+PASS -- TEST 'control_ras_intel' [05:20, 03:17](731 MB)
 
-PASS -- COMPILE 'csawmg_gnu' [05:07, 03:23]
-PASS -- TEST 'control_csawmg_gnu' [17:51, 09:21](587 MB)
-PASS -- TEST 'control_csawmgt_gnu' [17:51, 09:21](586 MB)
+PASS -- COMPILE 'csawmg_gnu' [06:07, 03:28]
+PASS -- TEST 'control_csawmg_gnu' [11:40, 08:48](586 MB)
+PASS -- TEST 'control_csawmgt_gnu' [11:38, 08:40](586 MB)
 
-PASS -- COMPILE 'wam_intel' [11:08, 09:11]
-PASS -- TEST 'control_wam_intel' [04:26, 02:34](653 MB)
+PASS -- COMPILE 'wam_intel' [11:07, 09:03]
+PASS -- TEST 'control_wam_intel' [04:19, 02:02](644 MB)
 
-PASS -- COMPILE 'atm_faster_dyn32_intel' [11:09, 09:51]
-PASS -- TEST 'control_p8_faster_intel' [07:20, 04:08](1605 MB)
-PASS -- TEST 'regional_control_faster_intel' [08:57, 06:26](852 MB)
+PASS -- COMPILE 'atm_faster_dyn32_intel' [12:07, 09:50]
+PASS -- TEST 'control_p8_faster_intel' [05:50, 02:41](1592 MB)
+PASS -- TEST 'regional_control_faster_intel' [06:39, 04:41](821 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_intel' [06:07, 04:29]
-PASS -- TEST 'control_CubedSphereGrid_debug_intel' [05:31, 03:51](811 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [05:32, 03:36](809 MB)
-PASS -- TEST 'control_stochy_debug_intel' [09:25, 06:34](785 MB)
-PASS -- TEST 'control_lndp_debug_intel' [05:21, 03:35](816 MB)
-PASS -- TEST 'control_csawmg_debug_intel' [07:39, 05:02](865 MB)
-PASS -- TEST 'control_csawmgt_debug_intel' [07:44, 05:55](827 MB)
-PASS -- TEST 'control_ras_debug_intel' [06:23, 03:44](827 MB)
-PASS -- TEST 'control_diag_debug_intel' [10:36, 03:01](866 MB)
-PASS -- TEST 'control_debug_p8_intel' [08:51, 02:54](1633 MB)
-PASS -- TEST 'regional_debug_intel' [22:48, 16:20](839 MB)
-PASS -- TEST 'rap_control_debug_intel' [10:28, 04:49](1188 MB)
-PASS -- TEST 'hrrr_control_debug_intel' [09:22, 04:40](1190 MB)
-PASS -- TEST 'hrrr_gf_debug_intel' [09:23, 04:51](1176 MB)
-PASS -- TEST 'hrrr_c3_debug_intel' [09:29, 04:52](1197 MB)
-PASS -- TEST 'rap_unified_drag_suite_debug_intel' [09:35, 04:51](1190 MB)
-PASS -- TEST 'rap_diag_debug_intel' [09:45, 05:06](1299 MB)
-PASS -- TEST 'rap_cires_ugwp_debug_intel' [08:21, 04:59](1188 MB)
-PASS -- TEST 'rap_unified_ugwp_debug_intel' [07:29, 04:49](1199 MB)
-PASS -- TEST 'rap_lndp_debug_intel' [07:23, 04:50](1204 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_intel' [07:29, 04:51](1197 MB)
-PASS -- TEST 'rap_noah_debug_intel' [06:24, 04:38](1188 MB)
-PASS -- TEST 'rap_sfcdiff_debug_intel' [07:26, 04:52](1199 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [09:24, 07:37](1192 MB)
-PASS -- TEST 'rrfs_v1beta_debug_intel' [06:28, 04:49](1185 MB)
-PASS -- TEST 'rap_clm_lake_debug_intel' [08:33, 06:04](1205 MB)
-PASS -- TEST 'rap_flake_debug_intel' [06:32, 04:52](1198 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [10:42, 08:08](1181 MB)
+PASS -- COMPILE 'atm_debug_dyn32_intel' [06:06, 04:16]
+PASS -- TEST 'control_CubedSphereGrid_debug_intel' [04:22, 02:40](807 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [04:25, 02:34](813 MB)
+PASS -- TEST 'control_stochy_debug_intel' [04:18, 03:00](781 MB)
+PASS -- TEST 'control_lndp_debug_intel' [04:17, 02:42](816 MB)
+PASS -- TEST 'control_csawmg_debug_intel' [06:35, 04:07](857 MB)
+PASS -- TEST 'control_csawmgt_debug_intel' [05:36, 04:00](856 MB)
+PASS -- TEST 'control_ras_debug_intel' [04:17, 02:43](792 MB)
+PASS -- TEST 'control_diag_debug_intel' [04:28, 02:47](865 MB)
+PASS -- TEST 'control_debug_p8_intel' [04:36, 02:45](1635 MB)
+PASS -- TEST 'regional_debug_intel' [18:38, 16:35](836 MB)
+PASS -- TEST 'rap_control_debug_intel' [06:20, 04:42](1192 MB)
+PASS -- TEST 'hrrr_control_debug_intel' [06:18, 04:38](1202 MB)
+PASS -- TEST 'hrrr_gf_debug_intel' [07:19, 04:48](1189 MB)
+PASS -- TEST 'hrrr_c3_debug_intel' [07:19, 04:46](1195 MB)
+PASS -- TEST 'rap_unified_drag_suite_debug_intel' [07:20, 04:46](1195 MB)
+PASS -- TEST 'rap_diag_debug_intel' [08:34, 05:04](1262 MB)
+PASS -- TEST 'rap_cires_ugwp_debug_intel' [07:21, 04:49](1206 MB)
+PASS -- TEST 'rap_unified_ugwp_debug_intel' [07:20, 04:48](1193 MB)
+PASS -- TEST 'rap_lndp_debug_intel' [07:21, 04:42](1193 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_intel' [07:23, 04:49](1201 MB)
+PASS -- TEST 'rap_noah_debug_intel' [08:20, 04:41](1202 MB)
+PASS -- TEST 'rap_sfcdiff_debug_intel' [08:21, 04:47](1197 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [11:20, 07:48](1200 MB)
+PASS -- TEST 'rrfs_v1beta_debug_intel' [08:22, 04:37](1181 MB)
+PASS -- TEST 'rap_clm_lake_debug_intel' [08:21, 05:42](1196 MB)
+PASS -- TEST 'rap_flake_debug_intel' [07:23, 04:45](1188 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [11:40, 08:05](1201 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_gnu' [04:07, 02:29]
-PASS -- TEST 'control_csawmg_debug_gnu' [04:47, 02:14](564 MB)
-PASS -- TEST 'control_csawmgt_debug_gnu' [04:47, 02:15](565 MB)
+PASS -- COMPILE 'atm_debug_dyn32_gnu' [04:06, 02:20]
+PASS -- TEST 'control_csawmg_debug_gnu' [04:37, 02:07](570 MB)
+PASS -- TEST 'control_csawmgt_debug_gnu' [04:34, 02:06](564 MB)
 
-PASS -- COMPILE 'wam_debug_intel' [11:10, 03:11]
-PASS -- TEST 'control_wam_debug_intel' [06:20, 04:43](514 MB)
+PASS -- COMPILE 'wam_debug_intel' [05:06, 03:02]
+PASS -- TEST 'control_wam_debug_intel' [06:18, 04:44](501 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [17:11, 09:32]
-PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [06:03, 03:57](1153 MB)
-PASS -- TEST 'rap_control_dyn32_phy32_intel' [08:43, 06:32](1044 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [06:37, 03:28](973 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [09:38, 06:15](1051 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [05:40, 03:15](953 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [06:33, 03:37](909 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_intel' [06:40, 04:47](1000 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [03:27, 01:51](897 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [11:07, 09:19]
+PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [06:00, 03:48](1156 MB)
+PASS -- TEST 'rap_control_dyn32_phy32_intel' [08:37, 06:19](1046 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [05:32, 03:21](985 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [08:30, 05:59](1097 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [05:27, 03:06](951 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [05:27, 03:33](915 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_intel' [17:42, 04:48](1031 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [03:21, 01:50](902 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [19:13, 11:49]
-PASS -- TEST 'conus13km_control_intel' [04:55, 02:10](1191 MB)
-PASS -- TEST 'conus13km_2threads_intel' [03:46, 00:52](1105 MB)
-PASS -- TEST 'conus13km_restart_mismatch_intel' [03:46, 01:13](1086 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [16:08, 11:44]
+PASS -- TEST 'conus13km_control_intel' [04:52, 02:00](1193 MB)
+PASS -- TEST 'conus13km_2threads_intel' [13:39, 00:56](1110 MB)
+PASS -- TEST 'conus13km_restart_mismatch_intel' [14:41, 01:12](1099 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [16:10, 09:40]
-PASS -- TEST 'rap_control_dyn64_phy32_intel' [06:48, 04:20](977 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [14:07, 09:15]
+PASS -- TEST 'rap_control_dyn64_phy32_intel' [06:40, 04:12](963 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [09:07, 03:06]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [07:25, 04:47](1059 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [07:23, 04:41](1058 MB)
-PASS -- TEST 'conus13km_debug_intel' [15:54, 13:53](1210 MB)
-PASS -- TEST 'conus13km_debug_qr_intel' [15:53, 14:02](897 MB)
-PASS -- TEST 'conus13km_debug_2threads_intel' [12:50, 07:50](1147 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_intel' [18:54, 13:42](1262 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [06:07, 03:13]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [06:21, 04:39](1047 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [06:18, 04:34](1068 MB)
+PASS -- TEST 'conus13km_debug_intel' [15:48, 13:33](1215 MB)
+PASS -- TEST 'conus13km_debug_qr_intel' [16:45, 13:59](919 MB)
+PASS -- TEST 'conus13km_debug_2threads_intel' [09:43, 07:46](1140 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_intel' [15:45, 13:44](1283 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [07:10, 03:17]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [07:27, 04:46](1125 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [05:07, 03:13]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [06:23, 04:46](1112 MB)
 
-PASS -- COMPILE 'hafsw_intel' [14:15, 10:40]
-PASS -- TEST 'hafs_regional_atm_intel' [08:23, 04:51](736 MB)
-PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [10:34, 05:54](1111 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_intel' [10:27, 06:51](831 MB)
-PASS -- TEST 'hafs_regional_atm_wav_intel' [17:20, 13:04](843 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [18:33, 14:42](876 MB)
-PASS -- TEST 'hafs_regional_1nest_atm_intel' [08:59, 05:20](500 MB)
-PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [10:20, 06:23](516 MB)
-PASS -- TEST 'hafs_global_1nest_atm_intel' [05:47, 02:39](371 MB)
-PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [11:12, 06:58](470 MB)
-PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [05:46, 03:34](525 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [05:48, 03:24](527 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [05:57, 04:02](580 MB)
-PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [03:29, 01:09](400 MB)
-PASS -- TEST 'gnv1_nested_intel' [06:45, 03:54](772 MB)
+PASS -- COMPILE 'hafsw_intel' [14:08, 10:24]
+PASS -- TEST 'hafs_regional_atm_intel' [07:15, 04:42](716 MB)
+PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [07:26, 05:42](1105 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_intel' [11:21, 06:47](823 MB)
+PASS -- TEST 'hafs_regional_atm_wav_intel' [15:15, 12:51](862 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [17:21, 14:30](880 MB)
+PASS -- TEST 'hafs_regional_1nest_atm_intel' [15:55, 05:16](502 MB)
+PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [09:14, 06:26](516 MB)
+PASS -- TEST 'hafs_global_1nest_atm_intel' [15:43, 02:36](371 MB)
+PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [21:20, 06:55](470 MB)
+PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [16:42, 03:33](524 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [16:43, 03:21](528 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [15:51, 04:01](579 MB)
+PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [13:26, 01:11](406 MB)
+PASS -- TEST 'gnv1_nested_intel' [16:47, 03:57](765 MB)
 
-PASS -- COMPILE 'hafsw_debug_intel' [07:13, 03:43]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [14:54, 12:12](568 MB)
+PASS -- COMPILE 'hafsw_debug_intel' [06:07, 03:30]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [24:52, 12:18](565 MB)
 
-PASS -- COMPILE 'hafsw_faster_intel' [15:30, 12:00]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [15:08, 08:23](670 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [15:06, 08:28](738 MB)
+PASS -- COMPILE 'hafsw_faster_intel' [14:09, 11:07]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [21:00, 08:22](639 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [22:05, 08:30](689 MB)
 
-PASS -- COMPILE 'hafs_mom6w_intel' [13:11, 10:55]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [12:05, 06:15](725 MB)
+PASS -- COMPILE 'hafs_mom6w_intel' [15:09, 11:02]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [19:02, 06:18](717 MB)
 
-PASS -- COMPILE 'hafs_all_intel' [13:14, 11:24]
-PASS -- TEST 'hafs_regional_docn_intel' [54:34, 06:13](832 MB)
-PASS -- TEST 'hafs_regional_docn_oisst_intel' [54:39, 06:20](808 MB)
-PASS -- TEST 'hafs_regional_datm_cdeps_intel' [03:09, 16:17](1219 MB)
+PASS -- COMPILE 'hafs_all_intel' [14:08, 10:19]
+PASS -- TEST 'hafs_regional_docn_intel' [19:12, 06:13](826 MB)
+PASS -- TEST 'hafs_regional_docn_oisst_intel' [20:17, 06:15](804 MB)
+PASS -- TEST 'hafs_regional_datm_cdeps_intel' [27:55, 16:17](1209 MB)
 
-PASS -- COMPILE 'datm_cdeps_intel' [11:13, 06:43]
-PASS -- TEST 'datm_cdeps_control_cfsr_intel' [49:29, 02:42](1122 MB)
-PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [03:20, 01:41](1074 MB)
-PASS -- TEST 'datm_cdeps_control_gefs_intel' [49:30, 02:36](1008 MB)
-PASS -- TEST 'datm_cdeps_iau_gefs_intel' [49:29, 02:39](1016 MB)
-PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [49:23, 02:36](1023 MB)
-PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [49:25, 02:41](1121 MB)
-PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [49:29, 02:41](1115 MB)
-PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [47:25, 02:37](991 MB)
-PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [52:44, 06:39](1051 MB)
-PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [52:42, 06:58](1025 MB)
-PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [47:24, 02:42](1116 MB)
-PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [14:20, 03:58](2483 MB)
-PASS -- TEST 'datm_cdeps_gfs_intel' [48:28, 04:12](2421 MB)
+PASS -- COMPILE 'datm_cdeps_intel' [07:07, 05:52]
+PASS -- TEST 'datm_cdeps_control_cfsr_intel' [05:14, 02:55](1120 MB)
+PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [08:17, 01:39](1069 MB)
+PASS -- TEST 'datm_cdeps_control_gefs_intel' [06:14, 02:35](1009 MB)
+PASS -- TEST 'datm_cdeps_iau_gefs_intel' [06:18, 02:39](994 MB)
+PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [12:15, 02:38](1001 MB)
+PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [10:18, 02:40](1121 MB)
+PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [09:15, 02:38](1120 MB)
+PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [08:15, 02:28](1010 MB)
+PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [11:22, 06:04](1051 MB)
+PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [11:12, 06:21](1030 MB)
+PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [06:12, 02:42](1133 MB)
+PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [08:17, 03:55](2431 MB)
+PASS -- TEST 'datm_cdeps_gfs_intel' [07:17, 03:52](2476 MB)
 
-PASS -- COMPILE 'datm_cdeps_debug_intel' [07:09, 03:08]
-PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [49:25, 06:08](1046 MB)
+PASS -- COMPILE 'datm_cdeps_debug_intel' [04:07, 02:53]
+PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [09:15, 06:08](1045 MB)
 
-PASS -- COMPILE 'datm_cdeps_faster_intel' [11:10, 06:47]
-PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [45:30, 02:40](1106 MB)
+PASS -- COMPILE 'datm_cdeps_faster_intel' [09:07, 06:06]
+PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [05:15, 02:40](1117 MB)
 
-PASS -- COMPILE 'datm_cdeps_land_intel' [02:06, 01:00]
-PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [43:38, 00:50](258 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_intel' [43:29, 00:52](320 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [02:24, 00:32](315 MB)
+PASS -- COMPILE 'datm_cdeps_land_intel' [04:06, 01:00]
+PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [03:27, 00:45](255 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_intel' [03:20, 00:47](321 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [03:21, 00:30](323 MB)
 
-PASS -- COMPILE 'atml_intel' [14:17, 13:01]
-PASS -- TEST 'control_p8_atmlnd_sbs_intel' [46:17, 04:27](1583 MB)
-PASS -- TEST 'control_p8_atmlnd_intel' [46:22, 04:27](1567 MB)
-PASS -- TEST 'control_restart_p8_atmlnd_intel' [10:14, 05:11](888 MB)
+PASS -- COMPILE 'atml_intel' [13:07, 10:49]
+PASS -- TEST 'control_p8_atmlnd_sbs_intel' [07:02, 04:14](1586 MB)
+PASS -- TEST 'control_p8_atmlnd_intel' [07:00, 04:14](1586 MB)
+PASS -- TEST 'control_restart_p8_atmlnd_intel' [04:48, 02:16](885 MB)
 
-PASS -- COMPILE 'atmw_intel' [13:13, 11:54]
-PASS -- TEST 'atmwav_control_noaero_p8_intel' [43:06, 01:53](1643 MB)
+PASS -- COMPILE 'atmw_intel' [12:08, 10:00]
+PASS -- TEST 'atmwav_control_noaero_p8_intel' [04:48, 01:45](1623 MB)
 
-PASS -- COMPILE 'atmwm_intel' [13:12, 11:56]
-PASS -- TEST 'control_atmwav_intel' [42:41, 01:46](669 MB)
+PASS -- COMPILE 'atmwm_intel' [12:07, 09:53]
+PASS -- TEST 'control_atmwav_intel' [03:31, 01:39](668 MB)
 
-PASS -- COMPILE 'atmaero_intel' [14:13, 12:14]
-PASS -- TEST 'atmaero_control_p8_intel' [43:13, 04:04](3020 MB)
-PASS -- TEST 'atmaero_control_p8_rad_intel' [43:18, 04:53](3092 MB)
-PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [41:59, 05:09](3115 MB)
+PASS -- COMPILE 'atmaero_intel' [12:08, 09:40]
+PASS -- TEST 'atmaero_control_p8_intel' [05:58, 03:53](3016 MB)
+PASS -- TEST 'atmaero_control_p8_rad_intel' [07:00, 04:44](3085 MB)
+PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [08:42, 05:05](3037 MB)
 
-PASS -- COMPILE 'atmaq_intel' [13:14, 11:46]
+PASS -- COMPILE 'atmaq_intel' [11:08, 09:22]
 
-PASS -- COMPILE 'atmaq_debug_intel' [09:16, 07:26]
-PASS -- TEST 'regional_atmaq_debug_intel' [57:29, 20:19](4434 MB)
+PASS -- COMPILE 'atmaq_debug_intel' [05:06, 03:17]
+PASS -- TEST 'regional_atmaq_debug_intel' [25:15, 20:06](4479 MB)
 
-PASS -- COMPILE 'atm_gnu' [08:07, 06:17]
-PASS -- TEST 'control_c48_gnu' [46:34, 11:45](787 MB)
-PASS -- TEST 'control_stochy_gnu' [38:27, 04:15](546 MB)
-PASS -- TEST 'control_ras_gnu' [39:32, 05:00](554 MB)
-PASS -- TEST 'control_p8_gnu' [36:27, 05:06](1303 MB)
-PASS -- TEST 'control_p8_ugwpv1_gnu' [08:09, 04:44](1309 MB)
-PASS -- TEST 'control_flake_gnu' [07:28, 05:55](595 MB)
+PASS -- COMPILE 'atm_gnu' [05:06, 03:27]
+PASS -- TEST 'control_c48_gnu' [14:25, 11:40](788 MB)
+PASS -- TEST 'control_stochy_gnu' [07:19, 04:01](549 MB)
+PASS -- TEST 'control_ras_gnu' [08:19, 04:59](553 MB)
+PASS -- TEST 'control_p8_gnu' [09:03, 04:53](1311 MB)
+PASS -- TEST 'control_p8_ugwpv1_gnu' [07:56, 04:44](1310 MB)
+PASS -- TEST 'control_flake_gnu' [08:19, 05:51](594 MB)
 
-PASS -- COMPILE 'rrfs_gnu' [09:08, 07:17]
-PASS -- TEST 'rap_control_gnu' [13:38, 11:53](894 MB)
-PASS -- TEST 'rap_decomp_gnu' [14:43, 11:52](895 MB)
-PASS -- TEST 'rap_2threads_gnu' [12:44, 10:37](983 MB)
-PASS -- TEST 'rap_restart_gnu' [03:04, 07:25](622 MB)
-PASS -- TEST 'rap_sfcdiff_gnu' [14:51, 11:46](895 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_gnu' [14:39, 11:57](899 MB)
-PASS -- TEST 'rap_sfcdiff_restart_gnu' [04:03, 10:11](627 MB)
-PASS -- TEST 'hrrr_control_gnu' [08:44, 06:02](895 MB)
-PASS -- TEST 'hrrr_control_noqr_gnu' [08:38, 05:59](877 MB)
-PASS -- TEST 'hrrr_control_2threads_gnu' [14:59, 08:52](971 MB)
-PASS -- TEST 'hrrr_control_decomp_gnu' [08:36, 06:02](888 MB)
-PASS -- TEST 'hrrr_control_restart_gnu' [03:40, 04:49](608 MB)
-PASS -- TEST 'hrrr_control_restart_noqr_gnu' [03:40, 04:38](702 MB)
-PASS -- TEST 'rrfs_v1beta_gnu' [21:01, 14:35](887 MB)
+PASS -- COMPILE 'rrfs_gnu' [05:06, 03:29]
+PASS -- TEST 'rap_control_gnu' [14:31, 11:43](894 MB)
+PASS -- TEST 'rap_decomp_gnu' [14:31, 11:50](895 MB)
+PASS -- TEST 'rap_2threads_gnu' [12:41, 10:28](971 MB)
+PASS -- TEST 'rap_restart_gnu' [08:39, 06:01](625 MB)
+PASS -- TEST 'rap_sfcdiff_gnu' [14:38, 11:46](893 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_gnu' [14:38, 11:42](892 MB)
+PASS -- TEST 'rap_sfcdiff_restart_gnu' [10:39, 08:46](627 MB)
+PASS -- TEST 'hrrr_control_gnu' [08:30, 06:00](888 MB)
+PASS -- TEST 'hrrr_control_noqr_gnu' [08:29, 05:56](878 MB)
+PASS -- TEST 'hrrr_control_2threads_gnu' [07:36, 05:12](976 MB)
+PASS -- TEST 'hrrr_control_decomp_gnu' [07:34, 06:00](889 MB)
+PASS -- TEST 'hrrr_control_restart_gnu' [06:26, 03:13](610 MB)
+PASS -- TEST 'hrrr_control_restart_noqr_gnu' [06:27, 03:13](705 MB)
+PASS -- TEST 'rrfs_v1beta_gnu' [13:42, 11:21](893 MB)
 
-PASS -- COMPILE 'atm_dyn32_debug_gnu' [09:09, 07:48]
-PASS -- TEST 'control_diag_debug_gnu' [09:46, 04:34](587 MB)
-PASS -- TEST 'regional_debug_gnu' [15:58, 10:31](595 MB)
-PASS -- TEST 'rap_control_debug_gnu' [09:42, 04:43](904 MB)
-PASS -- TEST 'hrrr_control_debug_gnu' [09:46, 05:56](902 MB)
-PASS -- TEST 'hrrr_gf_debug_gnu' [09:44, 04:59](907 MB)
-PASS -- TEST 'hrrr_c3_debug_gnu' [09:49, 05:11](903 MB)
-PASS -- TEST 'rap_diag_debug_gnu' [10:10, 05:58](991 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_gnu' [09:52, 06:05](901 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_gnu' [09:48, 05:12](904 MB)
-PASS -- TEST 'rrfs_v1beta_debug_gnu' [08:45, 04:58](898 MB)
-PASS -- TEST 'control_ras_debug_gnu' [07:39, 04:02](541 MB)
-PASS -- TEST 'control_stochy_debug_gnu' [07:37, 04:29](534 MB)
-PASS -- TEST 'control_debug_p8_gnu' [06:56, 04:06](1287 MB)
-PASS -- TEST 'rap_flake_debug_gnu' [07:40, 04:57](908 MB)
-PASS -- TEST 'rap_clm_lake_debug_gnu' [06:50, 05:08](907 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_gnu' [08:05, 06:32](907 MB)
+PASS -- COMPILE 'atm_dyn32_debug_gnu' [05:06, 03:21]
+PASS -- TEST 'control_diag_debug_gnu' [03:26, 01:36](589 MB)
+PASS -- TEST 'regional_debug_gnu' [09:43, 07:27](599 MB)
+PASS -- TEST 'rap_control_debug_gnu' [04:22, 02:31](906 MB)
+PASS -- TEST 'hrrr_control_debug_gnu' [04:20, 02:30](902 MB)
+PASS -- TEST 'hrrr_gf_debug_gnu' [04:18, 02:33](872 MB)
+PASS -- TEST 'hrrr_c3_debug_gnu' [05:17, 02:36](907 MB)
+PASS -- TEST 'rap_diag_debug_gnu' [05:36, 02:43](993 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_gnu' [07:22, 03:53](906 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_gnu' [04:23, 02:31](904 MB)
+PASS -- TEST 'rrfs_v1beta_debug_gnu' [04:19, 02:30](902 MB)
+PASS -- TEST 'control_ras_debug_gnu' [03:16, 01:32](542 MB)
+PASS -- TEST 'control_stochy_debug_gnu' [03:16, 01:50](536 MB)
+PASS -- TEST 'control_debug_p8_gnu' [04:41, 01:42](1293 MB)
+PASS -- TEST 'rap_flake_debug_gnu' [04:20, 02:32](911 MB)
+PASS -- TEST 'rap_clm_lake_debug_gnu' [04:22, 02:51](912 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_gnu' [06:37, 04:08](911 MB)
 
-PASS -- COMPILE 'wam_debug_gnu' [06:06, 04:36]
-PASS -- TEST 'control_wam_debug_gnu' [03:36, 04:00](242 MB)
+PASS -- COMPILE 'wam_debug_gnu' [03:06, 01:42]
+PASS -- TEST 'control_wam_debug_gnu' [04:18, 02:27](242 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_gnu' [07:08, 03:32]
-PASS -- TEST 'rap_control_dyn32_phy32_gnu' [12:50, 13:39](752 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_gnu' [03:49, 07:45](741 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_gnu' [07:55, 12:19](798 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_gnu' [01:52, 07:18](804 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_gnu' [01:43, 07:31](743 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_gnu' [34:07, 09:08](594 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_gnu' [33:56, 03:19](581 MB)
-PASS -- TEST 'conus13km_control_gnu' [55:12, 05:25](894 MB)
-PASS -- TEST 'conus13km_2threads_gnu' [34:12, 01:55](935 MB)
-PASS -- TEST 'conus13km_restart_mismatch_gnu' [35:15, 02:23](595 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_gnu' [05:06, 03:22]
+PASS -- TEST 'rap_control_dyn32_phy32_gnu' [14:34, 11:55](749 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_gnu' [08:27, 06:05](743 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_gnu' [13:37, 10:36](803 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_gnu' [07:32, 05:19](794 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_gnu' [07:27, 06:01](742 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_gnu' [11:37, 08:55](595 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_gnu' [05:22, 03:32](580 MB)
+PASS -- TEST 'conus13km_control_gnu' [07:57, 04:11](897 MB)
+PASS -- TEST 'conus13km_2threads_gnu' [04:40, 01:56](930 MB)
+PASS -- TEST 'conus13km_restart_mismatch_gnu' [04:40, 02:22](599 MB)
 
-PASS -- COMPILE 'atm_dyn64_phy32_gnu' [09:07, 05:15]
-PASS -- TEST 'rap_control_dyn64_phy32_gnu' [40:17, 07:06](779 MB)
+PASS -- COMPILE 'atm_dyn64_phy32_gnu' [06:06, 05:02]
+PASS -- TEST 'rap_control_dyn64_phy32_gnu' [09:42, 07:00](781 MB)
 
-PASS -- COMPILE 'atm_dyn32_phy32_debug_gnu' [06:09, 03:38]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_gnu' [34:47, 02:39](756 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_gnu' [34:46, 02:36](754 MB)
-PASS -- TEST 'conus13km_debug_gnu' [41:25, 07:17](913 MB)
-PASS -- TEST 'conus13km_debug_qr_gnu' [39:23, 07:13](630 MB)
-PASS -- TEST 'conus13km_debug_2threads_gnu' [36:12, 04:27](946 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_gnu' [41:16, 07:20](979 MB)
+PASS -- COMPILE 'atm_dyn32_phy32_debug_gnu' [05:08, 03:20]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_gnu' [05:20, 02:30](756 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_gnu' [05:19, 02:33](756 MB)
+PASS -- TEST 'conus13km_debug_gnu' [10:40, 07:02](912 MB)
+PASS -- TEST 'conus13km_debug_qr_gnu' [09:41, 07:02](627 MB)
+PASS -- TEST 'conus13km_debug_2threads_gnu' [06:40, 04:20](948 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_gnu' [09:40, 07:11](981 MB)
 
-PASS -- COMPILE 'atm_dyn64_phy32_debug_gnu' [05:07, 03:28]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_gnu' [36:58, 02:41](784 MB)
+PASS -- COMPILE 'atm_dyn64_phy32_debug_gnu' [05:09, 03:23]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_gnu' [04:20, 02:34](782 MB)
 
-PASS -- COMPILE 's2swa_gnu' [15:10, 13:56]
-PASS -- TEST 'cpld_control_p8_gnu' [46:03, 11:08](1511 MB)
+PASS -- COMPILE 's2swa_gnu' [15:09, 13:51]
+PASS -- TEST 'cpld_control_p8_gnu' [13:10, 10:50](1510 MB)
 
-PASS -- COMPILE 's2s_gnu' [15:10, 13:48]
-PASS -- TEST 'cpld_control_nowave_noaero_p8_gnu' [42:00, 06:54](1399 MB)
+PASS -- COMPILE 's2s_gnu' [15:09, 13:35]
+PASS -- TEST 'cpld_control_nowave_noaero_p8_gnu' [09:02, 06:34](1400 MB)
 
-PASS -- COMPILE 's2swa_debug_gnu' [04:07, 02:32]
-PASS -- TEST 'cpld_debug_p8_gnu' [40:44, 06:12](1512 MB)
+PASS -- COMPILE 's2swa_debug_gnu' [04:06, 02:18]
+PASS -- TEST 'cpld_debug_p8_gnu' [09:04, 06:12](1514 MB)
 
-PASS -- COMPILE 's2sw_pdlib_gnu' [15:08, 13:53]
-PASS -- TEST 'cpld_control_pdlib_p8_gnu' [56:39, 22:12](1378 MB)
+PASS -- COMPILE 's2sw_pdlib_gnu' [15:09, 13:38]
+PASS -- TEST 'cpld_control_pdlib_p8_gnu' [24:58, 22:17](1373 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_gnu' [04:07, 02:15]
-PASS -- TEST 'cpld_debug_pdlib_p8_gnu' [47:29, 13:12](1391 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_gnu' [04:06, 02:06]
+PASS -- TEST 'cpld_debug_pdlib_p8_gnu' [14:55, 12:49](1384 MB)
 
-PASS -- COMPILE 'datm_cdeps_gnu' [15:12, 13:43]
-PASS -- TEST 'datm_cdeps_control_cfsr_gnu' [53:32, 03:04](703 MB)
+PASS -- COMPILE 'datm_cdeps_gnu' [15:07, 13:23]
+PASS -- TEST 'datm_cdeps_control_cfsr_gnu' [05:14, 03:00](700 MB)
 
 SYNOPSIS:
-Starting Date/Time: 20240313 18:46:26
-Ending Date/Time: 20240313 23:52:57
-Total Time: 05h:09m:02s
+Starting Date/Time: 20240317 23:58:13
+Ending Date/Time: 20240318 01:49:49
+Total Time: 01h:51m:57s
 Compiles Completed: 55/55
 Tests Completed: 247/247
 

--- a/tests/logs/RegressionTests_hercules.log
+++ b/tests/logs/RegressionTests_hercules.log
@@ -1,7 +1,7 @@
 ====START OF HERCULES REGRESSION TESTING LOG====
 
 UFSWM hash used in testing:
-19159d93d74d6f3c37fdf74fb3475e000435f07e
+818ea1590078efdc8c6b0089acfbec656b9c1dca
 
 Submodule hashes used in testing:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
@@ -11,10 +11,10 @@ Submodule hashes used in testing:
  f6ff8f7c4d4cb6feabe3651b13204cf43fc948e3 CICE-interface/CICE/icepack (Icepack1.1.0-182-gf6ff8f7)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  6663459e58a04e3bda2157d5891d227e3abc3c7a FV3/atmos_cubed_sphere (201912_public_release-386-g6663459)
- 221788f4e2539af797eb02efe42465b153533201 FV3/ccpp/framework (ccpp_transition_to_vlab_master_20190705-613-g221788f)
- bbdec2ffceeb0cda70aaaa4f44e619a5468e7be3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5134-gbbdec2ff)
+ 87e6d92e2ca48a55b66f8810f347b51c70c193c4 FV3/ccpp/framework (v0.1.0-1436-g87e6d92)
+ 2f15ae92802cae11fd0efb902439a084609984f3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5141-g2f15ae92)
  74a0e098b2163425e4b5466c2dfcf8ae26d560a5 FV3/ccpp/physics/physics/Radiation/RRTMGP/rte-rrtmgp (v1.6)
  945cb2cef5e8bd5949afd4f0fc35c4fb6e95a1bf FV3/upp (upp_v10.2.0-159-g945cb2c)
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e FV3/upp/sorc/libIFI.fd
@@ -32,7 +32,7 @@ Submodule hashes used in testing:
  7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
@@ -47,366 +47,366 @@ The first time is for the full script (prep+run+finalize).
 The second time is specifically for the run phase.
 Times/Memory will be empty for failed tests.
 
-BASELINE DIRECTORY: /work/noaa/epic/hercules/UFS-WM_RT/NEMSfv3gfs/develop-20240312
-COMPARISON DIRECTORY: /work2/noaa/stmp/zshrader/stmp/zshrader/FV3_RT/rt_941138
+BASELINE DIRECTORY: /work/noaa/epic/hercules/UFS-WM_RT/NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /work2/noaa/epic/stmp/role-epic/stmp/role-epic/FV3_RT/rt_3021165
 
 RT.SH OPTIONS USED:
 * (-a) - HPC PROJECT ACCOUNT: epic
 * (-l) - USE CONFIG FILE: rt.conf
 * (-e) - USE ECFLOW
 
-PASS -- COMPILE 's2swa_32bit_intel' [13:06, 11:07]
-PASS -- TEST 'cpld_control_p8_mixedmode_intel' [09:56, 07:44](1889 MB)
+PASS -- COMPILE 's2swa_32bit_intel' [13:06, 11:32]
+PASS -- TEST 'cpld_control_p8_mixedmode_intel' [10:14, 07:43](1889 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_intel' [20:06, 18:08]
-PASS -- TEST 'cpld_control_gfsv17_intel' [21:02, 13:18](1769 MB)
-PASS -- TEST 'cpld_control_gfsv17_iau_intel' [17:15, 14:04](2183 MB)
-PASS -- TEST 'cpld_restart_gfsv17_intel' [11:19, 06:33](1189 MB)
-PASS -- TEST 'cpld_mpi_gfsv17_intel' [22:08, 14:54](1692 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_intel' [19:07, 17:43]
+PASS -- TEST 'cpld_control_gfsv17_intel' [16:10, 13:26](1773 MB)
+PASS -- TEST 'cpld_control_gfsv17_iau_intel' [17:32, 14:09](2163 MB)
+PASS -- TEST 'cpld_restart_gfsv17_intel' [09:24, 06:31](1182 MB)
+PASS -- TEST 'cpld_mpi_gfsv17_intel' [18:12, 15:15](1696 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [06:06, 04:43]
-PASS -- TEST 'cpld_debug_gfsv17_intel' [23:11, 20:23](1739 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [06:05, 04:47]
+PASS -- TEST 'cpld_debug_gfsv17_intel' [23:12, 20:17](1727 MB)
 
-PASS -- COMPILE 's2swa_intel' [13:06, 12:00]
-PASS -- TEST 'cpld_control_p8_intel' [09:46, 07:40](2088 MB)
-PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [09:57, 07:36](2063 MB)
-PASS -- TEST 'cpld_restart_p8_intel' [11:08, 04:17](1960 MB)
-PASS -- TEST 'cpld_control_qr_p8_intel' [09:45, 07:45](1977 MB)
-PASS -- TEST 'cpld_restart_qr_p8_intel' [11:10, 04:18](1731 MB)
-PASS -- TEST 'cpld_2threads_p8_intel' [10:44, 08:52](2499 MB)
-PASS -- TEST 'cpld_decomp_p8_intel' [09:43, 07:43](2064 MB)
-PASS -- TEST 'cpld_mpi_p8_intel' [08:50, 06:28](1906 MB)
-PASS -- TEST 'cpld_control_ciceC_p8_intel' [09:58, 07:35](2063 MB)
-PASS -- TEST 'cpld_control_c192_p8_intel' [25:31, 15:20](2810 MB)
-PASS -- TEST 'cpld_restart_c192_p8_intel' [09:01, 05:51](2926 MB)
-PASS -- TEST 'cpld_bmark_p8_intel' [20:33, 08:57](3635 MB)
-PASS -- TEST 'cpld_restart_bmark_p8_intel' [13:45, 05:12](3617 MB)
-PASS -- TEST 'cpld_s2sa_p8_intel' [06:45, 05:00](2033 MB)
+PASS -- COMPILE 's2swa_intel' [13:06, 11:05]
+PASS -- TEST 'cpld_control_p8_intel' [10:06, 07:41](2066 MB)
+PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [10:11, 07:40](2079 MB)
+PASS -- TEST 'cpld_restart_p8_intel' [07:17, 04:23](1978 MB)
+PASS -- TEST 'cpld_control_qr_p8_intel' [10:02, 07:35](1970 MB)
+PASS -- TEST 'cpld_restart_qr_p8_intel' [07:21, 04:21](1738 MB)
+PASS -- TEST 'cpld_2threads_p8_intel' [12:09, 09:04](2498 MB)
+PASS -- TEST 'cpld_decomp_p8_intel' [10:06, 07:29](2064 MB)
+PASS -- TEST 'cpld_mpi_p8_intel' [09:15, 06:24](1901 MB)
+PASS -- TEST 'cpld_control_ciceC_p8_intel' [10:13, 07:39](2062 MB)
+PASS -- TEST 'cpld_control_c192_p8_intel' [18:39, 15:32](2793 MB)
+PASS -- TEST 'cpld_restart_c192_p8_intel' [09:20, 05:49](2927 MB)
+PASS -- TEST 'cpld_bmark_p8_intel' [15:43, 09:01](3631 MB)
+PASS -- TEST 'cpld_restart_bmark_p8_intel' [14:23, 05:28](3612 MB)
+PASS -- TEST 'cpld_s2sa_p8_intel' [06:59, 04:58](2020 MB)
 
-PASS -- COMPILE 's2sw_intel' [13:06, 11:09]
-PASS -- TEST 'cpld_control_noaero_p8_intel' [09:47, 07:10](1772 MB)
-PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [05:47, 03:59](1816 MB)
+PASS -- COMPILE 's2sw_intel' [12:06, 10:41]
+PASS -- TEST 'cpld_control_noaero_p8_intel' [10:11, 07:07](1772 MB)
+PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [06:02, 04:01](1816 MB)
 
-PASS -- COMPILE 's2swa_debug_intel' [07:06, 05:19]
-PASS -- TEST 'cpld_debug_p8_intel' [08:47, 06:56](2052 MB)
+PASS -- COMPILE 's2swa_debug_intel' [07:06, 05:10]
+PASS -- TEST 'cpld_debug_p8_intel' [09:04, 06:53](2043 MB)
 
-PASS -- COMPILE 's2sw_debug_intel' [07:06, 05:17]
-PASS -- TEST 'cpld_debug_noaero_p8_intel' [06:47, 04:47](1799 MB)
+PASS -- COMPILE 's2sw_debug_intel' [06:05, 04:37]
+PASS -- TEST 'cpld_debug_noaero_p8_intel' [06:54, 04:42](1805 MB)
 
-PASS -- COMPILE 's2s_aoflux_intel' [11:06, 09:13]
-PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [05:44, 04:04](1817 MB)
+PASS -- COMPILE 's2s_aoflux_intel' [11:06, 09:14]
+PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [05:58, 03:59](1817 MB)
 
-PASS -- COMPILE 's2s_intel' [10:06, 08:12]
-PASS -- TEST 'cpld_control_c48_intel' [09:34, 07:17](2838 MB)
+PASS -- COMPILE 's2s_intel' [11:06, 09:19]
+PASS -- TEST 'cpld_control_c48_intel' [09:38, 07:13](2816 MB)
 
-PASS -- COMPILE 's2swa_faster_intel' [13:06, 11:39]
-PASS -- TEST 'cpld_control_p8_faster_intel' [09:59, 07:14](2065 MB)
+PASS -- COMPILE 's2swa_faster_intel' [15:06, 13:16]
+PASS -- TEST 'cpld_control_p8_faster_intel' [10:08, 07:15](2092 MB)
 
-PASS -- COMPILE 's2sw_pdlib_intel' [17:06, 15:48]
-PASS -- TEST 'cpld_control_pdlib_p8_intel' [19:47, 13:49](1808 MB)
-PASS -- TEST 'cpld_restart_pdlib_p8_intel' [11:11, 06:47](1285 MB)
-PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [19:51, 15:26](1729 MB)
+PASS -- COMPILE 's2sw_pdlib_intel' [19:07, 17:09]
+PASS -- TEST 'cpld_control_pdlib_p8_intel' [16:02, 13:50](1806 MB)
+PASS -- TEST 'cpld_restart_pdlib_p8_intel' [08:57, 06:56](1278 MB)
+PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [17:50, 15:37](1729 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_intel' [05:05, 04:03]
-PASS -- TEST 'cpld_debug_pdlib_p8_intel' [23:43, 21:41](1761 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_intel' [06:07, 04:34]
+PASS -- TEST 'cpld_debug_pdlib_p8_intel' [23:54, 22:05](1766 MB)
 
-PASS -- COMPILE 'atm_dyn32_intel' [09:05, 07:54]
-PASS -- TEST 'control_flake_intel' [15:20, 02:50](713 MB)
-PASS -- TEST 'control_CubedSphereGrid_intel' [14:20, 02:09](659 MB)
-PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [11:24, 02:11](671 MB)
-PASS -- TEST 'control_latlon_intel' [13:17, 02:07](661 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [14:24, 02:10](665 MB)
-PASS -- TEST 'control_c48_intel' [10:22, 05:41](860 MB)
-PASS -- TEST 'control_c48.v2.sfc_intel' [18:38, 05:45](855 MB)
-PASS -- TEST 'control_c192_intel' [15:27, 08:12](982 MB)
-PASS -- TEST 'control_c384_intel' [15:13, 08:15](1442 MB)
-PASS -- TEST 'control_c384gdas_intel' [14:51, 07:19](1520 MB)
-PASS -- TEST 'control_stochy_intel' [09:16, 01:27](680 MB)
-PASS -- TEST 'control_stochy_restart_intel' [05:19, 00:52](532 MB)
-PASS -- TEST 'control_lndp_intel' [11:18, 01:23](665 MB)
-PASS -- TEST 'control_iovr4_intel' [14:18, 02:08](658 MB)
-PASS -- TEST 'control_iovr5_intel' [11:15, 02:07](655 MB)
-PASS -- TEST 'control_p8_intel' [11:49, 02:32](1643 MB)
-PASS -- TEST 'control_p8.v2.sfc_intel' [11:48, 02:34](1626 MB)
-PASS -- TEST 'control_p8_ugwpv1_intel' [09:49, 02:28](1658 MB)
-PASS -- TEST 'control_restart_p8_intel' [03:45, 01:25](922 MB)
-PASS -- TEST 'control_noqr_p8_intel' [09:46, 02:33](1625 MB)
-PASS -- TEST 'control_restart_noqr_p8_intel' [03:42, 01:26](973 MB)
-PASS -- TEST 'control_decomp_p8_intel' [09:42, 02:40](1618 MB)
-PASS -- TEST 'control_2threads_p8_intel' [09:41, 02:22](1730 MB)
-PASS -- TEST 'control_p8_lndp_intel' [11:36, 04:31](1644 MB)
-PASS -- TEST 'control_p8_rrtmgp_intel' [07:52, 03:36](1717 MB)
-PASS -- TEST 'control_p8_mynn_intel' [05:47, 02:31](1644 MB)
-PASS -- TEST 'merra2_thompson_intel' [06:55, 02:59](1658 MB)
-PASS -- TEST 'regional_control_intel' [06:23, 04:33](957 MB)
-PASS -- TEST 'regional_restart_intel' [04:28, 02:29](1105 MB)
-PASS -- TEST 'regional_decomp_intel' [06:22, 04:46](945 MB)
-PASS -- TEST 'regional_2threads_intel' [04:26, 03:00](915 MB)
-PASS -- TEST 'regional_noquilt_intel' [06:25, 04:29](1488 MB)
-PASS -- TEST 'regional_netcdf_parallel_intel' [06:27, 04:39](955 MB)
-PASS -- TEST 'regional_2dwrtdecomp_intel' [06:22, 04:30](959 MB)
-PASS -- TEST 'regional_wofs_intel' [07:23, 05:36](2089 MB)
+PASS -- COMPILE 'atm_dyn32_intel' [10:06, 08:11]
+PASS -- TEST 'control_flake_intel' [04:20, 02:52](708 MB)
+PASS -- TEST 'control_CubedSphereGrid_intel' [04:22, 02:06](667 MB)
+PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [04:28, 02:10](667 MB)
+PASS -- TEST 'control_latlon_intel' [04:20, 02:10](663 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [04:25, 02:09](664 MB)
+PASS -- TEST 'control_c48_intel' [07:26, 05:45](855 MB)
+PASS -- TEST 'control_c48.v2.sfc_intel' [07:27, 05:45](856 MB)
+PASS -- TEST 'control_c192_intel' [09:32, 07:49](977 MB)
+PASS -- TEST 'control_c384_intel' [11:06, 08:22](1456 MB)
+PASS -- TEST 'control_c384gdas_intel' [10:59, 07:43](1532 MB)
+PASS -- TEST 'control_stochy_intel' [03:20, 01:25](668 MB)
+PASS -- TEST 'control_stochy_restart_intel' [02:26, 00:55](528 MB)
+PASS -- TEST 'control_lndp_intel' [03:20, 01:21](671 MB)
+PASS -- TEST 'control_iovr4_intel' [04:22, 02:07](663 MB)
+PASS -- TEST 'control_iovr5_intel' [04:19, 02:09](657 MB)
+PASS -- TEST 'control_p8_intel' [04:52, 02:39](1645 MB)
+PASS -- TEST 'control_p8.v2.sfc_intel' [05:06, 02:39](1637 MB)
+PASS -- TEST 'control_p8_ugwpv1_intel' [05:05, 02:29](1633 MB)
+PASS -- TEST 'control_restart_p8_intel' [03:56, 01:24](925 MB)
+PASS -- TEST 'control_noqr_p8_intel' [04:50, 02:32](1638 MB)
+PASS -- TEST 'control_restart_noqr_p8_intel' [03:55, 01:25](972 MB)
+PASS -- TEST 'control_decomp_p8_intel' [04:50, 02:38](1628 MB)
+PASS -- TEST 'control_2threads_p8_intel' [04:55, 02:28](1729 MB)
+PASS -- TEST 'control_p8_lndp_intel' [06:48, 04:28](1631 MB)
+PASS -- TEST 'control_p8_rrtmgp_intel' [06:05, 03:30](1714 MB)
+PASS -- TEST 'control_p8_mynn_intel' [05:01, 02:39](1635 MB)
+PASS -- TEST 'merra2_thompson_intel' [05:12, 02:59](1660 MB)
+PASS -- TEST 'regional_control_intel' [06:31, 04:34](957 MB)
+PASS -- TEST 'regional_restart_intel' [04:24, 02:30](1101 MB)
+PASS -- TEST 'regional_decomp_intel' [06:26, 04:44](946 MB)
+PASS -- TEST 'regional_2threads_intel' [04:32, 03:02](911 MB)
+PASS -- TEST 'regional_noquilt_intel' [06:30, 04:22](1487 MB)
+PASS -- TEST 'regional_netcdf_parallel_intel' [06:30, 04:31](955 MB)
+PASS -- TEST 'regional_2dwrtdecomp_intel' [06:30, 04:30](955 MB)
+PASS -- TEST 'regional_wofs_intel' [07:28, 05:51](2067 MB)
 
-PASS -- COMPILE 'rrfs_intel' [08:05, 07:03]
-PASS -- TEST 'rap_control_intel' [08:47, 06:46](1207 MB)
-PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [05:38, 03:47](1439 MB)
-PASS -- TEST 'rap_decomp_intel' [08:28, 06:51](1163 MB)
-PASS -- TEST 'rap_2threads_intel' [08:31, 06:12](1368 MB)
-PASS -- TEST 'rap_restart_intel' [05:52, 03:27](1147 MB)
-PASS -- TEST 'rap_sfcdiff_intel' [08:47, 06:39](1203 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_intel' [08:30, 06:50](1151 MB)
-PASS -- TEST 'rap_sfcdiff_restart_intel' [07:50, 05:06](1187 MB)
-PASS -- TEST 'hrrr_control_intel' [05:35, 03:21](1081 MB)
-PASS -- TEST 'hrrr_control_decomp_intel' [05:35, 03:26](1035 MB)
-PASS -- TEST 'hrrr_control_2threads_intel' [05:28, 03:03](1125 MB)
-PASS -- TEST 'hrrr_control_restart_intel' [03:17, 01:56](1035 MB)
-PASS -- TEST 'rrfs_v1beta_intel' [08:48, 06:19](1184 MB)
-PASS -- TEST 'rrfs_v1nssl_intel' [09:18, 07:38](2006 MB)
-PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [09:20, 07:30](2156 MB)
+PASS -- COMPILE 'rrfs_intel' [09:06, 07:41]
+PASS -- TEST 'rap_control_intel' [08:51, 06:37](1192 MB)
+PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [05:48, 03:26](1416 MB)
+PASS -- TEST 'rap_decomp_intel' [08:39, 06:56](1121 MB)
+PASS -- TEST 'rap_2threads_intel' [08:34, 06:13](1389 MB)
+PASS -- TEST 'rap_restart_intel' [05:52, 03:30](1131 MB)
+PASS -- TEST 'rap_sfcdiff_intel' [08:38, 06:26](1199 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_intel' [08:33, 06:54](1148 MB)
+PASS -- TEST 'rap_sfcdiff_restart_intel' [07:01, 04:56](1199 MB)
+PASS -- TEST 'hrrr_control_intel' [05:52, 03:25](1062 MB)
+PASS -- TEST 'hrrr_control_decomp_intel' [05:37, 03:37](1057 MB)
+PASS -- TEST 'hrrr_control_2threads_intel' [05:34, 03:13](1111 MB)
+PASS -- TEST 'hrrr_control_restart_intel' [03:20, 01:50](1019 MB)
+PASS -- TEST 'rrfs_v1beta_intel' [09:00, 06:32](1186 MB)
+PASS -- TEST 'rrfs_v1nssl_intel' [09:21, 07:41](2014 MB)
+PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [09:21, 07:38](2202 MB)
 
-PASS -- COMPILE 'csawmg_intel' [08:05, 06:35]
-PASS -- TEST 'control_csawmg_intel' [07:25, 05:21](833 MB)
-PASS -- TEST 'control_csawmgt_intel' [07:23, 05:14](848 MB)
-PASS -- TEST 'control_ras_intel' [04:13, 02:53](806 MB)
+PASS -- COMPILE 'csawmg_intel' [09:06, 07:25]
+PASS -- TEST 'control_csawmg_intel' [07:26, 05:20](842 MB)
+PASS -- TEST 'control_csawmgt_intel' [07:29, 05:16](817 MB)
+PASS -- TEST 'control_ras_intel' [04:16, 02:51](818 MB)
 
-PASS -- COMPILE 'csawmg_gnu' [06:05, 04:08]
-PASS -- TEST 'control_csawmg_gnu' [08:26, 06:27](811 MB)
-PASS -- TEST 'control_csawmgt_gnu' [08:25, 06:18](811 MB)
+PASS -- COMPILE 'csawmg_gnu' [06:05, 04:29]
+PASS -- TEST 'control_csawmg_gnu' [08:33, 06:33](811 MB)
+PASS -- TEST 'control_csawmgt_gnu' [08:25, 06:25](807 MB)
 
-PASS -- COMPILE 'wam_intel' [08:05, 06:33]
-PASS -- TEST 'control_wam_intel' [03:17, 01:48](796 MB)
+PASS -- COMPILE 'wam_intel' [08:06, 06:52]
+PASS -- TEST 'control_wam_intel' [03:19, 01:54](784 MB)
 
-PASS -- COMPILE 'atm_faster_dyn32_intel' [11:06, 09:30]
-PASS -- TEST 'control_p8_faster_intel' [04:46, 02:15](1641 MB)
-PASS -- TEST 'regional_control_faster_intel' [06:21, 04:02](961 MB)
+PASS -- COMPILE 'atm_faster_dyn32_intel' [12:05, 10:04]
+PASS -- TEST 'control_p8_faster_intel' [04:58, 02:15](1630 MB)
+PASS -- TEST 'regional_control_faster_intel' [06:29, 04:09](957 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_intel' [05:05, 03:43]
-PASS -- TEST 'control_CubedSphereGrid_debug_intel' [05:16, 02:16](819 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [05:18, 02:12](825 MB)
-PASS -- TEST 'control_stochy_debug_intel' [05:12, 02:26](823 MB)
-PASS -- TEST 'control_lndp_debug_intel' [05:12, 02:20](821 MB)
-PASS -- TEST 'control_csawmg_debug_intel' [05:24, 03:24](882 MB)
-PASS -- TEST 'control_csawmgt_debug_intel' [05:22, 03:20](879 MB)
-PASS -- TEST 'control_ras_debug_intel' [04:11, 02:19](834 MB)
-PASS -- TEST 'control_diag_debug_intel' [04:20, 02:20](880 MB)
-PASS -- TEST 'control_debug_p8_intel' [04:27, 02:22](1657 MB)
-PASS -- TEST 'regional_debug_intel' [16:30, 14:13](891 MB)
-PASS -- TEST 'rap_control_debug_intel' [05:18, 03:59](1218 MB)
-PASS -- TEST 'hrrr_control_debug_intel' [05:15, 03:57](1218 MB)
-PASS -- TEST 'hrrr_gf_debug_intel' [05:12, 03:59](1220 MB)
-PASS -- TEST 'hrrr_c3_debug_intel' [06:13, 04:05](1218 MB)
-PASS -- TEST 'rap_unified_drag_suite_debug_intel' [05:13, 03:58](1221 MB)
-PASS -- TEST 'rap_diag_debug_intel' [06:22, 04:13](1299 MB)
-PASS -- TEST 'rap_cires_ugwp_debug_intel' [06:17, 04:08](1218 MB)
-PASS -- TEST 'rap_unified_ugwp_debug_intel' [06:16, 04:09](1212 MB)
-PASS -- TEST 'rap_lndp_debug_intel' [06:15, 04:04](1218 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_intel' [05:14, 04:03](1222 MB)
-PASS -- TEST 'rap_noah_debug_intel' [05:15, 03:57](1213 MB)
-PASS -- TEST 'rap_sfcdiff_debug_intel' [06:15, 04:05](1227 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [08:17, 06:31](1223 MB)
-PASS -- TEST 'rrfs_v1beta_debug_intel' [05:15, 04:00](1209 MB)
-PASS -- TEST 'rap_clm_lake_debug_intel' [06:15, 04:51](1211 MB)
-PASS -- TEST 'rap_flake_debug_intel' [06:15, 04:03](1222 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [10:45, 06:56](1220 MB)
+PASS -- COMPILE 'atm_debug_dyn32_intel' [05:05, 03:53]
+PASS -- TEST 'control_CubedSphereGrid_debug_intel' [04:19, 02:21](822 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [04:21, 02:15](828 MB)
+PASS -- TEST 'control_stochy_debug_intel' [04:21, 02:32](839 MB)
+PASS -- TEST 'control_lndp_debug_intel' [04:19, 02:14](827 MB)
+PASS -- TEST 'control_csawmg_debug_intel' [05:27, 03:27](878 MB)
+PASS -- TEST 'control_csawmgt_debug_intel' [05:23, 03:20](872 MB)
+PASS -- TEST 'control_ras_debug_intel' [04:14, 02:18](849 MB)
+PASS -- TEST 'control_diag_debug_intel' [04:22, 02:19](888 MB)
+PASS -- TEST 'control_debug_p8_intel' [04:30, 02:24](1663 MB)
+PASS -- TEST 'regional_debug_intel' [16:31, 14:23](899 MB)
+PASS -- TEST 'rap_control_debug_intel' [05:16, 03:58](1218 MB)
+PASS -- TEST 'hrrr_control_debug_intel' [05:13, 03:53](1217 MB)
+PASS -- TEST 'hrrr_gf_debug_intel' [05:13, 03:59](1222 MB)
+PASS -- TEST 'hrrr_c3_debug_intel' [06:16, 04:04](1237 MB)
+PASS -- TEST 'rap_unified_drag_suite_debug_intel' [06:17, 04:02](1215 MB)
+PASS -- TEST 'rap_diag_debug_intel' [06:35, 04:08](1296 MB)
+PASS -- TEST 'rap_cires_ugwp_debug_intel' [06:17, 04:05](1216 MB)
+PASS -- TEST 'rap_unified_ugwp_debug_intel' [05:17, 04:03](1228 MB)
+PASS -- TEST 'rap_lndp_debug_intel' [05:16, 04:02](1219 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_intel' [05:29, 03:58](1220 MB)
+PASS -- TEST 'rap_noah_debug_intel' [05:22, 03:56](1213 MB)
+PASS -- TEST 'rap_sfcdiff_debug_intel' [05:15, 03:56](1230 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [08:17, 06:26](1217 MB)
+PASS -- TEST 'rrfs_v1beta_debug_intel' [05:16, 03:56](1220 MB)
+PASS -- TEST 'rap_clm_lake_debug_intel' [06:18, 04:51](1219 MB)
+PASS -- TEST 'rap_flake_debug_intel' [05:20, 03:58](1215 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [08:53, 06:54](1226 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_gnu' [05:05, 03:19]
-PASS -- TEST 'control_csawmg_debug_gnu' [05:26, 01:45](788 MB)
-PASS -- TEST 'control_csawmgt_debug_gnu' [05:27, 01:45](786 MB)
+PASS -- COMPILE 'atm_debug_dyn32_gnu' [05:06, 03:37]
+PASS -- TEST 'control_csawmg_debug_gnu' [03:29, 01:46](793 MB)
+PASS -- TEST 'control_csawmgt_debug_gnu' [03:23, 01:46](790 MB)
 
-PASS -- COMPILE 'wam_debug_intel' [07:06, 02:46]
+PASS -- COMPILE 'wam_debug_intel' [04:06, 02:38]
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [09:06, 06:52]
-PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [07:45, 03:38](1273 MB)
-PASS -- TEST 'rap_control_dyn32_phy32_intel' [08:49, 05:28](1146 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [05:53, 02:52](1034 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [08:32, 05:11](1274 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [05:33, 02:42](1039 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [06:31, 03:03](1001 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_intel' [11:46, 04:12](1104 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [08:20, 01:39](960 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [09:05, 07:14]
+PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [05:45, 03:17](1274 MB)
+PASS -- TEST 'rap_control_dyn32_phy32_intel' [07:49, 05:27](1135 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [04:56, 02:54](1043 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [07:51, 05:21](1292 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [04:40, 02:39](1035 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [04:37, 03:04](975 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_intel' [06:50, 04:17](1101 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [03:23, 01:39](950 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [12:06, 09:19]
-PASS -- TEST 'conus13km_control_intel' [03:34, 01:44](1285 MB)
-PASS -- TEST 'conus13km_2threads_intel' [07:24, 00:53](1209 MB)
-PASS -- TEST 'conus13km_restart_mismatch_intel' [07:25, 01:04](1156 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [11:07, 09:19]
+PASS -- TEST 'conus13km_control_intel' [03:41, 01:43](1295 MB)
+PASS -- TEST 'conus13km_2threads_intel' [02:29, 00:44](1200 MB)
+PASS -- TEST 'conus13km_restart_mismatch_intel' [03:24, 01:04](1152 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [09:06, 06:58]
-PASS -- TEST 'rap_control_dyn64_phy32_intel' [05:29, 03:45](1070 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [09:06, 07:06]
+PASS -- TEST 'rap_control_dyn64_phy32_intel' [05:40, 03:45](1074 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [05:06, 02:56]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [06:20, 03:56](1108 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [06:13, 03:52](1085 MB)
-PASS -- TEST 'conus13km_debug_intel' [18:28, 11:50](1346 MB)
-PASS -- TEST 'conus13km_debug_qr_intel' [19:27, 12:09](999 MB)
-PASS -- TEST 'conus13km_debug_2threads_intel' [14:26, 06:50](1246 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_intel' [19:31, 11:56](1400 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [04:06, 02:57]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [05:21, 03:57](1102 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [05:15, 03:59](1088 MB)
+PASS -- TEST 'conus13km_debug_intel' [13:30, 11:35](1351 MB)
+PASS -- TEST 'conus13km_debug_qr_intel' [13:39, 12:03](998 MB)
+PASS -- TEST 'conus13km_debug_2threads_intel' [08:36, 06:41](1231 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_intel' [13:37, 11:40](1391 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [04:06, 02:52]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [11:16, 03:58](1148 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [04:06, 02:58]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [05:20, 04:01](1154 MB)
 
-PASS -- COMPILE 'hafsw_intel' [15:06, 09:36]
-PASS -- TEST 'hafs_regional_atm_intel' [08:59, 05:30](878 MB)
-PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [10:16, 05:24](1265 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_intel' [15:09, 06:34](956 MB)
-PASS -- TEST 'hafs_regional_atm_wav_intel' [22:01, 14:00](989 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [21:07, 15:27](991 MB)
-PASS -- TEST 'hafs_regional_1nest_atm_intel' [13:47, 05:36](607 MB)
-PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [13:13, 07:11](619 MB)
-PASS -- TEST 'hafs_global_1nest_atm_intel' [10:34, 02:54](438 MB)
-PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [11:54, 08:02](543 MB)
-PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [09:36, 03:58](616 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [11:38, 03:47](621 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [10:43, 04:54](675 MB)
-PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [07:21, 01:21](447 MB)
+PASS -- COMPILE 'hafsw_intel' [11:08, 09:56]
+PASS -- TEST 'hafs_regional_atm_intel' [08:01, 05:23](882 MB)
+PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [07:17, 05:09](1277 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_intel' [09:10, 06:26](937 MB)
+PASS -- TEST 'hafs_regional_atm_wav_intel' [16:00, 13:45](980 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [17:16, 14:49](962 MB)
+PASS -- TEST 'hafs_regional_1nest_atm_intel' [07:52, 05:33](607 MB)
+PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [10:25, 07:11](614 MB)
+PASS -- TEST 'hafs_global_1nest_atm_intel' [04:43, 02:54](435 MB)
+PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [11:12, 07:57](535 MB)
+PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [06:49, 04:06](616 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [05:39, 03:43](618 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [06:42, 04:57](686 MB)
+PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [03:21, 01:37](454 MB)
 
-PASS -- COMPILE 'hafsw_debug_intel' [07:06, 02:57]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [16:43, 11:20](636 MB)
+PASS -- COMPILE 'hafsw_debug_intel' [05:06, 03:15]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [13:46, 11:14](632 MB)
 
-PASS -- COMPILE 'hafsw_faster_intel' [13:05, 10:14]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [23:54, 17:50](731 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [23:51, 16:02](845 MB)
+PASS -- COMPILE 'hafsw_faster_intel' [13:06, 11:19]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [18:57, 16:39](729 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [18:55, 16:35](811 MB)
 
-PASS -- COMPILE 'hafs_mom6w_intel' [11:05, 09:03]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [17:53, 10:01](814 MB)
+PASS -- COMPILE 'hafs_mom6w_intel' [12:05, 10:19]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [11:55, 09:44](795 MB)
 
-PASS -- COMPILE 'hafs_all_intel' [12:05, 09:24]
-PASS -- TEST 'hafs_regional_docn_intel' [13:04, 05:34](948 MB)
-PASS -- TEST 'hafs_regional_docn_oisst_intel' [11:59, 05:41](920 MB)
-PASS -- TEST 'hafs_regional_datm_cdeps_intel' [21:39, 16:31](1342 MB)
+PASS -- COMPILE 'hafs_all_intel' [11:05, 09:40]
+PASS -- TEST 'hafs_regional_docn_intel' [08:00, 05:26](947 MB)
+PASS -- TEST 'hafs_regional_docn_oisst_intel' [08:02, 05:26](957 MB)
+PASS -- TEST 'hafs_regional_datm_cdeps_intel' [18:39, 16:24](1345 MB)
 
-PASS -- COMPILE 'datm_cdeps_intel' [08:06, 05:43]
-PASS -- TEST 'datm_cdeps_control_cfsr_intel' [08:11, 02:08](1150 MB)
-PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [05:11, 01:21](1094 MB)
-PASS -- TEST 'datm_cdeps_control_gefs_intel' [08:10, 02:04](1010 MB)
-PASS -- TEST 'datm_cdeps_iau_gefs_intel' [07:10, 02:05](1011 MB)
-PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [07:11, 02:08](1010 MB)
-PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [07:10, 02:10](1147 MB)
-PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [08:10, 02:08](1143 MB)
-PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [08:09, 02:06](1008 MB)
-PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [06:46, 04:51](1168 MB)
-PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [07:46, 04:56](1142 MB)
-PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [08:13, 02:10](1143 MB)
-PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [08:14, 03:01](2441 MB)
-PASS -- TEST 'datm_cdeps_gfs_intel' [09:10, 03:04](2388 MB)
+PASS -- COMPILE 'datm_cdeps_intel' [09:06, 07:06]
+PASS -- TEST 'datm_cdeps_control_cfsr_intel' [04:11, 02:08](1155 MB)
+PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [03:10, 01:19](1103 MB)
+PASS -- TEST 'datm_cdeps_control_gefs_intel' [03:11, 02:03](1016 MB)
+PASS -- TEST 'datm_cdeps_iau_gefs_intel' [04:12, 02:07](1013 MB)
+PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [04:09, 02:08](1017 MB)
+PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [04:09, 02:07](1161 MB)
+PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [04:09, 02:07](1154 MB)
+PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [04:09, 02:05](1011 MB)
+PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [06:49, 04:58](1165 MB)
+PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [06:44, 04:52](1140 MB)
+PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [04:08, 02:09](1148 MB)
+PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [04:10, 02:59](2432 MB)
+PASS -- TEST 'datm_cdeps_gfs_intel' [04:12, 03:02](2442 MB)
 
-PASS -- COMPILE 'datm_cdeps_debug_intel' [05:05, 03:36]
-PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [11:11, 05:02](1083 MB)
+PASS -- COMPILE 'datm_cdeps_debug_intel' [05:06, 03:55]
+PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [07:12, 05:06](1067 MB)
 
-PASS -- COMPILE 'datm_cdeps_faster_intel' [08:05, 05:03]
-PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [09:12, 02:10](1147 MB)
+PASS -- COMPILE 'datm_cdeps_faster_intel' [07:05, 05:43]
+PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [04:09, 02:07](1153 MB)
 
-PASS -- COMPILE 'datm_cdeps_land_intel' [03:05, 00:43]
-PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [04:21, 00:52](336 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_intel' [04:17, 00:51](560 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [03:15, 00:36](560 MB)
+PASS -- COMPILE 'datm_cdeps_land_intel' [02:06, 00:55]
+PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [02:22, 00:57](337 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_intel' [02:15, 00:54](558 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [02:16, 00:34](564 MB)
 
-PASS -- COMPILE 'atml_intel' [10:05, 07:27]
-PASS -- TEST 'control_p8_atmlnd_sbs_intel' [09:54, 06:07](1644 MB)
-PASS -- TEST 'control_p8_atmlnd_intel' [08:56, 06:06](1653 MB)
-PASS -- TEST 'control_restart_p8_atmlnd_intel' [04:36, 02:58](956 MB)
+PASS -- COMPILE 'atml_intel' [10:07, 09:01]
+PASS -- TEST 'control_p8_atmlnd_sbs_intel' [08:42, 05:53](1653 MB)
+PASS -- TEST 'control_p8_atmlnd_intel' [08:39, 05:54](1653 MB)
+PASS -- TEST 'control_restart_p8_atmlnd_intel' [05:39, 03:05](945 MB)
 
-PASS -- COMPILE 'atmw_intel' [10:05, 08:56]
-PASS -- TEST 'atmwav_control_noaero_p8_intel' [03:49, 01:36](1688 MB)
+PASS -- COMPILE 'atmw_intel' [11:06, 09:43]
+PASS -- TEST 'atmwav_control_noaero_p8_intel' [03:50, 01:33](1692 MB)
 
-PASS -- COMPILE 'atmwm_intel' [12:06, 10:06]
-PASS -- TEST 'control_atmwav_intel' [03:39, 01:29](700 MB)
+PASS -- COMPILE 'atmwm_intel' [11:06, 09:59]
+PASS -- TEST 'control_atmwav_intel' [03:41, 01:32](702 MB)
 
-PASS -- COMPILE 'atmaero_intel' [10:06, 08:34]
-PASS -- TEST 'atmaero_control_p8_intel' [06:48, 03:36](1801 MB)
-PASS -- TEST 'atmaero_control_p8_rad_intel' [06:46, 04:16](1807 MB)
-PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [07:38, 04:29](1818 MB)
+PASS -- COMPILE 'atmaero_intel' [09:05, 07:39]
+PASS -- TEST 'atmaero_control_p8_intel' [05:45, 03:35](1793 MB)
+PASS -- TEST 'atmaero_control_p8_rad_intel' [06:47, 04:12](1805 MB)
+PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [07:25, 04:31](1821 MB)
 
-PASS -- COMPILE 'atmaq_intel' [08:05, 07:02]
+PASS -- COMPILE 'atmaq_intel' [09:06, 07:12]
 
-PASS -- COMPILE 'atmaq_debug_intel' [04:05, 02:34]
-PASS -- TEST 'regional_atmaq_debug_intel' [20:18, 16:36](4591 MB)
+PASS -- COMPILE 'atmaq_debug_intel' [04:05, 02:52]
+PASS -- TEST 'regional_atmaq_debug_intel' [20:34, 17:22](4603 MB)
 
-PASS -- COMPILE 'atm_gnu' [06:06, 03:53]
-PASS -- TEST 'control_c48_gnu' [13:23, 09:28](882 MB)
-PASS -- TEST 'control_stochy_gnu' [05:13, 02:20](729 MB)
-PASS -- TEST 'control_ras_gnu' [07:13, 03:50](732 MB)
-PASS -- TEST 'control_p8_gnu' [07:53, 03:39](1515 MB)
-PASS -- TEST 'control_p8_ugwpv1_gnu' [06:37, 03:29](1517 MB)
-PASS -- TEST 'control_flake_gnu' [07:13, 04:25](808 MB)
+PASS -- COMPILE 'atm_gnu' [06:05, 04:34]
+PASS -- TEST 'control_c48_gnu' [11:25, 09:27](860 MB)
+PASS -- TEST 'control_stochy_gnu' [04:18, 02:20](733 MB)
+PASS -- TEST 'control_ras_gnu' [05:15, 03:47](728 MB)
+PASS -- TEST 'control_p8_gnu' [05:50, 03:38](1515 MB)
+PASS -- TEST 'control_p8_ugwpv1_gnu' [05:40, 03:32](1516 MB)
+PASS -- TEST 'control_flake_gnu' [06:45, 04:26](810 MB)
 
-PASS -- COMPILE 'rrfs_gnu' [05:06, 03:49]
-PASS -- TEST 'rap_control_gnu' [10:47, 07:44](1084 MB)
-PASS -- TEST 'rap_decomp_gnu' [10:32, 07:53](1085 MB)
-PASS -- TEST 'rap_2threads_gnu' [09:31, 07:16](1124 MB)
-PASS -- TEST 'rap_restart_gnu' [05:37, 03:55](885 MB)
-PASS -- TEST 'rap_sfcdiff_gnu' [09:47, 07:39](1086 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_gnu' [09:32, 07:54](1086 MB)
-PASS -- TEST 'rap_sfcdiff_restart_gnu' [07:38, 05:47](884 MB)
-PASS -- TEST 'hrrr_control_gnu' [06:29, 04:07](1072 MB)
-PASS -- TEST 'hrrr_control_noqr_gnu' [05:34, 04:01](1139 MB)
-PASS -- TEST 'hrrr_control_2threads_gnu' [05:32, 03:39](1038 MB)
-PASS -- TEST 'hrrr_control_decomp_gnu' [05:35, 04:04](1072 MB)
-PASS -- TEST 'hrrr_control_restart_gnu' [04:15, 02:07](881 MB)
-PASS -- TEST 'hrrr_control_restart_noqr_gnu' [03:14, 02:03](934 MB)
-PASS -- TEST 'rrfs_v1beta_gnu' [09:47, 07:37](1081 MB)
+PASS -- COMPILE 'rrfs_gnu' [06:05, 04:08]
+PASS -- TEST 'rap_control_gnu' [09:54, 07:49](1088 MB)
+PASS -- TEST 'rap_decomp_gnu' [09:40, 07:56](1083 MB)
+PASS -- TEST 'rap_2threads_gnu' [09:30, 07:28](1151 MB)
+PASS -- TEST 'rap_restart_gnu' [05:47, 03:58](885 MB)
+PASS -- TEST 'rap_sfcdiff_gnu' [10:09, 07:50](1088 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_gnu' [10:02, 07:51](1083 MB)
+PASS -- TEST 'rap_sfcdiff_restart_gnu' [07:55, 05:44](884 MB)
+PASS -- TEST 'hrrr_control_gnu' [05:47, 03:57](1071 MB)
+PASS -- TEST 'hrrr_control_noqr_gnu' [05:45, 04:00](1133 MB)
+PASS -- TEST 'hrrr_control_2threads_gnu' [05:45, 03:41](1030 MB)
+PASS -- TEST 'hrrr_control_decomp_gnu' [06:31, 04:06](1071 MB)
+PASS -- TEST 'hrrr_control_restart_gnu' [04:19, 02:05](879 MB)
+PASS -- TEST 'hrrr_control_restart_noqr_gnu' [03:22, 02:01](935 MB)
+PASS -- TEST 'rrfs_v1beta_gnu' [09:47, 07:35](1080 MB)
 
-PASS -- COMPILE 'atm_dyn32_debug_gnu' [07:06, 04:58]
-PASS -- TEST 'control_diag_debug_gnu' [03:22, 01:11](774 MB)
-PASS -- TEST 'regional_debug_gnu' [08:24, 06:27](921 MB)
-PASS -- TEST 'rap_control_debug_gnu' [03:14, 01:58](1097 MB)
-PASS -- TEST 'hrrr_control_debug_gnu' [03:12, 02:00](1088 MB)
-PASS -- TEST 'hrrr_gf_debug_gnu' [04:14, 02:03](1094 MB)
-PASS -- TEST 'hrrr_c3_debug_gnu' [03:14, 02:00](1093 MB)
-PASS -- TEST 'rap_diag_debug_gnu' [04:24, 02:03](1268 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_gnu' [05:15, 03:07](1094 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_gnu' [03:15, 01:58](1097 MB)
-PASS -- TEST 'rrfs_v1beta_debug_gnu' [03:15, 01:56](1092 MB)
-PASS -- TEST 'control_ras_debug_gnu' [03:12, 01:13](722 MB)
-PASS -- TEST 'control_stochy_debug_gnu' [03:13, 01:15](721 MB)
-PASS -- TEST 'control_debug_p8_gnu' [03:26, 01:16](1502 MB)
-PASS -- TEST 'rap_flake_debug_gnu' [03:16, 01:58](1096 MB)
-PASS -- TEST 'rap_clm_lake_debug_gnu' [04:17, 02:10](1097 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_gnu' [05:44, 03:17](1101 MB)
+PASS -- COMPILE 'atm_dyn32_debug_gnu' [06:05, 04:47]
+PASS -- TEST 'control_diag_debug_gnu' [03:33, 01:22](777 MB)
+PASS -- TEST 'regional_debug_gnu' [08:26, 06:21](923 MB)
+PASS -- TEST 'rap_control_debug_gnu' [03:18, 01:57](1098 MB)
+PASS -- TEST 'hrrr_control_debug_gnu' [03:41, 02:04](1088 MB)
+PASS -- TEST 'hrrr_gf_debug_gnu' [04:13, 02:04](1093 MB)
+PASS -- TEST 'hrrr_c3_debug_gnu' [03:13, 02:01](1094 MB)
+PASS -- TEST 'rap_diag_debug_gnu' [03:23, 02:02](1268 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_gnu' [04:29, 03:04](1097 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_gnu' [03:17, 02:00](1096 MB)
+PASS -- TEST 'rrfs_v1beta_debug_gnu' [03:17, 01:57](1091 MB)
+PASS -- TEST 'control_ras_debug_gnu' [03:14, 01:09](725 MB)
+PASS -- TEST 'control_stochy_debug_gnu' [03:17, 01:16](723 MB)
+PASS -- TEST 'control_debug_p8_gnu' [03:36, 01:26](1504 MB)
+PASS -- TEST 'rap_flake_debug_gnu' [03:18, 02:01](1101 MB)
+PASS -- TEST 'rap_clm_lake_debug_gnu' [04:16, 02:07](1099 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_gnu' [05:47, 03:19](1102 MB)
 
-PASS -- COMPILE 'wam_debug_gnu' [05:05, 02:17]
+PASS -- COMPILE 'wam_debug_gnu' [04:05, 02:34]
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_gnu' [06:05, 04:35]
-PASS -- TEST 'rap_control_dyn32_phy32_gnu' [09:32, 07:21](965 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_gnu' [05:49, 03:50](952 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_gnu' [08:45, 06:46](975 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_gnu' [05:31, 03:27](873 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_gnu' [05:32, 03:49](953 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_gnu' [07:39, 05:31](858 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_gnu' [06:22, 02:06](857 MB)
-PASS -- TEST 'conus13km_control_gnu' [04:38, 02:31](1266 MB)
-PASS -- TEST 'conus13km_2threads_gnu' [04:23, 01:12](1175 MB)
-PASS -- TEST 'conus13km_restart_mismatch_gnu' [05:24, 01:33](926 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_gnu' [06:07, 04:35]
+PASS -- TEST 'rap_control_dyn32_phy32_gnu' [09:44, 07:14](961 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_gnu' [05:51, 03:48](949 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_gnu' [08:51, 06:44](1008 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_gnu' [05:34, 03:33](891 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_gnu' [05:36, 03:54](950 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_gnu' [07:53, 05:29](858 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_gnu' [03:17, 01:59](856 MB)
+PASS -- TEST 'conus13km_control_gnu' [04:39, 02:27](1266 MB)
+PASS -- TEST 'conus13km_2threads_gnu' [03:33, 01:08](1171 MB)
+PASS -- TEST 'conus13km_restart_mismatch_gnu' [03:30, 01:26](946 MB)
 
-PASS -- COMPILE 'atm_dyn64_phy32_gnu' [10:05, 08:53]
-PASS -- TEST 'rap_control_dyn64_phy32_gnu' [06:31, 04:21](987 MB)
+PASS -- COMPILE 'atm_dyn64_phy32_gnu' [11:06, 09:16]
+PASS -- TEST 'rap_control_dyn64_phy32_gnu' [06:29, 04:18](992 MB)
 
-PASS -- COMPILE 'atm_dyn32_phy32_debug_gnu' [06:05, 04:26]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_gnu' [03:15, 02:01](976 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_gnu' [03:14, 01:56](968 MB)
-PASS -- TEST 'conus13km_debug_gnu' [07:27, 05:28](1281 MB)
-PASS -- TEST 'conus13km_debug_qr_gnu' [07:27, 05:37](970 MB)
-PASS -- TEST 'conus13km_debug_2threads_gnu' [05:26, 03:15](1192 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_gnu' [07:26, 05:20](1348 MB)
+PASS -- COMPILE 'atm_dyn32_phy32_debug_gnu' [07:05, 05:55]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_gnu' [03:15, 02:01](978 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_gnu' [03:13, 01:52](972 MB)
+PASS -- TEST 'conus13km_debug_gnu' [07:30, 05:28](1278 MB)
+PASS -- TEST 'conus13km_debug_qr_gnu' [07:29, 05:31](960 MB)
+PASS -- TEST 'conus13km_debug_2threads_gnu' [05:27, 03:16](1188 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_gnu' [07:27, 05:22](1348 MB)
 
-PASS -- COMPILE 'atm_dyn64_phy32_debug_gnu' [06:05, 04:43]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_gnu' [03:15, 01:59](1005 MB)
+PASS -- COMPILE 'atm_dyn64_phy32_debug_gnu' [08:06, 06:39]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_gnu' [03:18, 01:57](1010 MB)
 
-PASS -- COMPILE 's2swa_gnu' [16:06, 14:49]
+PASS -- COMPILE 's2swa_gnu' [20:06, 18:13]
 
-PASS -- COMPILE 's2s_gnu' [16:06, 14:39]
+PASS -- COMPILE 's2s_gnu' [18:06, 16:17]
 
-PASS -- COMPILE 's2swa_debug_gnu' [07:05, 05:54]
+PASS -- COMPILE 's2swa_debug_gnu' [08:06, 06:52]
 
-PASS -- COMPILE 's2sw_pdlib_gnu' [16:07, 15:02]
+PASS -- COMPILE 's2sw_pdlib_gnu' [17:06, 15:47]
 
-PASS -- COMPILE 's2sw_pdlib_debug_gnu' [05:05, 03:47]
+PASS -- COMPILE 's2sw_pdlib_debug_gnu' [08:06, 06:41]
 
-PASS -- COMPILE 'datm_cdeps_gnu' [16:06, 14:52]
+PASS -- COMPILE 'datm_cdeps_gnu' [18:06, 16:22]
 
 SYNOPSIS:
-Starting Date/Time: 20240314 07:27:36
-Ending Date/Time: 20240314 09:02:12
-Total Time: 01h:35m:02s
+Starting Date/Time: 20240317 15:38:17
+Ending Date/Time: 20240317 17:01:00
+Total Time: 01h:23m:19s
 Compiles Completed: 55/55
 Tests Completed: 238/238
 

--- a/tests/logs/RegressionTests_jet.log
+++ b/tests/logs/RegressionTests_jet.log
@@ -1,7 +1,7 @@
 ====START OF JET REGRESSION TESTING LOG====
 
 UFSWM hash used in testing:
-0d7aa189232097602b4a7b5cdab9caad9aba58ad
+0939a1dff2a2060b541eca9642a19c5ed1541f17
 
 Submodule hashes used in testing:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
@@ -11,10 +11,10 @@ Submodule hashes used in testing:
  f6ff8f7c4d4cb6feabe3651b13204cf43fc948e3 CICE-interface/CICE/icepack (Icepack1.1.0-182-gf6ff8f7)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  6663459e58a04e3bda2157d5891d227e3abc3c7a FV3/atmos_cubed_sphere (201912_public_release-386-g6663459)
- 221788f4e2539af797eb02efe42465b153533201 FV3/ccpp/framework (ccpp_transition_to_vlab_master_20190705-613-g221788f)
- bbdec2ffceeb0cda70aaaa4f44e619a5468e7be3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5134-gbbdec2ff)
+ 87e6d92e2ca48a55b66f8810f347b51c70c193c4 FV3/ccpp/framework (v0.1.0-1436-g87e6d92)
+ 2f15ae92802cae11fd0efb902439a084609984f3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5141-g2f15ae92)
  74a0e098b2163425e4b5466c2dfcf8ae26d560a5 FV3/ccpp/physics/physics/Radiation/RRTMGP/rte-rrtmgp (v1.6)
  945cb2cef5e8bd5949afd4f0fc35c4fb6e95a1bf FV3/upp (upp_v10.2.0-159-g945cb2c)
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e FV3/upp/sorc/libIFI.fd
@@ -32,7 +32,7 @@ Submodule hashes used in testing:
  7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
@@ -47,245 +47,245 @@ The first time is for the full script (prep+run+finalize).
 The second time is specifically for the run phase.
 Times/Memory will be empty for failed tests.
 
-BASELINE DIRECTORY: /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20240312
-COMPARISON DIRECTORY: /lfs4/HFIP/h-nems/Fernando.Andrade-maldonado/RT_RUNDIRS/Fernando.Andrade-maldonado/FV3_RT/rt_2771308
+BASELINE DIRECTORY: /mnt/lfs4/HFIP/hfv3gfs/role.epic/RT/NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /lfs4/HFIP/h-nems/Fernando.Andrade-maldonado/RT_RUNDIRS/Fernando.Andrade-maldonado/FV3_RT/rt_2893158
 
 RT.SH OPTIONS USED:
 * (-a) - HPC PROJECT ACCOUNT: h-nems
 * (-l) - USE CONFIG FILE: rt.conf
 * (-e) - USE ECFLOW
 
-PASS -- COMPILE 's2swa_32bit_intel' [39:25, 38:12]
-PASS -- TEST 'cpld_control_p8_mixedmode_intel' [09:43, 06:41](1789 MB)
+PASS -- COMPILE 's2swa_32bit_intel' [39:23, 37:48]
+PASS -- TEST 'cpld_control_p8_mixedmode_intel' [09:45, 06:51](1792 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_intel' [54:32, 53:08]
-PASS -- TEST 'cpld_control_gfsv17_intel' [24:07, 20:38](1669 MB)
-PASS -- TEST 'cpld_control_gfsv17_iau_intel' [25:20, 22:05](1874 MB)
-PASS -- TEST 'cpld_restart_gfsv17_intel' [14:06, 10:25](995 MB)
-PASS -- TEST 'cpld_mpi_gfsv17_intel' [26:40, 23:43](1628 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_intel' [54:29, 52:51]
+PASS -- TEST 'cpld_control_gfsv17_intel' [24:00, 20:30](1662 MB)
+PASS -- TEST 'cpld_control_gfsv17_iau_intel' [25:12, 22:01](1883 MB)
+PASS -- TEST 'cpld_restart_gfsv17_intel' [14:12, 10:13](998 MB)
+PASS -- TEST 'cpld_mpi_gfsv17_intel' [26:34, 23:37](1630 MB)
 
-PASS -- COMPILE 's2swa_intel' [40:25, 38:23]
-PASS -- TEST 'cpld_control_p8_intel' [10:23, 07:29](1825 MB)
-PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [10:42, 07:26](1830 MB)
-PASS -- TEST 'cpld_restart_p8_intel' [07:47, 04:17](1714 MB)
-PASS -- TEST 'cpld_control_qr_p8_intel' [10:23, 07:30](1852 MB)
-PASS -- TEST 'cpld_restart_qr_p8_intel' [07:47, 04:19](1733 MB)
-PASS -- TEST 'cpld_2threads_p8_intel' [10:16, 07:09](2265 MB)
-PASS -- TEST 'cpld_decomp_p8_intel' [10:17, 07:33](1830 MB)
-PASS -- TEST 'cpld_mpi_p8_intel' [09:40, 06:24](1784 MB)
-PASS -- TEST 'cpld_control_ciceC_p8_intel' [10:41, 07:28](1825 MB)
-PASS -- TEST 'cpld_s2sa_p8_intel' [10:31, 07:09](1797 MB)
+PASS -- COMPILE 's2swa_intel' [39:23, 38:15]
+PASS -- TEST 'cpld_control_p8_intel' [10:21, 07:28](1828 MB)
+PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [10:43, 07:36](1821 MB)
+PASS -- TEST 'cpld_restart_p8_intel' [07:47, 04:19](1711 MB)
+PASS -- TEST 'cpld_control_qr_p8_intel' [10:22, 07:34](1851 MB)
+PASS -- TEST 'cpld_restart_qr_p8_intel' [07:46, 04:21](1730 MB)
+PASS -- TEST 'cpld_2threads_p8_intel' [10:14, 07:09](2274 MB)
+PASS -- TEST 'cpld_decomp_p8_intel' [10:14, 07:42](1826 MB)
+PASS -- TEST 'cpld_mpi_p8_intel' [09:38, 06:24](1791 MB)
+PASS -- TEST 'cpld_control_ciceC_p8_intel' [10:40, 07:28](1833 MB)
+PASS -- TEST 'cpld_s2sa_p8_intel' [10:29, 07:09](1786 MB)
 
-PASS -- COMPILE 's2sw_intel' [37:24, 35:45]
-PASS -- TEST 'cpld_control_noaero_p8_intel' [08:29, 05:49](1666 MB)
-PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [08:37, 05:38](1715 MB)
+PASS -- COMPILE 's2sw_intel' [37:22, 35:55]
+PASS -- TEST 'cpld_control_noaero_p8_intel' [08:28, 05:43](1662 MB)
+PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [08:39, 05:43](1717 MB)
 
-PASS -- COMPILE 's2swa_debug_intel' [07:10, 05:11]
-PASS -- TEST 'cpld_debug_p8_intel' [13:54, 10:27](1844 MB)
+PASS -- COMPILE 's2swa_debug_intel' [07:09, 05:06]
+PASS -- TEST 'cpld_debug_p8_intel' [14:03, 10:25](1842 MB)
 
-PASS -- COMPILE 's2sw_debug_intel' [06:09, 04:41]
-PASS -- TEST 'cpld_debug_noaero_p8_intel' [10:26, 07:10](1680 MB)
+PASS -- COMPILE 's2sw_debug_intel' [06:08, 04:40]
+PASS -- TEST 'cpld_debug_noaero_p8_intel' [10:21, 07:10](1681 MB)
 
-PASS -- COMPILE 's2s_aoflux_intel' [33:21, 32:02]
-PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [08:54, 05:34](1721 MB)
+PASS -- COMPILE 's2s_aoflux_intel' [33:18, 31:51]
+PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [08:49, 05:39](1709 MB)
 
-PASS -- COMPILE 's2s_intel' [33:21, 31:57]
-PASS -- TEST 'cpld_control_c48_intel' [15:11, 12:39](2795 MB)
+PASS -- COMPILE 's2s_intel' [33:18, 32:02]
+PASS -- TEST 'cpld_control_c48_intel' [15:09, 12:41](2798 MB)
 
-PASS -- COMPILE 's2swa_faster_intel' [34:52, 32:51]
-PASS -- TEST 'cpld_control_p8_faster_intel' [10:08, 07:02](1832 MB)
+PASS -- COMPILE 's2swa_faster_intel' [34:43, 32:58]
+PASS -- TEST 'cpld_control_p8_faster_intel' [09:56, 07:02](1829 MB)
 
-PASS -- COMPILE 's2sw_pdlib_intel' [47:30, 45:45]
-PASS -- TEST 'cpld_control_pdlib_p8_intel' [23:46, 20:43](1687 MB)
-PASS -- TEST 'cpld_restart_pdlib_p8_intel' [13:48, 10:17](1035 MB)
-PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [26:48, 23:52](1656 MB)
+PASS -- COMPILE 's2sw_pdlib_intel' [49:24, 48:06]
+PASS -- TEST 'cpld_control_pdlib_p8_intel' [23:49, 20:40](1682 MB)
+PASS -- TEST 'cpld_restart_pdlib_p8_intel' [13:49, 10:19](1033 MB)
+PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [26:37, 23:50](1654 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_intel' [06:07, 04:41]
-PASS -- TEST 'cpld_debug_pdlib_p8_intel' [34:50, 32:03](1691 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_intel' [06:08, 04:41]
+PASS -- TEST 'cpld_debug_pdlib_p8_intel' [34:41, 31:59](1690 MB)
 
-PASS -- COMPILE 'atm_dyn32_intel' [36:21, 34:21]
-PASS -- TEST 'control_flake_intel' [06:29, 04:30](644 MB)
-PASS -- TEST 'control_CubedSphereGrid_intel' [05:29, 03:15](596 MB)
-PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [05:37, 03:47](600 MB)
-PASS -- TEST 'control_latlon_intel' [05:25, 03:18](600 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [05:35, 03:28](595 MB)
-PASS -- TEST 'control_c48_intel' [11:35, 10:04](840 MB)
-PASS -- TEST 'control_c48.v2.sfc_intel' [11:35, 10:04](842 MB)
-PASS -- TEST 'control_c192_intel' [14:46, 12:19](726 MB)
-PASS -- TEST 'control_c384_intel' [18:40, 15:44](897 MB)
-PASS -- TEST 'control_c384gdas_intel' [18:24, 13:23](1016 MB)
-PASS -- TEST 'control_stochy_intel' [04:29, 02:11](606 MB)
-PASS -- TEST 'control_stochy_restart_intel' [03:27, 01:17](434 MB)
-PASS -- TEST 'control_lndp_intel' [04:28, 02:08](602 MB)
-PASS -- TEST 'control_iovr4_intel' [05:31, 03:18](593 MB)
-PASS -- TEST 'control_iovr5_intel' [05:31, 03:19](593 MB)
-PASS -- TEST 'control_p8_intel' [06:43, 03:57](1570 MB)
-PASS -- TEST 'control_p8.v2.sfc_intel' [06:46, 03:52](1577 MB)
-PASS -- TEST 'control_p8_ugwpv1_intel' [06:41, 03:51](1583 MB)
-PASS -- TEST 'control_restart_p8_intel' [04:59, 02:07](816 MB)
-PASS -- TEST 'control_noqr_p8_intel' [06:13, 03:48](1572 MB)
-PASS -- TEST 'control_restart_noqr_p8_intel' [04:21, 02:03](847 MB)
-PASS -- TEST 'control_decomp_p8_intel' [06:11, 04:00](1569 MB)
-PASS -- TEST 'control_2threads_p8_intel' [06:09, 03:38](1653 MB)
-PASS -- TEST 'control_p8_lndp_intel' [08:50, 06:55](1575 MB)
-PASS -- TEST 'control_p8_rrtmgp_intel' [08:32, 05:07](1643 MB)
-PASS -- TEST 'control_p8_mynn_intel' [06:26, 03:57](1579 MB)
-PASS -- TEST 'merra2_thompson_intel' [07:48, 04:30](1581 MB)
-PASS -- TEST 'regional_control_intel' [08:41, 06:58](770 MB)
-PASS -- TEST 'regional_restart_intel' [05:47, 03:42](937 MB)
-PASS -- TEST 'regional_decomp_intel' [09:41, 07:24](768 MB)
-PASS -- TEST 'regional_2threads_intel' [06:40, 04:18](751 MB)
-PASS -- TEST 'regional_netcdf_parallel_intel' [08:43, 06:53](763 MB)
-PASS -- TEST 'regional_2dwrtdecomp_intel' [08:38, 07:01](762 MB)
+PASS -- COMPILE 'atm_dyn32_intel' [36:20, 34:33]
+PASS -- TEST 'control_flake_intel' [06:27, 04:30](646 MB)
+PASS -- TEST 'control_CubedSphereGrid_intel' [05:28, 03:18](599 MB)
+PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [05:34, 03:44](605 MB)
+PASS -- TEST 'control_latlon_intel' [05:25, 03:21](604 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [05:34, 03:29](600 MB)
+PASS -- TEST 'control_c48_intel' [11:34, 10:06](843 MB)
+PASS -- TEST 'control_c48.v2.sfc_intel' [12:37, 10:08](849 MB)
+PASS -- TEST 'control_c192_intel' [14:46, 12:28](730 MB)
+PASS -- TEST 'control_c384_intel' [18:39, 15:43](895 MB)
+PASS -- TEST 'control_c384gdas_intel' [18:17, 13:23](1017 MB)
+PASS -- TEST 'control_stochy_intel' [04:27, 02:17](602 MB)
+PASS -- TEST 'control_stochy_restart_intel' [03:25, 01:17](435 MB)
+PASS -- TEST 'control_lndp_intel' [04:27, 02:12](600 MB)
+PASS -- TEST 'control_iovr4_intel' [05:28, 03:23](600 MB)
+PASS -- TEST 'control_iovr5_intel' [05:30, 03:25](596 MB)
+PASS -- TEST 'control_p8_intel' [06:31, 04:02](1582 MB)
+PASS -- TEST 'control_p8.v2.sfc_intel' [06:45, 03:53](1575 MB)
+PASS -- TEST 'control_p8_ugwpv1_intel' [06:37, 03:45](1578 MB)
+PASS -- TEST 'control_restart_p8_intel' [05:03, 02:09](818 MB)
+PASS -- TEST 'control_noqr_p8_intel' [06:13, 03:48](1571 MB)
+PASS -- TEST 'control_restart_noqr_p8_intel' [05:13, 02:05](844 MB)
+PASS -- TEST 'control_decomp_p8_intel' [06:07, 04:00](1565 MB)
+PASS -- TEST 'control_2threads_p8_intel' [06:07, 03:40](1669 MB)
+PASS -- TEST 'control_p8_lndp_intel' [08:49, 06:57](1570 MB)
+PASS -- TEST 'control_p8_rrtmgp_intel' [08:35, 05:05](1631 MB)
+PASS -- TEST 'control_p8_mynn_intel' [06:23, 04:00](1575 MB)
+PASS -- TEST 'merra2_thompson_intel' [07:47, 04:32](1586 MB)
+PASS -- TEST 'regional_control_intel' [09:43, 07:04](767 MB)
+PASS -- TEST 'regional_restart_intel' [05:49, 03:41](936 MB)
+PASS -- TEST 'regional_decomp_intel' [09:41, 07:21](762 MB)
+PASS -- TEST 'regional_2threads_intel' [06:40, 04:14](757 MB)
+PASS -- TEST 'regional_netcdf_parallel_intel' [08:44, 06:57](761 MB)
+PASS -- TEST 'regional_2dwrtdecomp_intel' [08:40, 06:56](766 MB)
 
-PASS -- COMPILE 'rrfs_intel' [34:24, 32:34]
-PASS -- TEST 'rap_control_intel' [12:10, 10:07](990 MB)
-PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [08:23, 05:39](1215 MB)
-PASS -- TEST 'rap_decomp_intel' [13:16, 10:38](981 MB)
-PASS -- TEST 'rap_2threads_intel' [12:10, 09:30](1096 MB)
-PASS -- TEST 'rap_restart_intel' [08:29, 05:14](992 MB)
-PASS -- TEST 'rap_sfcdiff_intel' [12:35, 10:04](985 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_intel' [13:11, 10:38](983 MB)
-PASS -- TEST 'rap_sfcdiff_restart_intel' [10:31, 07:30](993 MB)
-PASS -- TEST 'hrrr_control_intel' [08:02, 05:14](992 MB)
-PASS -- TEST 'hrrr_control_decomp_intel' [08:03, 05:28](984 MB)
-PASS -- TEST 'hrrr_control_2threads_intel' [07:34, 04:47](1064 MB)
-PASS -- TEST 'hrrr_control_restart_intel' [04:30, 02:48](923 MB)
-PASS -- TEST 'rrfs_v1beta_intel' [12:35, 09:57](991 MB)
-PASS -- TEST 'rrfs_v1nssl_intel' [13:36, 12:07](1940 MB)
-PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [13:36, 11:57](1941 MB)
+PASS -- COMPILE 'rrfs_intel' [34:18, 32:17]
+PASS -- TEST 'rap_control_intel' [12:10, 10:05](993 MB)
+PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [08:19, 05:32](1217 MB)
+PASS -- TEST 'rap_decomp_intel' [13:10, 10:39](980 MB)
+PASS -- TEST 'rap_2threads_intel' [12:10, 09:35](1079 MB)
+PASS -- TEST 'rap_restart_intel' [08:26, 05:14](987 MB)
+PASS -- TEST 'rap_sfcdiff_intel' [12:36, 10:04](999 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_intel' [13:09, 10:44](980 MB)
+PASS -- TEST 'rap_sfcdiff_restart_intel' [10:19, 07:29](1002 MB)
+PASS -- TEST 'hrrr_control_intel' [08:02, 05:08](990 MB)
+PASS -- TEST 'hrrr_control_decomp_intel' [08:01, 05:16](978 MB)
+PASS -- TEST 'hrrr_control_2threads_intel' [07:33, 04:43](1060 MB)
+PASS -- TEST 'hrrr_control_restart_intel' [04:29, 02:46](920 MB)
+PASS -- TEST 'rrfs_v1beta_intel' [12:34, 09:52](983 MB)
+PASS -- TEST 'rrfs_v1nssl_intel' [14:35, 12:22](1944 MB)
+PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [14:35, 12:11](1938 MB)
 
-PASS -- COMPILE 'csawmg_intel' [32:17, 30:54]
-PASS -- TEST 'control_csawmg_intel' [09:44, 07:57](698 MB)
-PASS -- TEST 'control_csawmgt_intel' [09:42, 07:51](696 MB)
-PASS -- TEST 'control_ras_intel' [06:24, 04:22](669 MB)
+PASS -- COMPILE 'csawmg_intel' [32:20, 30:47]
+PASS -- TEST 'control_csawmg_intel' [09:42, 08:01](692 MB)
+PASS -- TEST 'control_csawmgt_intel' [09:42, 07:52](695 MB)
+PASS -- TEST 'control_ras_intel' [06:21, 04:23](664 MB)
 
-PASS -- COMPILE 'wam_intel' [31:18, 29:34]
-PASS -- TEST 'control_wam_intel' [04:21, 02:45](496 MB)
+PASS -- COMPILE 'wam_intel' [31:20, 29:34]
+PASS -- TEST 'control_wam_intel' [04:22, 02:45](501 MB)
 
-PASS -- COMPILE 'atm_faster_dyn32_intel' [33:19, 31:20]
-PASS -- TEST 'control_p8_faster_intel' [06:51, 03:35](1574 MB)
-PASS -- TEST 'regional_control_faster_intel' [08:51, 06:31](763 MB)
+PASS -- COMPILE 'atm_faster_dyn32_intel' [33:19, 31:18]
+PASS -- TEST 'control_p8_faster_intel' [06:44, 03:36](1581 MB)
+PASS -- TEST 'regional_control_faster_intel' [08:49, 06:27](764 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_intel' [07:09, 05:23]
-PASS -- TEST 'control_CubedSphereGrid_debug_intel' [05:22, 03:18](765 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [05:27, 03:25](760 MB)
-PASS -- TEST 'control_stochy_debug_intel' [05:20, 03:41](764 MB)
-PASS -- TEST 'control_lndp_debug_intel' [05:20, 03:19](768 MB)
-PASS -- TEST 'control_csawmg_debug_intel' [07:44, 05:13](808 MB)
-PASS -- TEST 'control_csawmgt_debug_intel' [07:41, 05:14](806 MB)
-PASS -- TEST 'control_ras_debug_intel' [05:22, 03:22](773 MB)
-PASS -- TEST 'control_diag_debug_intel' [05:31, 03:25](816 MB)
-PASS -- TEST 'control_debug_p8_intel' [05:53, 03:31](1597 MB)
-PASS -- TEST 'regional_debug_intel' [23:53, 21:36](778 MB)
-PASS -- TEST 'rap_control_debug_intel' [07:26, 05:58](1154 MB)
-PASS -- TEST 'hrrr_control_debug_intel' [07:25, 05:53](1145 MB)
-PASS -- TEST 'hrrr_gf_debug_intel' [07:25, 05:58](1153 MB)
-PASS -- TEST 'hrrr_c3_debug_intel' [07:26, 06:00](1152 MB)
-PASS -- TEST 'rap_unified_drag_suite_debug_intel' [07:26, 06:00](1151 MB)
-PASS -- TEST 'rap_diag_debug_intel' [08:41, 06:17](1232 MB)
-PASS -- TEST 'rap_cires_ugwp_debug_intel' [08:25, 06:07](1154 MB)
-PASS -- TEST 'rap_unified_ugwp_debug_intel' [08:26, 06:07](1151 MB)
-PASS -- TEST 'rap_lndp_debug_intel' [07:31, 06:02](1153 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_intel' [07:27, 06:05](1157 MB)
-PASS -- TEST 'rap_noah_debug_intel' [07:26, 05:52](1148 MB)
-PASS -- TEST 'rap_sfcdiff_debug_intel' [07:28, 06:00](1146 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [11:30, 09:49](1149 MB)
-PASS -- TEST 'rrfs_v1beta_debug_intel' [07:28, 05:56](1145 MB)
-PASS -- TEST 'rap_clm_lake_debug_intel' [09:31, 07:13](1155 MB)
-PASS -- TEST 'rap_flake_debug_intel' [07:28, 06:00](1144 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [13:36, 10:25](1157 MB)
+PASS -- COMPILE 'atm_debug_dyn32_intel' [07:08, 05:22]
+PASS -- TEST 'control_CubedSphereGrid_debug_intel' [05:23, 03:18](756 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [05:26, 03:19](756 MB)
+PASS -- TEST 'control_stochy_debug_intel' [05:19, 03:42](769 MB)
+PASS -- TEST 'control_lndp_debug_intel' [05:20, 03:19](764 MB)
+PASS -- TEST 'control_csawmg_debug_intel' [07:37, 05:14](808 MB)
+PASS -- TEST 'control_csawmgt_debug_intel' [07:42, 05:09](809 MB)
+PASS -- TEST 'control_ras_debug_intel' [05:22, 03:23](771 MB)
+PASS -- TEST 'control_diag_debug_intel' [05:34, 03:26](815 MB)
+PASS -- TEST 'control_debug_p8_intel' [05:50, 03:32](1587 MB)
+PASS -- TEST 'regional_debug_intel' [23:52, 21:35](775 MB)
+PASS -- TEST 'rap_control_debug_intel' [07:24, 06:02](1152 MB)
+PASS -- TEST 'hrrr_control_debug_intel' [07:24, 05:53](1151 MB)
+PASS -- TEST 'hrrr_gf_debug_intel' [07:23, 05:57](1155 MB)
+PASS -- TEST 'hrrr_c3_debug_intel' [07:24, 06:01](1148 MB)
+PASS -- TEST 'rap_unified_drag_suite_debug_intel' [07:25, 06:01](1156 MB)
+PASS -- TEST 'rap_diag_debug_intel' [08:41, 06:20](1238 MB)
+PASS -- TEST 'rap_cires_ugwp_debug_intel' [08:28, 06:06](1154 MB)
+PASS -- TEST 'rap_unified_ugwp_debug_intel' [08:22, 06:06](1154 MB)
+PASS -- TEST 'rap_lndp_debug_intel' [07:25, 06:01](1143 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_intel' [07:25, 05:59](1159 MB)
+PASS -- TEST 'rap_noah_debug_intel' [07:26, 05:52](1144 MB)
+PASS -- TEST 'rap_sfcdiff_debug_intel' [07:26, 06:03](1151 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [11:28, 09:48](1148 MB)
+PASS -- TEST 'rrfs_v1beta_debug_intel' [07:27, 05:55](1144 MB)
+PASS -- TEST 'rap_clm_lake_debug_intel' [09:32, 07:18](1145 MB)
+PASS -- TEST 'rap_flake_debug_intel' [07:29, 05:59](1152 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [13:31, 10:21](1159 MB)
 
-PASS -- COMPILE 'wam_debug_intel' [05:07, 04:00]
-PASS -- TEST 'control_wam_debug_intel' [08:26, 06:08](439 MB)
+PASS -- COMPILE 'wam_debug_intel' [05:07, 03:40]
+PASS -- TEST 'control_wam_debug_intel' [08:25, 06:07](441 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [31:17, 29:53]
-PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [08:16, 05:07](1074 MB)
-PASS -- TEST 'rap_control_dyn32_phy32_intel' [11:03, 08:12](896 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [07:11, 04:22](862 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [10:30, 07:50](945 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [07:11, 04:05](910 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [07:11, 04:33](857 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_intel' [09:32, 06:21](902 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [04:29, 02:20](848 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [31:20, 29:36]
+PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [08:13, 05:09](1079 MB)
+PASS -- TEST 'rap_control_dyn32_phy32_intel' [11:02, 08:14](912 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [07:03, 04:21](871 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [10:22, 07:48](945 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [06:41, 03:59](906 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [07:01, 04:37](859 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_intel' [09:22, 06:14](899 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [04:28, 02:22](846 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [43:22, 42:04]
-PASS -- TEST 'conus13km_control_intel' [05:07, 02:56](1106 MB)
-PASS -- TEST 'conus13km_2threads_intel' [03:47, 01:20](1054 MB)
-PASS -- TEST 'conus13km_restart_mismatch_intel' [03:44, 01:34](1028 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [43:23, 42:17]
+PASS -- TEST 'conus13km_control_intel' [05:04, 02:53](1105 MB)
+PASS -- TEST 'conus13km_2threads_intel' [03:44, 01:20](1048 MB)
+PASS -- TEST 'conus13km_restart_mismatch_intel' [03:42, 01:35](1027 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [31:22, 30:09]
-PASS -- TEST 'rap_control_dyn64_phy32_intel' [07:59, 05:27](909 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [31:19, 30:14]
+PASS -- TEST 'rap_control_dyn64_phy32_intel' [07:57, 05:26](903 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [05:07, 03:51]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [07:27, 05:56](1029 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [07:27, 05:51](1032 MB)
-PASS -- TEST 'conus13km_debug_intel' [21:05, 18:18](1144 MB)
-PASS -- TEST 'conus13km_debug_qr_intel' [21:05, 18:28](845 MB)
-PASS -- TEST 'conus13km_debug_2threads_intel' [12:55, 10:39](1083 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_intel' [21:01, 18:16](1206 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [05:07, 03:44]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [07:28, 05:56](1025 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [07:23, 05:53](1027 MB)
+PASS -- TEST 'conus13km_debug_intel' [21:06, 18:30](1134 MB)
+PASS -- TEST 'conus13km_debug_qr_intel' [21:06, 18:39](858 MB)
+PASS -- TEST 'conus13km_debug_2threads_intel' [12:57, 10:40](1086 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_intel' [21:01, 18:26](1207 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [05:09, 03:40]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [07:30, 06:01](1074 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [05:08, 03:44]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [07:33, 06:02](1070 MB)
 
-PASS -- COMPILE 'hafsw_intel' [36:21, 34:41]
-PASS -- TEST 'hafs_regional_atm_intel' [09:19, 07:02](715 MB)
-PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [08:31, 06:20](1084 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_intel' [12:42, 09:10](769 MB)
-PASS -- TEST 'hafs_regional_atm_wav_intel' [19:29, 16:17](797 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [20:51, 18:05](825 MB)
-PASS -- TEST 'gnv1_nested_intel' [08:16, 05:40](774 MB)
+PASS -- COMPILE 'hafsw_intel' [35:18, 34:11]
+PASS -- TEST 'hafs_regional_atm_intel' [09:16, 07:01](712 MB)
+PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [08:30, 06:23](1085 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_intel' [12:39, 09:15](771 MB)
+PASS -- TEST 'hafs_regional_atm_wav_intel' [19:25, 16:23](795 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [21:45, 18:12](830 MB)
+PASS -- TEST 'gnv1_nested_intel' [08:24, 05:41](780 MB)
 
-PASS -- COMPILE 'hafs_all_intel' [33:19, 31:41]
-PASS -- TEST 'hafs_regional_docn_intel' [11:31, 08:34](769 MB)
-PASS -- TEST 'hafs_regional_docn_oisst_intel' [11:29, 08:39](751 MB)
+PASS -- COMPILE 'hafs_all_intel' [33:21, 31:24]
+PASS -- TEST 'hafs_regional_docn_intel' [11:29, 08:35](774 MB)
+PASS -- TEST 'hafs_regional_docn_oisst_intel' [11:31, 08:34](750 MB)
 
-PASS -- COMPILE 'datm_cdeps_intel' [09:09, 07:49]
-PASS -- TEST 'datm_cdeps_control_cfsr_intel' [05:20, 03:35](1059 MB)
-PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [04:20, 02:13](1023 MB)
-PASS -- TEST 'datm_cdeps_control_gefs_intel' [05:20, 03:31](924 MB)
-PASS -- TEST 'datm_cdeps_iau_gefs_intel' [05:20, 03:35](923 MB)
-PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [05:20, 03:34](917 MB)
-PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [05:20, 03:35](1056 MB)
-PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [05:20, 03:39](1059 MB)
-PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [05:20, 03:29](938 MB)
-PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [10:19, 07:52](886 MB)
-PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [10:17, 07:50](844 MB)
-PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [05:16, 03:35](1061 MB)
-PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [07:22, 05:08](2403 MB)
-PASS -- TEST 'datm_cdeps_gfs_intel' [06:20, 05:06](2401 MB)
+PASS -- COMPILE 'datm_cdeps_intel' [09:09, 07:43]
+PASS -- TEST 'datm_cdeps_control_cfsr_intel' [05:21, 03:36](1060 MB)
+PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [04:21, 02:09](1018 MB)
+PASS -- TEST 'datm_cdeps_control_gefs_intel' [05:20, 03:30](930 MB)
+PASS -- TEST 'datm_cdeps_iau_gefs_intel' [05:20, 03:34](927 MB)
+PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [05:21, 03:36](924 MB)
+PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [05:21, 03:36](1047 MB)
+PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [05:20, 03:38](1060 MB)
+PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [05:21, 03:31](919 MB)
+PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [10:11, 07:51](894 MB)
+PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [10:12, 07:36](840 MB)
+PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [05:17, 03:37](1065 MB)
+PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [06:21, 05:00](2399 MB)
+PASS -- TEST 'datm_cdeps_gfs_intel' [06:21, 05:01](2402 MB)
 
-PASS -- COMPILE 'datm_cdeps_debug_intel' [05:09, 03:21]
-PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [09:20, 07:57](1014 MB)
+PASS -- COMPILE 'datm_cdeps_debug_intel' [05:07, 03:15]
+PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [09:21, 08:00](1028 MB)
 
-PASS -- COMPILE 'datm_cdeps_faster_intel' [09:10, 07:57]
-PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [05:21, 03:36](1061 MB)
+PASS -- COMPILE 'datm_cdeps_faster_intel' [09:10, 07:48]
+PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [05:20, 03:37](1047 MB)
 
-PASS -- COMPILE 'datm_cdeps_land_intel' [03:06, 01:50]
-PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [03:31, 01:33](228 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_intel' [03:24, 01:17](249 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [02:28, 00:46](249 MB)
+PASS -- COMPILE 'datm_cdeps_land_intel' [03:06, 01:38]
+PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [03:32, 01:31](227 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_intel' [03:26, 01:17](250 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [02:28, 00:48](252 MB)
 
-PASS -- COMPILE 'atml_intel' [35:19, 33:55]
-PASS -- TEST 'control_p8_atmlnd_sbs_intel' [12:41, 08:35](1608 MB)
-PASS -- TEST 'control_p8_atmlnd_intel' [13:53, 09:09](1600 MB)
-PASS -- TEST 'control_restart_p8_atmlnd_intel' [09:08, 05:48](868 MB)
+PASS -- COMPILE 'atml_intel' [35:20, 33:36]
+PASS -- TEST 'control_p8_atmlnd_sbs_intel' [10:42, 07:54](1596 MB)
+PASS -- TEST 'control_p8_atmlnd_intel' [10:38, 07:45](1602 MB)
+PASS -- TEST 'control_restart_p8_atmlnd_intel' [05:51, 03:56](874 MB)
 
-PASS -- COMPILE 'atmw_intel' [33:20, 32:10]
-PASS -- TEST 'atmwav_control_noaero_p8_intel' [05:41, 02:15](1601 MB)
+PASS -- COMPILE 'atmw_intel' [34:18, 32:26]
+PASS -- TEST 'atmwav_control_noaero_p8_intel' [05:41, 02:14](1606 MB)
 
-PASS -- COMPILE 'atmwm_intel' [33:18, 31:26]
-PASS -- TEST 'control_atmwav_intel' [05:23, 02:10](612 MB)
+PASS -- COMPILE 'atmwm_intel' [33:19, 31:37]
+PASS -- TEST 'control_atmwav_intel' [05:10, 02:12](613 MB)
 
-PASS -- COMPILE 'atmaero_intel' [33:25, 32:08]
-PASS -- TEST 'atmaero_control_p8_intel' [10:04, 06:30](1694 MB)
-PASS -- TEST 'atmaero_control_p8_rad_intel' [11:06, 07:10](1717 MB)
-PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [10:48, 07:45](1747 MB)
+PASS -- COMPILE 'atmaero_intel' [32:18, 30:18]
+PASS -- TEST 'atmaero_control_p8_intel' [08:34, 05:07](1698 MB)
+PASS -- TEST 'atmaero_control_p8_rad_intel' [09:27, 06:14](1722 MB)
+PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [09:12, 06:38](1743 MB)
 
 SYNOPSIS:
-Starting Date/Time: 20240313 18:37:03
-Ending Date/Time: 20240313 22:09:37
-Total Time: 03h:33m:10s
+Starting Date/Time: 20240315 18:58:13
+Ending Date/Time: 20240315 22:27:49
+Total Time: 03h:30m:13s
 Compiles Completed: 33/33
 Tests Completed: 161/161
 

--- a/tests/logs/RegressionTests_orion.log
+++ b/tests/logs/RegressionTests_orion.log
@@ -1,7 +1,7 @@
 ====START OF ORION REGRESSION TESTING LOG====
 
 UFSWM hash used in testing:
-0d7aa189232097602b4a7b5cdab9caad9aba58ad
+0939a1dff2a2060b541eca9642a19c5ed1541f17
 
 Submodule hashes used in testing:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
@@ -11,10 +11,10 @@ Submodule hashes used in testing:
  f6ff8f7c4d4cb6feabe3651b13204cf43fc948e3 CICE-interface/CICE/icepack (Icepack1.1.0-182-gf6ff8f7)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  6663459e58a04e3bda2157d5891d227e3abc3c7a FV3/atmos_cubed_sphere (201912_public_release-386-g6663459)
- 221788f4e2539af797eb02efe42465b153533201 FV3/ccpp/framework (ccpp_transition_to_vlab_master_20190705-613-g221788f)
- bbdec2ffceeb0cda70aaaa4f44e619a5468e7be3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5134-gbbdec2ff)
+ 87e6d92e2ca48a55b66f8810f347b51c70c193c4 FV3/ccpp/framework (v0.1.0-1436-g87e6d92)
+ 2f15ae92802cae11fd0efb902439a084609984f3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5141-g2f15ae92)
  74a0e098b2163425e4b5466c2dfcf8ae26d560a5 FV3/ccpp/physics/physics/Radiation/RRTMGP/rte-rrtmgp (v1.6)
  945cb2cef5e8bd5949afd4f0fc35c4fb6e95a1bf FV3/upp (upp_v10.2.0-159-g945cb2c)
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e FV3/upp/sorc/libIFI.fd
@@ -32,7 +32,7 @@ Submodule hashes used in testing:
  7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
@@ -47,280 +47,358 @@ The first time is for the full script (prep+run+finalize).
 The second time is specifically for the run phase.
 Times/Memory will be empty for failed tests.
 
-BASELINE DIRECTORY: /work/noaa/epic/UFS-WM_RT/NEMSfv3gfs/develop-20240312
-COMPARISON DIRECTORY: /work/noaa/stmp/zshrader/stmp/zshrader/FV3_RT/rt_318497
+BASELINE DIRECTORY: /work/noaa/epic/UFS-WM_RT/NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /work/noaa/stmp/zshrader/stmp/zshrader/FV3_RT/rt_400865
 
 RT.SH OPTIONS USED:
 * (-a) - HPC PROJECT ACCOUNT: nems
 * (-l) - USE CONFIG FILE: rt.conf
 * (-e) - USE ECFLOW
 
-PASS -- COMPILE 's2swa_32bit_intel' [16:07, 14:21]
-PASS -- TEST 'cpld_control_p8_mixedmode_intel' [08:43, 05:11](3187 MB)
+PASS -- COMPILE 's2swa_32bit_intel' [16:10, 14:57]
+PASS -- TEST 'cpld_control_p8_mixedmode_intel' [13:50, 05:08](3183 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_intel' [25:07, 23:32]
-PASS -- TEST 'cpld_control_gfsv17_intel' [19:47, 16:54](1737 MB)
-PASS -- TEST 'cpld_control_gfsv17_iau_intel' [20:55, 17:26](2024 MB)
-PASS -- TEST 'cpld_restart_gfsv17_intel' [12:01, 08:09](1113 MB)
-PASS -- TEST 'cpld_mpi_gfsv17_intel' [21:51, 18:32](1639 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_intel' [21:10, 19:36]
+PASS -- TEST 'cpld_control_gfsv17_intel' [23:55, 16:21](1740 MB)
+PASS -- TEST 'cpld_control_gfsv17_iau_intel' [22:04, 18:04](2024 MB)
+PASS -- TEST 'cpld_restart_gfsv17_intel' [12:05, 08:13](1111 MB)
+PASS -- TEST 'cpld_mpi_gfsv17_intel' [24:55, 18:30](1644 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [07:06, 05:17]
-PASS -- TEST 'cpld_debug_gfsv17_intel' [25:47, 22:58](1691 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [07:07, 05:43]
+PASS -- TEST 'cpld_debug_gfsv17_intel' [26:53, 23:32](1697 MB)
 
-PASS -- COMPILE 's2swa_intel' [16:07, 14:43]
-PASS -- TEST 'cpld_control_p8_intel' [08:33, 05:41](3213 MB)
-PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [08:40, 05:40](3213 MB)
-PASS -- TEST 'cpld_restart_p8_intel' [06:54, 03:18](3258 MB)
-PASS -- TEST 'cpld_control_qr_p8_intel' [08:33, 05:44](3233 MB)
-PASS -- TEST 'cpld_restart_qr_p8_intel' [06:54, 03:21](3274 MB)
-PASS -- TEST 'cpld_2threads_p8_intel' [09:45, 06:13](3559 MB)
-PASS -- TEST 'cpld_decomp_p8_intel' [08:32, 05:39](3199 MB)
-PASS -- TEST 'cpld_mpi_p8_intel' [07:34, 04:47](3076 MB)
-PASS -- TEST 'cpld_control_ciceC_p8_intel' [08:44, 05:46](3214 MB)
-PASS -- TEST 'cpld_control_c192_p8_intel' [14:32, 10:08](3337 MB)
-PASS -- TEST 'cpld_restart_c192_p8_intel' [11:03, 06:47](3621 MB)
-PASS -- TEST 'cpld_bmark_p8_intel' [19:37, 11:16](4084 MB)
-PASS -- TEST 'cpld_restart_bmark_p8_intel' [16:03, 06:56](4368 MB)
-PASS -- TEST 'cpld_s2sa_p8_intel' [08:36, 05:28](3172 MB)
+PASS -- COMPILE 's2swa_intel' [16:10, 14:38]
+PASS -- TEST 'cpld_control_p8_intel' [14:50, 05:33](3211 MB)
+PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [15:04, 05:51](3210 MB)
+PASS -- TEST 'cpld_restart_p8_intel' [07:00, 03:23](3252 MB)
+PASS -- TEST 'cpld_control_qr_p8_intel' [16:04, 05:46](3241 MB)
+PASS -- TEST 'cpld_restart_qr_p8_intel' [07:56, 03:24](3276 MB)
+PASS -- TEST 'cpld_2threads_p8_intel' [12:50, 06:12](3555 MB)
+PASS -- TEST 'cpld_decomp_p8_intel' [14:50, 05:46](3196 MB)
+PASS -- TEST 'cpld_mpi_p8_intel' [09:48, 04:43](3071 MB)
+PASS -- TEST 'cpld_control_ciceC_p8_intel' [13:49, 05:39](3210 MB)
+PASS -- TEST 'cpld_control_c192_p8_intel' [16:07, 09:55](3346 MB)
+PASS -- TEST 'cpld_restart_c192_p8_intel' [11:10, 06:08](3617 MB)
+PASS -- TEST 'cpld_bmark_p8_intel' [21:57, 10:59](4129 MB)
+PASS -- TEST 'cpld_restart_bmark_p8_intel' [17:46, 06:58](4359 MB)
+PASS -- TEST 'cpld_s2sa_p8_intel' [14:51, 05:28](3169 MB)
 
-PASS -- COMPILE 's2sw_intel' [15:06, 13:06]
-PASS -- TEST 'cpld_control_noaero_p8_intel' [07:01, 04:31](1736 MB)
-PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [07:18, 04:20](1779 MB)
+PASS -- COMPILE 's2sw_intel' [16:10, 14:22]
+PASS -- TEST 'cpld_control_noaero_p8_intel' [14:34, 04:29](1742 MB)
+PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [11:46, 04:26](1778 MB)
 
-PASS -- COMPILE 's2swa_debug_intel' [06:06, 04:52]
-PASS -- TEST 'cpld_debug_p8_intel' [11:34, 08:34](3250 MB)
+PASS -- COMPILE 's2swa_debug_intel' [07:07, 05:41]
+PASS -- TEST 'cpld_debug_p8_intel' [11:28, 08:40](3251 MB)
 
-PASS -- COMPILE 's2sw_debug_intel' [06:06, 04:41]
-PASS -- TEST 'cpld_debug_noaero_p8_intel' [08:02, 06:03](1750 MB)
+PASS -- COMPILE 's2sw_debug_intel' [06:07, 04:52]
+PASS -- TEST 'cpld_debug_noaero_p8_intel' [08:12, 06:03](1757 MB)
 
-PASS -- COMPILE 's2s_aoflux_intel' [14:07, 12:55]
-PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [07:17, 04:18](1782 MB)
+PASS -- COMPILE 's2s_aoflux_intel' [14:10, 12:11]
+PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [07:37, 04:32](1705 MB)
 
-PASS -- COMPILE 's2s_intel' [14:06, 12:34]
-PASS -- TEST 'cpld_control_c48_intel' [09:51, 08:02](2831 MB)
+PASS -- COMPILE 's2s_intel' [14:10, 12:10]
+PASS -- TEST 'cpld_control_c48_intel' [10:00, 08:01](2835 MB)
 
-PASS -- COMPILE 's2swa_faster_intel' [19:07, 17:08]
-PASS -- TEST 'cpld_control_p8_faster_intel' [08:23, 05:16](3212 MB)
+PASS -- COMPILE 's2swa_faster_intel' [21:10, 19:41]
+PASS -- TEST 'cpld_control_p8_faster_intel' [12:43, 05:18](3152 MB)
 
-PASS -- COMPILE 's2sw_pdlib_intel' [19:07, 17:26]
-PASS -- TEST 'cpld_control_pdlib_p8_intel' [19:09, 16:33](1722 MB)
-PASS -- TEST 'cpld_restart_pdlib_p8_intel' [11:16, 08:12](1171 MB)
-PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [21:18, 18:27](1679 MB)
+PASS -- COMPILE 's2sw_pdlib_intel' [19:08, 17:07]
+PASS -- TEST 'cpld_control_pdlib_p8_intel' [19:14, 16:32](1774 MB)
+PASS -- TEST 'cpld_restart_pdlib_p8_intel' [10:58, 08:05](1176 MB)
+PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [21:13, 18:34](1677 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_intel' [06:06, 04:37]
-PASS -- TEST 'cpld_debug_pdlib_p8_intel' [27:08, 24:09](1716 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_intel' [07:07, 05:20]
+PASS -- TEST 'cpld_debug_pdlib_p8_intel' [27:10, 24:51](1721 MB)
 
-PASS -- COMPILE 'atm_dyn32_intel' [13:06, 11:32]
-PASS -- TEST 'control_flake_intel' [05:21, 03:30](700 MB)
-PASS -- TEST 'control_CubedSphereGrid_intel' [04:22, 02:28](651 MB)
-PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [04:26, 02:38](654 MB)
-PASS -- TEST 'control_latlon_intel' [04:20, 02:30](650 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [04:28, 02:34](650 MB)
-PASS -- TEST 'control_c48_intel' [07:25, 05:58](878 MB)
-PASS -- TEST 'control_c48.v2.sfc_intel' [07:28, 05:57](864 MB)
-PASS -- TEST 'control_c192_intel' [11:34, 09:08](860 MB)
-PASS -- TEST 'control_c384_intel' [13:33, 10:04](1242 MB)
-PASS -- TEST 'control_c384gdas_intel' [13:42, 09:03](1360 MB)
-PASS -- TEST 'control_stochy_intel' [03:19, 01:46](655 MB)
-PASS -- TEST 'control_stochy_restart_intel' [02:20, 01:00](504 MB)
-PASS -- TEST 'control_lndp_intel' [03:20, 01:38](658 MB)
-PASS -- TEST 'control_iovr4_intel' [04:25, 02:33](650 MB)
-PASS -- TEST 'control_iovr5_intel' [04:21, 02:30](655 MB)
-PASS -- TEST 'control_p8_intel' [05:03, 02:57](1638 MB)
-PASS -- TEST 'control_p8.v2.sfc_intel' [05:14, 02:57](1639 MB)
-PASS -- TEST 'control_p8_ugwpv1_intel' [05:25, 02:51](1626 MB)
-PASS -- TEST 'control_restart_p8_intel' [04:09, 01:39](892 MB)
-PASS -- TEST 'control_noqr_p8_intel' [05:13, 02:57](1612 MB)
-PASS -- TEST 'control_restart_noqr_p8_intel' [04:17, 01:36](930 MB)
-PASS -- TEST 'control_decomp_p8_intel' [05:20, 03:03](1609 MB)
-PASS -- TEST 'control_2threads_p8_intel' [06:28, 03:06](1722 MB)
-PASS -- TEST 'control_p8_lndp_intel' [07:56, 05:11](1624 MB)
-PASS -- TEST 'control_p8_rrtmgp_intel' [06:42, 03:58](1693 MB)
-PASS -- TEST 'control_p8_mynn_intel' [06:41, 03:02](1639 MB)
-PASS -- TEST 'merra2_thompson_intel' [07:01, 03:31](1644 MB)
-PASS -- TEST 'regional_control_intel' [07:54, 05:09](860 MB)
-PASS -- TEST 'regional_restart_intel' [04:43, 02:43](977 MB)
-PASS -- TEST 'regional_decomp_intel' [07:51, 05:28](853 MB)
-PASS -- TEST 'regional_2threads_intel' [05:46, 03:39](847 MB)
-PASS -- TEST 'regional_noquilt_intel' [06:39, 05:03](1364 MB)
-PASS -- TEST 'regional_netcdf_parallel_intel' [07:36, 05:05](859 MB)
-PASS -- TEST 'regional_2dwrtdecomp_intel' [07:35, 05:06](856 MB)
-PASS -- TEST 'regional_wofs_intel' [08:37, 06:32](1920 MB)
+PASS -- COMPILE 'atm_dyn32_intel' [15:08, 13:45]
+PASS -- TEST 'control_flake_intel' [09:23, 03:31](700 MB)
+PASS -- TEST 'control_CubedSphereGrid_intel' [08:22, 02:25](657 MB)
+PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [08:28, 02:32](657 MB)
+PASS -- TEST 'control_latlon_intel' [08:20, 02:26](655 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [08:29, 02:31](654 MB)
+PASS -- TEST 'control_c48_intel' [11:28, 05:56](882 MB)
+PASS -- TEST 'control_c48.v2.sfc_intel' [11:28, 05:58](873 MB)
+PASS -- TEST 'control_c192_intel' [15:41, 09:10](852 MB)
+PASS -- TEST 'control_c384_intel' [17:32, 10:09](1252 MB)
+PASS -- TEST 'control_c384gdas_intel' [16:57, 09:05](1352 MB)
+PASS -- TEST 'control_stochy_intel' [06:23, 01:38](652 MB)
+PASS -- TEST 'control_stochy_restart_intel' [03:28, 00:58](507 MB)
+PASS -- TEST 'control_lndp_intel' [03:25, 01:41](654 MB)
+PASS -- TEST 'control_iovr4_intel' [04:23, 02:28](656 MB)
+PASS -- TEST 'control_iovr5_intel' [05:22, 02:28](648 MB)
+PASS -- TEST 'control_p8_intel' [06:00, 03:02](1633 MB)
+PASS -- TEST 'control_p8.v2.sfc_intel' [06:19, 02:57](1627 MB)
+PASS -- TEST 'control_p8_ugwpv1_intel' [05:32, 02:49](1638 MB)
+PASS -- TEST 'control_restart_p8_intel' [05:14, 01:37](895 MB)
+PASS -- TEST 'control_noqr_p8_intel' [05:20, 02:52](1616 MB)
+PASS -- TEST 'control_restart_noqr_p8_intel' [05:12, 01:36](926 MB)
+PASS -- TEST 'control_decomp_p8_intel' [06:13, 02:58](1620 MB)
+PASS -- TEST 'control_2threads_p8_intel' [06:12, 03:00](1716 MB)
+PASS -- TEST 'control_p8_lndp_intel' [07:56, 05:11](1633 MB)
+PASS -- TEST 'control_p8_rrtmgp_intel' [06:39, 03:53](1651 MB)
+PASS -- TEST 'control_p8_mynn_intel' [06:32, 02:59](1639 MB)
+PASS -- TEST 'merra2_thompson_intel' [06:58, 03:25](1635 MB)
+PASS -- TEST 'regional_control_intel' [07:36, 05:12](856 MB)
+PASS -- TEST 'regional_restart_intel' [05:37, 02:43](1023 MB)
+PASS -- TEST 'regional_decomp_intel' [07:35, 05:29](849 MB)
+PASS -- TEST 'regional_2threads_intel' [05:46, 03:38](849 MB)
+PASS -- TEST 'regional_noquilt_intel' [07:37, 05:04](1361 MB)
+PASS -- TEST 'regional_netcdf_parallel_intel' [07:43, 05:02](859 MB)
+PASS -- TEST 'regional_2dwrtdecomp_intel' [07:42, 05:06](853 MB)
+PASS -- TEST 'regional_wofs_intel' [08:37, 06:35](1917 MB)
 
-PASS -- COMPILE 'rrfs_intel' [12:06, 10:51]
-PASS -- TEST 'rap_control_intel' [10:29, 07:41](1101 MB)
-PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [06:53, 04:46](1295 MB)
-PASS -- TEST 'rap_decomp_intel' [10:58, 08:07](1024 MB)
-PASS -- TEST 'rap_2threads_intel' [10:09, 07:54](1180 MB)
-PASS -- TEST 'rap_restart_intel' [06:18, 04:00](1110 MB)
-PASS -- TEST 'rap_sfcdiff_intel' [10:26, 07:43](1109 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_intel' [11:05, 08:11](1039 MB)
-PASS -- TEST 'rap_sfcdiff_restart_intel' [08:23, 05:47](1136 MB)
-PASS -- TEST 'hrrr_control_intel' [06:02, 03:58](1038 MB)
-PASS -- TEST 'hrrr_control_decomp_intel' [06:01, 04:05](1022 MB)
-PASS -- TEST 'hrrr_control_2threads_intel' [05:53, 03:29](1114 MB)
-PASS -- TEST 'hrrr_control_restart_intel' [04:20, 02:10](995 MB)
-PASS -- TEST 'rrfs_v1beta_intel' [10:18, 07:34](1106 MB)
-PASS -- TEST 'rrfs_v1nssl_intel' [11:26, 09:12](1998 MB)
-PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [10:23, 08:56](2077 MB)
+PASS -- COMPILE 'rrfs_intel' [14:09, 12:06]
+PASS -- TEST 'rap_control_intel' [11:28, 07:49](1107 MB)
+PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [06:56, 04:44](1299 MB)
+PASS -- TEST 'rap_decomp_intel' [12:03, 08:14](1030 MB)
+PASS -- TEST 'rap_2threads_intel' [11:18, 07:57](1179 MB)
+PASS -- TEST 'rap_restart_intel' [06:20, 04:00](1096 MB)
+PASS -- TEST 'rap_sfcdiff_intel' [11:06, 07:41](1110 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_intel' [11:06, 08:07](1030 MB)
+PASS -- TEST 'rap_sfcdiff_restart_intel' [08:31, 05:54](1132 MB)
+PASS -- TEST 'hrrr_control_intel' [07:06, 03:57](996 MB)
+PASS -- TEST 'hrrr_control_decomp_intel' [07:00, 04:06](1019 MB)
+PASS -- TEST 'hrrr_control_2threads_intel' [06:53, 03:28](1109 MB)
+PASS -- TEST 'hrrr_control_restart_intel' [04:21, 02:12](998 MB)
+PASS -- TEST 'rrfs_v1beta_intel' [11:17, 07:36](1098 MB)
+PASS -- TEST 'rrfs_v1nssl_intel' [11:29, 09:10](1994 MB)
+PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [10:32, 08:58](2076 MB)
 
-PASS -- COMPILE 'csawmg_intel' [13:07, 11:27]
-PASS -- TEST 'control_csawmg_intel' [08:34, 06:04](750 MB)
-PASS -- TEST 'control_csawmgt_intel' [07:47, 05:57](749 MB)
-PASS -- TEST 'control_ras_intel' [05:20, 03:18](738 MB)
+PASS -- COMPILE 'csawmg_intel' [14:09, 12:40]
+PASS -- TEST 'control_csawmg_intel' [08:43, 06:03](742 MB)
+PASS -- TEST 'control_csawmgt_intel' [08:42, 05:57](748 MB)
+PASS -- TEST 'control_ras_intel' [05:23, 03:21](745 MB)
 
-PASS -- COMPILE 'wam_intel' [12:07, 10:18]
-PASS -- TEST 'control_wam_intel' [04:19, 02:09](659 MB)
+PASS -- COMPILE 'wam_intel' [12:06, 10:53]
+PASS -- TEST 'control_wam_intel' [04:20, 02:06](659 MB)
 
-PASS -- COMPILE 'atm_faster_dyn32_intel' [13:07, 11:17]
-PASS -- TEST 'control_p8_faster_intel' [05:40, 02:39](1617 MB)
-PASS -- TEST 'regional_control_faster_intel' [06:40, 04:36](852 MB)
+PASS -- COMPILE 'atm_faster_dyn32_intel' [13:08, 11:09]
+PASS -- TEST 'control_p8_faster_intel' [05:26, 02:39](1631 MB)
+PASS -- TEST 'regional_control_faster_intel' [07:40, 04:38](851 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_intel' [06:05, 04:23]
-PASS -- TEST 'control_CubedSphereGrid_debug_intel' [04:23, 02:47](816 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [04:25, 02:46](819 MB)
-PASS -- TEST 'control_stochy_debug_intel' [05:17, 03:08](814 MB)
-PASS -- TEST 'control_lndp_debug_intel' [04:19, 02:49](815 MB)
-PASS -- TEST 'control_csawmg_debug_intel' [06:38, 04:15](817 MB)
-PASS -- TEST 'control_csawmgt_debug_intel' [06:39, 04:06](859 MB)
-PASS -- TEST 'control_ras_debug_intel' [04:20, 02:52](825 MB)
-PASS -- TEST 'control_diag_debug_intel' [04:24, 02:59](871 MB)
-PASS -- TEST 'control_debug_p8_intel' [04:44, 02:57](1633 MB)
-PASS -- TEST 'regional_debug_intel' [18:38, 16:57](838 MB)
-PASS -- TEST 'rap_control_debug_intel' [06:22, 04:57](1200 MB)
-PASS -- TEST 'hrrr_control_debug_intel' [06:17, 04:44](1199 MB)
-PASS -- TEST 'hrrr_gf_debug_intel' [06:17, 04:56](1201 MB)
-PASS -- TEST 'hrrr_c3_debug_intel' [06:19, 04:58](1197 MB)
-PASS -- TEST 'rap_unified_drag_suite_debug_intel' [06:22, 04:54](1201 MB)
-PASS -- TEST 'rap_diag_debug_intel' [07:31, 05:14](1285 MB)
-PASS -- TEST 'rap_cires_ugwp_debug_intel' [06:20, 05:00](1201 MB)
-PASS -- TEST 'rap_unified_ugwp_debug_intel' [06:21, 05:01](1199 MB)
-PASS -- TEST 'rap_lndp_debug_intel' [06:21, 05:02](1199 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_intel' [06:23, 04:55](1208 MB)
-PASS -- TEST 'rap_noah_debug_intel' [06:20, 04:56](1205 MB)
-PASS -- TEST 'rap_sfcdiff_debug_intel' [06:19, 04:53](1164 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [09:19, 07:59](1200 MB)
-PASS -- TEST 'rrfs_v1beta_debug_intel' [06:23, 04:52](1201 MB)
-PASS -- TEST 'rap_clm_lake_debug_intel' [08:19, 06:12](1200 MB)
-PASS -- TEST 'rap_flake_debug_intel' [06:19, 04:58](1204 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [11:25, 08:30](1199 MB)
+PASS -- COMPILE 'atm_debug_dyn32_intel' [06:07, 04:26]
+PASS -- TEST 'control_CubedSphereGrid_debug_intel' [05:27, 02:45](814 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [05:24, 02:42](809 MB)
+PASS -- TEST 'control_stochy_debug_intel' [05:17, 03:03](813 MB)
+PASS -- TEST 'control_lndp_debug_intel' [05:16, 02:48](820 MB)
+PASS -- TEST 'control_csawmg_debug_intel' [06:35, 04:06](866 MB)
+PASS -- TEST 'control_csawmgt_debug_intel' [06:39, 04:07](864 MB)
+PASS -- TEST 'control_ras_debug_intel' [04:20, 02:48](825 MB)
+PASS -- TEST 'control_diag_debug_intel' [04:29, 02:52](870 MB)
+PASS -- TEST 'control_debug_p8_intel' [04:41, 03:01](1635 MB)
+PASS -- TEST 'regional_debug_intel' [19:45, 17:41](842 MB)
+PASS -- TEST 'rap_control_debug_intel' [06:25, 04:59](1203 MB)
+PASS -- TEST 'hrrr_control_debug_intel' [06:22, 04:49](1202 MB)
+PASS -- TEST 'hrrr_gf_debug_intel' [06:23, 05:04](1146 MB)
+PASS -- TEST 'hrrr_c3_debug_intel' [06:21, 04:56](1204 MB)
+PASS -- TEST 'rap_unified_drag_suite_debug_intel' [06:21, 04:52](1202 MB)
+PASS -- TEST 'rap_diag_debug_intel' [07:29, 05:11](1288 MB)
+PASS -- TEST 'rap_cires_ugwp_debug_intel' [06:22, 05:05](1206 MB)
+PASS -- TEST 'rap_unified_ugwp_debug_intel' [06:17, 05:04](1201 MB)
+PASS -- TEST 'rap_lndp_debug_intel' [06:28, 05:00](1203 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_intel' [06:23, 04:53](1203 MB)
+PASS -- TEST 'rap_noah_debug_intel' [06:20, 04:53](1198 MB)
+PASS -- TEST 'rap_sfcdiff_debug_intel' [06:23, 04:57](1202 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [09:18, 07:58](1203 MB)
+PASS -- TEST 'rrfs_v1beta_debug_intel' [06:22, 04:54](1198 MB)
+PASS -- TEST 'rap_clm_lake_debug_intel' [07:41, 05:58](1206 MB)
+PASS -- TEST 'rap_flake_debug_intel' [06:30, 04:55](1204 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [11:23, 08:29](1204 MB)
 
-PASS -- COMPILE 'wam_debug_intel' [05:05, 03:13]
-PASS -- TEST 'control_wam_debug_intel' [07:17, 05:04](502 MB)
+PASS -- COMPILE 'wam_debug_intel' [05:07, 03:22]
+PASS -- TEST 'control_wam_debug_intel' [10:19, 05:10](512 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [13:06, 11:16]
-PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [06:52, 04:43](1162 MB)
-PASS -- TEST 'rap_control_dyn32_phy32_intel' [09:24, 06:27](1052 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [06:05, 03:22](988 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [08:56, 06:40](1089 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [05:22, 02:58](964 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [06:42, 03:37](923 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_intel' [07:13, 04:49](1033 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [03:20, 01:52](935 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [15:07, 10:47]
+PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [07:25, 04:27](1165 MB)
+PASS -- TEST 'rap_control_dyn32_phy32_intel' [09:11, 06:26](1043 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [06:24, 03:27](982 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [08:52, 06:42](1092 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [05:48, 03:01](964 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [06:47, 03:35](926 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_intel' [11:16, 04:48](1039 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [06:47, 01:53](934 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [15:07, 13:23]
-PASS -- TEST 'conus13km_control_intel' [04:53, 02:07](1202 MB)
-PASS -- TEST 'conus13km_2threads_intel' [02:41, 01:02](1119 MB)
-PASS -- TEST 'conus13km_restart_mismatch_intel' [03:33, 01:16](1114 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [17:08, 12:44]
+PASS -- TEST 'conus13km_control_intel' [05:06, 02:04](1199 MB)
+PASS -- TEST 'conus13km_2threads_intel' [05:46, 01:02](1123 MB)
+PASS -- TEST 'conus13km_restart_mismatch_intel' [06:43, 01:18](1107 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [13:07, 11:09]
-PASS -- TEST 'rap_control_dyn64_phy32_intel' [06:42, 04:18](996 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [15:07, 10:50]
+PASS -- TEST 'rap_control_dyn64_phy32_intel' [06:44, 04:14](994 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [04:06, 03:00]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [06:21, 05:00](1082 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [06:18, 04:50](1080 MB)
-PASS -- TEST 'conus13km_debug_intel' [16:50, 14:33](1231 MB)
-PASS -- TEST 'conus13km_debug_qr_intel' [16:50, 14:36](952 MB)
-PASS -- TEST 'conus13km_debug_2threads_intel' [10:35, 08:49](1158 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_intel' [16:41, 14:26](1299 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [06:06, 03:26]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [07:23, 05:11](1023 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [07:19, 05:07](1074 MB)
+PASS -- TEST 'conus13km_debug_intel' [16:53, 14:14](1253 MB)
+PASS -- TEST 'conus13km_debug_qr_intel' [16:50, 14:12](921 MB)
+PASS -- TEST 'conus13km_debug_2threads_intel' [10:39, 08:30](1153 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_intel' [20:57, 14:37](1294 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [04:06, 03:03]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [06:22, 04:59](1077 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [06:06, 03:18]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [06:23, 05:02](1116 MB)
 
-PASS -- COMPILE 'hafsw_intel' [14:08, 12:54]
-PASS -- TEST 'hafs_regional_atm_intel' [08:11, 05:38](740 MB)
-PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [07:24, 05:58](1116 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_intel' [09:30, 07:00](833 MB)
-PASS -- TEST 'hafs_regional_atm_wav_intel' [15:12, 12:50](861 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [17:21, 14:28](884 MB)
-PASS -- TEST 'hafs_regional_1nest_atm_intel' [08:58, 06:09](498 MB)
-PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [10:20, 07:36](518 MB)
-PASS -- TEST 'hafs_global_1nest_atm_intel' [05:50, 03:09](372 MB)
-PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [11:18, 08:02](482 MB)
-PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [06:46, 04:09](532 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [05:48, 03:55](531 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [07:54, 05:20](592 MB)
-PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [03:25, 01:26](403 MB)
-PASS -- TEST 'gnv1_nested_intel' [06:57, 04:27](807 MB)
+PASS -- COMPILE 'hafsw_intel' [16:07, 12:35]
+PASS -- TEST 'hafs_regional_atm_intel' [09:21, 06:19](750 MB)
+PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [09:26, 06:08](1121 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_intel' [14:31, 06:57](832 MB)
+PASS -- TEST 'hafs_regional_atm_wav_intel' [19:40, 12:47](864 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [21:03, 14:30](882 MB)
+PASS -- TEST 'hafs_regional_1nest_atm_intel' [11:19, 06:06](504 MB)
+PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [10:37, 07:32](468 MB)
+PASS -- TEST 'hafs_global_1nest_atm_intel' [08:01, 03:11](373 MB)
+PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [13:35, 08:08](432 MB)
+PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [08:48, 04:07](529 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [09:53, 03:55](530 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [08:53, 05:26](585 MB)
+PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [06:25, 01:31](400 MB)
+FAIL TO COMPARE -- TEST 'gnv1_nested_intel' [, ]( MB)
 
-PASS -- COMPILE 'hafsw_debug_intel' [06:06, 04:07]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [14:47, 12:50](531 MB)
+PASS -- COMPILE 'hafsw_debug_intel' [06:06, 04:03]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [18:54, 13:18](574 MB)
 
-PASS -- COMPILE 'hafsw_faster_intel' [15:08, 13:31]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [11:57, 09:27](636 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [12:04, 09:35](744 MB)
+PASS -- COMPILE 'hafsw_faster_intel' [15:10, 13:15]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [14:07, 09:44](770 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [15:04, 09:50](708 MB)
 
-PASS -- COMPILE 'hafs_mom6w_intel' [14:08, 12:55]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [08:58, 06:56](729 MB)
+PASS -- COMPILE 'hafs_mom6w_intel' [16:10, 15:05]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [10:59, 06:55](731 MB)
 
-PASS -- COMPILE 'hafs_all_intel' [14:08, 12:12]
-PASS -- TEST 'hafs_regional_docn_intel' [09:14, 06:17](830 MB)
-PASS -- TEST 'hafs_regional_docn_oisst_intel' [09:11, 06:24](814 MB)
-PASS -- TEST 'hafs_regional_datm_cdeps_intel' [17:57, 16:04](1210 MB)
+PASS -- COMPILE 'hafs_all_intel' [13:08, 12:00]
+PASS -- TEST 'hafs_regional_docn_intel' [11:10, 06:13](831 MB)
+PASS -- TEST 'hafs_regional_docn_oisst_intel' [10:15, 06:19](763 MB)
+PASS -- TEST 'hafs_regional_datm_cdeps_intel' [18:57, 16:00](1209 MB)
 
-PASS -- COMPILE 'datm_cdeps_intel' [10:07, 08:13]
-PASS -- TEST 'datm_cdeps_control_cfsr_intel' [04:15, 02:41](1081 MB)
-PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [03:15, 01:41](1088 MB)
-PASS -- TEST 'datm_cdeps_control_gefs_intel' [04:13, 02:34](1018 MB)
-PASS -- TEST 'datm_cdeps_iau_gefs_intel' [04:14, 02:41](1013 MB)
-PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [04:12, 02:37](1016 MB)
-PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [04:13, 02:39](1125 MB)
-PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [04:14, 02:36](1139 MB)
-PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [04:13, 02:37](1014 MB)
-PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [08:11, 05:55](1055 MB)
-PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [08:11, 05:54](1029 MB)
-PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [04:12, 02:41](1104 MB)
-PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [05:14, 03:34](2494 MB)
-PASS -- TEST 'datm_cdeps_gfs_intel' [05:14, 03:38](2498 MB)
+PASS -- COMPILE 'datm_cdeps_intel' [09:08, 07:44]
+PASS -- TEST 'datm_cdeps_control_cfsr_intel' [05:15, 02:35](1133 MB)
+PASS -- TEST 'datm_cdeps_restart_cfsr_intel' [03:16, 01:40](1090 MB)
+PASS -- TEST 'datm_cdeps_control_gefs_intel' [04:14, 02:31](1020 MB)
+PASS -- TEST 'datm_cdeps_iau_gefs_intel' [04:14, 02:33](1015 MB)
+PASS -- TEST 'datm_cdeps_stochy_gefs_intel' [04:14, 02:38](1013 MB)
+PASS -- TEST 'datm_cdeps_ciceC_cfsr_intel' [04:14, 02:38](1127 MB)
+PASS -- TEST 'datm_cdeps_bulk_cfsr_intel' [04:14, 02:40](1136 MB)
+PASS -- TEST 'datm_cdeps_bulk_gefs_intel' [04:14, 02:33](1017 MB)
+PASS -- TEST 'datm_cdeps_mx025_cfsr_intel' [08:24, 06:02](1063 MB)
+PASS -- TEST 'datm_cdeps_mx025_gefs_intel' [08:26, 06:01](1040 MB)
+PASS -- TEST 'datm_cdeps_multiple_files_cfsr_intel' [04:14, 02:53](1097 MB)
+PASS -- TEST 'datm_cdeps_3072x1536_cfsr_intel' [05:14, 03:34](2446 MB)
+PASS -- TEST 'datm_cdeps_gfs_intel' [05:15, 03:40](2489 MB)
 
-PASS -- COMPILE 'datm_cdeps_debug_intel' [06:06, 04:17]
-PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [08:14, 06:07](1063 MB)
+PASS -- COMPILE 'datm_cdeps_debug_intel' [05:08, 03:26]
+PASS -- TEST 'datm_cdeps_debug_cfsr_intel' [08:15, 06:22](1062 MB)
 
-PASS -- COMPILE 'datm_cdeps_faster_intel' [10:07, 08:21]
-PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [04:12, 02:33](1130 MB)
+PASS -- COMPILE 'datm_cdeps_faster_intel' [09:08, 07:37]
+PASS -- TEST 'datm_cdeps_control_cfsr_faster_intel' [04:13, 02:37](1131 MB)
 
-PASS -- COMPILE 'datm_cdeps_land_intel' [02:06, 00:57]
-PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [02:25, 00:51](251 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_intel' [02:19, 00:49](320 MB)
-PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [02:23, 00:33](321 MB)
+PASS -- COMPILE 'datm_cdeps_land_intel' [03:06, 01:02]
+PASS -- TEST 'datm_cdeps_lnd_gswp3_intel' [03:28, 00:52](252 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_intel' [03:21, 00:48](321 MB)
+PASS -- TEST 'datm_cdeps_lnd_era5_rst_intel' [02:25, 00:35](322 MB)
 
-PASS -- COMPILE 'atml_intel' [14:08, 12:10]
-PASS -- TEST 'control_p8_atmlnd_sbs_intel' [07:34, 04:19](1607 MB)
-PASS -- TEST 'control_p8_atmlnd_intel' [07:26, 04:16](1595 MB)
-PASS -- TEST 'control_restart_p8_atmlnd_intel' [04:44, 02:16](895 MB)
+PASS -- COMPILE 'atml_intel' [16:07, 11:59]
+PASS -- TEST 'control_p8_atmlnd_sbs_intel' [08:41, 04:20](1615 MB)
+PASS -- TEST 'control_p8_atmlnd_intel' [07:32, 04:19](1611 MB)
+PASS -- TEST 'control_restart_p8_atmlnd_intel' [05:52, 02:23](896 MB)
 
-PASS -- COMPILE 'atmw_intel' [14:09, 12:12]
-PASS -- TEST 'atmwav_control_noaero_p8_intel' [04:17, 01:47](1664 MB)
+PASS -- COMPILE 'atmw_intel' [16:08, 12:03]
+PASS -- TEST 'atmwav_control_noaero_p8_intel' [05:36, 01:46](1663 MB)
 
-PASS -- COMPILE 'atmwm_intel' [13:07, 11:59]
-PASS -- TEST 'control_atmwav_intel' [04:05, 01:40](670 MB)
+PASS -- COMPILE 'atmwm_intel' [15:07, 11:58]
+PASS -- TEST 'control_atmwav_intel' [05:28, 01:40](675 MB)
 
-PASS -- COMPILE 'atmaero_intel' [13:07, 11:08]
-PASS -- TEST 'atmaero_control_p8_intel' [06:17, 03:57](3024 MB)
-PASS -- TEST 'atmaero_control_p8_rad_intel' [07:17, 04:48](3088 MB)
-PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [08:00, 05:05](3108 MB)
+PASS -- COMPILE 'atmaero_intel' [15:06, 11:40]
+PASS -- TEST 'atmaero_control_p8_intel' [07:30, 04:08](2951 MB)
+PASS -- TEST 'atmaero_control_p8_rad_intel' [07:18, 04:50](3100 MB)
+PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [08:06, 05:04](3107 MB)
 
-PASS -- COMPILE 'atmaq_intel' [12:06, 10:44]
+PASS -- COMPILE 'atmaq_intel' [13:08, 11:25]
 
-PASS -- COMPILE 'atmaq_debug_intel' [04:06, 03:04]
-PASS -- TEST 'regional_atmaq_debug_intel' [24:50, 21:20](4578 MB)
+PASS -- COMPILE 'atmaq_debug_intel' [05:06, 03:21]
+PASS -- TEST 'regional_atmaq_debug_intel' [23:52, 20:37](4393 MB)
 
 SYNOPSIS:
-Starting Date/Time: 20240314 09:08:52
-Ending Date/Time: 20240314 10:37:33
-Total Time: 01h:29m:30s
+Starting Date/Time: 20240315 12:47:18
+Ending Date/Time: 20240315 14:22:44
+Total Time: 01h:36m:12s
 Compiles Completed: 39/39
-Tests Completed: 182/182
+Tests Completed: 181/182
+Failed Tests:
+* TEST gnv1_nested_intel: FAIL TO COMPARE
+-- LOG: /work2/noaa/stmp/zshrader/orion/rt-2181/tests/logs/log_orion/rt_gnv1_nested_intel.log
+
+NOTES:
+A file 'test_changes.list' was generated with list of all failed tests.
+You can use './rt.sh -c -b test_changes.list' to create baselines for the failed tests.
+If you are using this log as a pull request verification, please commit 'test_changes.list'.
+
+Result: FAILURE
+
+====END OF ORION REGRESSION TESTING LOG====
+====START OF ORION REGRESSION TESTING LOG====
+
+UFSWM hash used in testing:
+0939a1dff2a2060b541eca9642a19c5ed1541f17
+
+Submodule hashes used in testing:
+ 37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
+ be5d28fd1b60522e6fc98aefeead20e6aac3530b AQM/src/model/CMAQ (CMAQv5.2.1_07Feb2018-198-gbe5d28fd1)
+ 3d7067a523b8557058755289e4275f5f5c985daf CDEPS-interface/CDEPS (cdeps0.4.17-40-g3d7067a)
+ 7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
+ f6ff8f7c4d4cb6feabe3651b13204cf43fc948e3 CICE-interface/CICE/icepack (Icepack1.1.0-182-gf6ff8f7)
+ 758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
+ cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
+ 6663459e58a04e3bda2157d5891d227e3abc3c7a FV3/atmos_cubed_sphere (201912_public_release-386-g6663459)
+ 87e6d92e2ca48a55b66f8810f347b51c70c193c4 FV3/ccpp/framework (v0.1.0-1436-g87e6d92)
+ 2f15ae92802cae11fd0efb902439a084609984f3 FV3/ccpp/physics (master-tag-before-replacing-with-ipd-setup-step-fast-5141-g2f15ae92)
+ 74a0e098b2163425e4b5466c2dfcf8ae26d560a5 FV3/ccpp/physics/physics/Radiation/RRTMGP/rte-rrtmgp (v1.6)
+ 945cb2cef5e8bd5949afd4f0fc35c4fb6e95a1bf FV3/upp (upp_v10.2.0-159-g945cb2c)
+-1ba8270870947b583cd51bc72ff8960f4c1fb36e FV3/upp/sorc/libIFI.fd
+-a9828705b587c451fc2a7267d1c374d737be425b FV3/upp/sorc/ncep_post.fd/post_gtg.fd
+ 041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
+ 35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
+ 10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
+ 9423197f894112edfcb1502245f7d7b873d551f9 MOM6-interface/MOM6/pkg/CVMix-src (9423197)
+ 29e64d652786e1d076a05128c920f394202bfe10 MOM6-interface/MOM6/pkg/GSW-Fortran (29e64d6)
+ 0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
+ 4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
+ a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
+ 37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
+ 3d7067a523b8557058755289e4275f5f5c985daf CDEPS-interface/CDEPS (cdeps0.4.17-40-g3d7067a)
+ 7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
+ 758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
+ cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
+ 041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
+ 35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
+ 10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
+ 0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
+ 4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
+ a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
+
+
+NOTES:
+[Times](Memory) are at the end of each compile/test in format [MM:SS](Size).
+The first time is for the full script (prep+run+finalize).
+The second time is specifically for the run phase.
+Times/Memory will be empty for failed tests.
+
+BASELINE DIRECTORY: /work/noaa/epic/UFS-WM_RT/NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /work/noaa/stmp/zshrader/stmp/zshrader/FV3_RT/rt_120510
+
+RT.SH OPTIONS USED:
+* (-a) - HPC PROJECT ACCOUNT: nems
+* (-l) - USE CONFIG FILE: rt.conf
+* (-e) - USE ECFLOW
+
+PASS -- COMPILE 'hafsw_intel' [16:08, 14:05]
+PASS -- TEST 'gnv1_nested_intel' [06:42, 04:50](809 MB)
+
+SYNOPSIS:
+Starting Date/Time: 20240315 14:56:25
+Ending Date/Time: 20240315 15:36:40
+Total Time: 00h:40m:30s
+Compiles Completed: 1/1
+Tests Completed: 1/1
 
 NOTES:
 A file 'test_changes.list' was generated but is empty.

--- a/tests/logs/RegressionTests_wcoss2.log
+++ b/tests/logs/RegressionTests_wcoss2.log
@@ -1,7 +1,7 @@
 ====START OF WCOSS2 REGRESSION TESTING LOG====
 
 UFSWM hash used in testing:
-0d7aa189232097602b4a7b5cdab9caad9aba58ad
+0939a1dff2a2060b541eca9642a19c5ed1541f17
 
 Submodule hashes used in testing:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
@@ -11,10 +11,10 @@ Submodule hashes used in testing:
  f6ff8f7c4d4cb6feabe3651b13204cf43fc948e3 CICE-interface/CICE/icepack (Icepack1.1.0-182-gf6ff8f7)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  6663459e58a04e3bda2157d5891d227e3abc3c7a FV3/atmos_cubed_sphere (201912_public_release-386-g6663459)
- 221788f4e2539af797eb02efe42465b153533201 FV3/ccpp/framework (ccpp_transition_to_vlab_master_20190705-613-g221788f)
- bbdec2ffceeb0cda70aaaa4f44e619a5468e7be3 FV3/ccpp/physics (remotes/origin/HEAD-432-gbbdec2ff)
+ 87e6d92e2ca48a55b66f8810f347b51c70c193c4 FV3/ccpp/framework (v0.1.0-1436-g87e6d92)
+ 2f15ae92802cae11fd0efb902439a084609984f3 FV3/ccpp/physics (EP4-695-g2f15ae92)
  74a0e098b2163425e4b5466c2dfcf8ae26d560a5 FV3/ccpp/physics/physics/Radiation/RRTMGP/rte-rrtmgp (v1.6)
  945cb2cef5e8bd5949afd4f0fc35c4fb6e95a1bf FV3/upp (upp_v10.2.0-159-g945cb2c)
 -1ba8270870947b583cd51bc72ff8960f4c1fb36e FV3/upp/sorc/libIFI.fd
@@ -32,7 +32,7 @@ Submodule hashes used in testing:
  7d4e5defc1c5ff6d67cd74470e8fdbce5de84be1 CICE-interface/CICE (CICE6.0.0-446-g7d4e5de)
  758491ed6681dd6054b1ff877027e6da381e86f8 CMEPS-interface/CMEPS (cmeps_v0.4.1-2305-g758491e)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 2bafb6fa982fdd7b2cd9fc7801a4bbadcc230fc6 FV3 (remotes/origin/csawv2_gjf)
+ 5e667b1ecd159f7c53336ff2791bbf219dca6891 FV3 (remotes/origin/feature/ccpp_framework_merge_feature_capgen_into_main_20240308)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  10521a921d2f442de19a0cda240d912fd918c40c MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-10030-g10521a921)
@@ -47,236 +47,236 @@ The first time is for the full script (prep+run+finalize).
 The second time is specifically for the run phase.
 Times/Memory will be empty for failed tests.
 
-BASELINE DIRECTORY: /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20240312
-COMPARISON DIRECTORY: /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_69973
+BASELINE DIRECTORY: /lfs/h2/emc/nems/noscrub/emc.nems/RT/NEMSfv3gfs/develop-20240315
+COMPARISON DIRECTORY: /lfs/h2/emc/ptmp/brian.curtis/FV3_RT/rt_259455
 
 RT.SH OPTIONS USED:
 * (-a) - HPC PROJECT ACCOUNT: GFS-DEV
 * (-e) - USE ECFLOW
 
-PASS -- COMPILE 's2swa_32bit_intel' [26:11, 25:55]
-PASS -- TEST 'cpld_control_p8_mixedmode_intel' [53:52, 01:35](2976 MB)
+PASS -- COMPILE 's2swa_32bit_intel' [16:03, 15:20]
+PASS -- TEST 'cpld_control_p8_mixedmode_intel' [53:17, 01:28](2974 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_intel' [27:13, 26:28]
-PASS -- TEST 'cpld_control_gfsv17_intel' [52:50, 01:33](1590 MB)
-PASS -- TEST 'cpld_control_gfsv17_iau_intel' [32:16, 01:50](1707 MB)
-PASS -- TEST 'cpld_restart_gfsv17_intel' [32:01, 02:04](847 MB)
-PASS -- TEST 'cpld_mpi_gfsv17_intel' [52:51, 02:22](1578 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_intel' [12:57, 11:47]
+PASS -- TEST 'cpld_control_gfsv17_intel' [56:21, 02:13](1590 MB)
+PASS -- TEST 'cpld_control_gfsv17_iau_intel' [37:41, 02:06](1710 MB)
+PASS -- TEST 'cpld_restart_gfsv17_intel' [37:21, 01:22](846 MB)
+PASS -- TEST 'cpld_mpi_gfsv17_intel' [56:22, 01:44](1564 MB)
 
-PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [22:02, 21:48]
-PASS -- TEST 'cpld_debug_gfsv17_intel' [58:02, 01:43](1606 MB)
+PASS -- COMPILE 's2swa_32bit_pdlib_debug_intel' [05:22, 04:22]
+PASS -- TEST 'cpld_debug_gfsv17_intel' [03:58, 01:44](1609 MB)
 
-PASS -- COMPILE 's2swa_intel' [22:02, 21:22]
-PASS -- TEST 'cpld_control_p8_intel' [58:01, 01:39](3002 MB)
-PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [58:01, 01:34](3000 MB)
-PASS -- TEST 'cpld_restart_p8_intel' [46:26, 01:04](3060 MB)
-PASS -- TEST 'cpld_control_qr_p8_intel' [58:01, 01:13](3025 MB)
-PASS -- TEST 'cpld_restart_qr_p8_intel' [46:26, 01:40](3082 MB)
-PASS -- TEST 'cpld_2threads_p8_intel' [58:01, 01:15](3315 MB)
-PASS -- TEST 'cpld_decomp_p8_intel' [58:01, 01:30](3002 MB)
-PASS -- TEST 'cpld_mpi_p8_intel' [58:02, 01:28](2924 MB)
-PASS -- TEST 'cpld_control_ciceC_p8_intel' [58:01, 01:38](3004 MB)
-PASS -- TEST 'cpld_bmark_p8_intel' [58:10, 03:54](3957 MB)
-PASS -- TEST 'cpld_restart_bmark_p8_intel' [34:27, 04:08](4253 MB)
-PASS -- TEST 'cpld_s2sa_p8_intel' [58:01, 01:40](2971 MB)
+PASS -- COMPILE 's2swa_intel' [11:53, 11:07]
+PASS -- TEST 'cpld_control_p8_intel' [57:26, 01:50](3005 MB)
+PASS -- TEST 'cpld_control_p8.v2.sfc_intel' [57:26, 02:21](3004 MB)
+PASS -- TEST 'cpld_restart_p8_intel' [48:24, 01:45](3060 MB)
+PASS -- TEST 'cpld_control_qr_p8_intel' [57:26, 01:50](3027 MB)
+PASS -- TEST 'cpld_restart_qr_p8_intel' [48:24, 01:42](3081 MB)
+PASS -- TEST 'cpld_2threads_p8_intel' [57:26, 01:22](3314 MB)
+PASS -- TEST 'cpld_decomp_p8_intel' [57:26, 01:43](3000 MB)
+PASS -- TEST 'cpld_mpi_p8_intel' [57:27, 01:46](2925 MB)
+PASS -- TEST 'cpld_control_ciceC_p8_intel' [57:26, 02:07](3003 MB)
+PASS -- TEST 'cpld_bmark_p8_intel' [57:35, 03:30](3955 MB)
+PASS -- TEST 'cpld_restart_bmark_p8_intel' [39:00, 04:30](4255 MB)
+PASS -- TEST 'cpld_s2sa_p8_intel' [57:26, 02:17](2967 MB)
 
-PASS -- COMPILE 's2sw_intel' [14:48, 14:22]
-PASS -- TEST 'cpld_control_noaero_p8_intel' [05:15, 01:04](1581 MB)
-PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [05:15, 01:14](1640 MB)
+PASS -- COMPILE 's2sw_intel' [21:13, 20:46]
+PASS -- TEST 'cpld_control_noaero_p8_intel' [48:06, 00:48](1588 MB)
+PASS -- TEST 'cpld_control_nowave_noaero_p8_intel' [48:06, 01:58](1637 MB)
 
-PASS -- COMPILE 's2s_aoflux_intel' [22:02, 20:51]
-PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [58:01, 01:27](1636 MB)
+PASS -- COMPILE 's2s_aoflux_intel' [23:17, 22:22]
+PASS -- TEST 'cpld_control_noaero_p8_agrid_intel' [46:01, 00:57](1634 MB)
 
-PASS -- COMPILE 's2s_intel' [11:41, 11:12]
-PASS -- TEST 'cpld_control_c48_intel' [08:22, 00:57](2643 MB)
+PASS -- COMPILE 's2s_intel' [10:51, 09:41]
+PASS -- TEST 'cpld_control_c48_intel' [58:28, 00:43](2652 MB)
 
-PASS -- COMPILE 's2swa_faster_intel' [27:14, 26:35]
-PASS -- TEST 'cpld_control_p8_faster_intel' [52:50, 01:17](3002 MB)
+PASS -- COMPILE 's2swa_faster_intel' [32:40, 31:36]
+PASS -- TEST 'cpld_control_p8_faster_intel' [36:22, 01:57](3002 MB)
 
-PASS -- COMPILE 's2sw_pdlib_intel' [11:43, 10:31]
-PASS -- TEST 'cpld_control_pdlib_p8_intel' [08:20, 01:37](1608 MB)
-PASS -- TEST 'cpld_restart_pdlib_p8_intel' [47:21, 01:32](903 MB)
-PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [47:22, 01:24](1584 MB)
+PASS -- COMPILE 's2sw_pdlib_intel' [16:03, 15:27]
+PASS -- TEST 'cpld_control_pdlib_p8_intel' [53:17, 01:26](1607 MB)
+PASS -- TEST 'cpld_restart_pdlib_p8_intel' [35:39, 01:33](900 MB)
+PASS -- TEST 'cpld_mpi_pdlib_p8_intel' [35:04, 00:46](1580 MB)
 
-PASS -- COMPILE 's2sw_pdlib_debug_intel' [28:24, 27:15]
-PASS -- TEST 'cpld_debug_pdlib_p8_intel' [51:41, 01:30](1616 MB)
+PASS -- COMPILE 's2sw_pdlib_debug_intel' [05:21, 04:10]
+PASS -- TEST 'cpld_debug_pdlib_p8_intel' [03:59, 01:37](1612 MB)
 
-PASS -- COMPILE 'atm_dyn32_intel' [31:19, 27:57]
-PASS -- TEST 'control_flake_intel' [37:03, 00:35](572 MB)
-PASS -- TEST 'control_CubedSphereGrid_intel' [37:03, 00:52](523 MB)
-PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [37:03, 00:47](533 MB)
-PASS -- TEST 'control_latlon_intel' [37:03, 00:48](524 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [37:03, 00:55](522 MB)
-PASS -- TEST 'control_c48_intel' [37:02, 01:10](713 MB)
-PASS -- TEST 'control_c48.v2.sfc_intel' [37:02, 01:16](719 MB)
-PASS -- TEST 'control_c192_intel' [37:03, 00:53](639 MB)
-PASS -- TEST 'control_c384_intel' [36:58, 01:52](948 MB)
-PASS -- TEST 'control_c384gdas_intel' [36:44, 03:09](1094 MB)
-PASS -- TEST 'control_stochy_intel' [35:43, 00:28](529 MB)
-PASS -- TEST 'control_stochy_restart_intel' [33:12, 00:33](331 MB)
-PASS -- TEST 'control_lndp_intel' [34:57, 01:06](526 MB)
-PASS -- TEST 'control_iovr4_intel' [34:57, 01:30](527 MB)
-PASS -- TEST 'control_iovr5_intel' [34:41, 00:22](524 MB)
-PASS -- TEST 'control_p8_intel' [34:37, 01:52](1496 MB)
-PASS -- TEST 'control_p8.v2.sfc_intel' [34:37, 02:01](1499 MB)
-PASS -- TEST 'control_p8_ugwpv1_intel' [34:24, 02:29](1507 MB)
-PASS -- TEST 'control_restart_p8_intel' [27:53, 01:26](689 MB)
-PASS -- TEST 'control_noqr_p8_intel' [34:21, 01:36](1489 MB)
-PASS -- TEST 'control_restart_noqr_p8_intel' [27:53, 01:24](694 MB)
-PASS -- TEST 'control_decomp_p8_intel' [34:21, 01:34](1502 MB)
-PASS -- TEST 'control_2threads_p8_intel' [34:21, 01:59](1595 MB)
-PASS -- TEST 'control_p8_lndp_intel' [34:21, 01:12](1504 MB)
-PASS -- TEST 'control_p8_rrtmgp_intel' [34:04, 01:41](1565 MB)
-PASS -- TEST 'control_p8_mynn_intel' [33:21, 02:07](1518 MB)
-PASS -- TEST 'merra2_thompson_intel' [33:19, 02:49](1508 MB)
-PASS -- TEST 'regional_control_intel' [33:16, 00:53](609 MB)
-PASS -- TEST 'regional_restart_intel' [26:12, 00:17](778 MB)
-PASS -- TEST 'regional_decomp_intel' [33:11, 00:49](607 MB)
-PASS -- TEST 'regional_2threads_intel' [32:18, 01:26](665 MB)
-PASS -- TEST 'regional_noquilt_intel' [31:18, 01:22](1140 MB)
-PASS -- TEST 'regional_netcdf_parallel_intel' [31:07, 01:26](608 MB)
-PASS -- TEST 'regional_2dwrtdecomp_intel' [30:41, 00:21](609 MB)
-PASS -- TEST 'regional_wofs_intel' [30:08, 00:58](1581 MB)
+PASS -- COMPILE 'atm_dyn32_intel' [22:07, 21:33]
+PASS -- TEST 'control_flake_intel' [41:50, 00:24](574 MB)
+PASS -- TEST 'control_CubedSphereGrid_intel' [41:50, 00:48](523 MB)
+PASS -- TEST 'control_CubedSphereGrid_parallel_intel' [41:50, 00:44](529 MB)
+PASS -- TEST 'control_latlon_intel' [41:50, 00:46](522 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_intel' [41:50, 00:51](523 MB)
+PASS -- TEST 'control_c48_intel' [41:49, 00:57](713 MB)
+PASS -- TEST 'control_c48.v2.sfc_intel' [41:49, 00:58](714 MB)
+PASS -- TEST 'control_c192_intel' [41:50, 00:27](636 MB)
+PASS -- TEST 'control_c384_intel' [41:54, 01:59](957 MB)
+PASS -- TEST 'control_c384gdas_intel' [41:54, 02:34](1087 MB)
+PASS -- TEST 'control_stochy_intel' [41:50, 00:27](529 MB)
+PASS -- TEST 'control_stochy_restart_intel' [39:25, 00:58](333 MB)
+PASS -- TEST 'control_lndp_intel' [41:50, 00:31](528 MB)
+PASS -- TEST 'control_iovr4_intel' [41:50, 00:45](522 MB)
+PASS -- TEST 'control_iovr5_intel' [41:50, 00:44](523 MB)
+PASS -- TEST 'control_p8_intel' [41:50, 01:57](1500 MB)
+PASS -- TEST 'control_p8.v2.sfc_intel' [41:50, 02:01](1502 MB)
+PASS -- TEST 'control_p8_ugwpv1_intel' [41:50, 02:04](1507 MB)
+PASS -- TEST 'control_restart_p8_intel' [36:18, 01:22](692 MB)
+PASS -- TEST 'control_noqr_p8_intel' [41:31, 01:38](1504 MB)
+PASS -- TEST 'control_restart_noqr_p8_intel' [36:16, 01:22](700 MB)
+PASS -- TEST 'control_decomp_p8_intel' [41:22, 01:32](1495 MB)
+PASS -- TEST 'control_2threads_p8_intel' [41:22, 01:13](1589 MB)
+PASS -- TEST 'control_p8_lndp_intel' [40:14, 01:19](1511 MB)
+PASS -- TEST 'control_p8_rrtmgp_intel' [39:30, 01:01](1568 MB)
+PASS -- TEST 'control_p8_mynn_intel' [39:26, 01:50](1517 MB)
+PASS -- TEST 'merra2_thompson_intel' [38:23, 01:42](1512 MB)
+PASS -- TEST 'regional_control_intel' [38:19, 00:25](608 MB)
+PASS -- TEST 'regional_restart_intel' [32:26, 00:25](777 MB)
+PASS -- TEST 'regional_decomp_intel' [38:19, 00:10](608 MB)
+PASS -- TEST 'regional_2threads_intel' [38:19, 01:15](665 MB)
+PASS -- TEST 'regional_noquilt_intel' [38:15, 00:33](1154 MB)
+PASS -- TEST 'regional_netcdf_parallel_intel' [38:11, 00:33](609 MB)
+PASS -- TEST 'regional_2dwrtdecomp_intel' [38:08, 00:22](610 MB)
+PASS -- TEST 'regional_wofs_intel' [37:56, 01:05](1579 MB)
 
-PASS -- COMPILE 'rrfs_intel' [24:03, 20:33]
-PASS -- TEST 'rap_control_intel' [44:16, 01:33](920 MB)
-PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [44:17, 01:21](1095 MB)
-PASS -- TEST 'rap_decomp_intel' [44:16, 01:19](919 MB)
-PASS -- TEST 'rap_2threads_intel' [44:16, 01:33](1012 MB)
-PASS -- TEST 'rap_restart_intel' [30:05, 02:12](787 MB)
-PASS -- TEST 'rap_sfcdiff_intel' [44:16, 01:57](912 MB)
-PASS -- TEST 'rap_sfcdiff_decomp_intel' [44:16, 01:43](915 MB)
-PASS -- TEST 'rap_sfcdiff_restart_intel' [29:55, 01:51](787 MB)
-PASS -- TEST 'hrrr_control_intel' [44:16, 01:55](910 MB)
-PASS -- TEST 'hrrr_control_decomp_intel' [44:16, 01:47](910 MB)
-PASS -- TEST 'hrrr_control_2threads_intel' [44:17, 01:59](993 MB)
-PASS -- TEST 'hrrr_control_restart_intel' [37:58, 00:51](744 MB)
-PASS -- TEST 'rrfs_v1beta_intel' [44:16, 01:53](910 MB)
-PASS -- TEST 'rrfs_v1nssl_intel' [44:16, 00:56](1874 MB)
-PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [44:16, 01:17](1862 MB)
+PASS -- COMPILE 'rrfs_intel' [33:32, 32:40]
+PASS -- TEST 'rap_control_intel' [30:25, 01:20](919 MB)
+PASS -- TEST 'regional_spp_sppt_shum_skeb_intel' [30:26, 01:12](1095 MB)
+PASS -- TEST 'rap_decomp_intel' [30:25, 01:40](917 MB)
+PASS -- TEST 'rap_2threads_intel' [30:25, 01:58](1006 MB)
+PASS -- TEST 'rap_restart_intel' [21:45, 01:22](786 MB)
+PASS -- TEST 'rap_sfcdiff_intel' [30:25, 01:21](912 MB)
+PASS -- TEST 'rap_sfcdiff_decomp_intel' [30:25, 01:40](916 MB)
+PASS -- TEST 'rap_sfcdiff_restart_intel' [21:46, 01:50](787 MB)
+PASS -- TEST 'hrrr_control_intel' [30:25, 01:10](909 MB)
+PASS -- TEST 'hrrr_control_decomp_intel' [30:25, 01:07](910 MB)
+PASS -- TEST 'hrrr_control_2threads_intel' [30:26, 01:34](998 MB)
+PASS -- TEST 'hrrr_control_restart_intel' [25:13, 01:05](739 MB)
+PASS -- TEST 'rrfs_v1beta_intel' [30:25, 01:19](912 MB)
+PASS -- TEST 'rrfs_v1nssl_intel' [30:25, 01:09](1881 MB)
+PASS -- TEST 'rrfs_v1nssl_nohailnoccn_intel' [30:01, 00:29](1861 MB)
 
-PASS -- COMPILE 'csawmg_intel' [21:58, 19:57]
-PASS -- TEST 'control_csawmg_intel' [43:17, 01:11](599 MB)
-PASS -- TEST 'control_csawmgt_intel' [43:17, 01:18](598 MB)
-PASS -- TEST 'control_ras_intel' [43:17, 01:15](562 MB)
+PASS -- COMPILE 'csawmg_intel' [18:52, 18:25]
+PASS -- TEST 'control_csawmg_intel' [37:43, 00:45](600 MB)
+PASS -- TEST 'control_csawmgt_intel' [36:59, 00:49](600 MB)
+PASS -- TEST 'control_ras_intel' [36:56, 01:00](560 MB)
 
-PASS -- COMPILE 'wam_intel' [14:40, 11:04]
-PASS -- TEST 'control_wam_intel' [43:20, 01:17](275 MB)
+PASS -- COMPILE 'wam_intel' [16:47, 16:12]
+PASS -- TEST 'control_wam_intel' [36:16, 00:54](272 MB)
 
-PASS -- COMPILE 'atm_faster_dyn32_intel' [13:38, 10:18]
-PASS -- TEST 'control_p8_faster_intel' [44:23, 01:51](1510 MB)
-PASS -- TEST 'regional_control_faster_intel' [44:22, 00:30](610 MB)
+PASS -- COMPILE 'atm_faster_dyn32_intel' [12:38, 12:14]
+PASS -- TEST 'control_p8_faster_intel' [43:44, 02:09](1505 MB)
+PASS -- TEST 'regional_control_faster_intel' [43:43, 00:29](611 MB)
 
-PASS -- COMPILE 'atm_debug_dyn32_intel' [26:10, 22:40]
-PASS -- TEST 'control_CubedSphereGrid_debug_intel' [29:53, 01:15](687 MB)
-PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [29:01, 00:40](691 MB)
-PASS -- TEST 'control_stochy_debug_intel' [28:54, 00:41](690 MB)
-PASS -- TEST 'control_lndp_debug_intel' [27:53, 00:38](694 MB)
-PASS -- TEST 'control_csawmg_debug_intel' [27:52, 00:18](732 MB)
-PASS -- TEST 'control_csawmgt_debug_intel' [27:44, 01:18](730 MB)
-PASS -- TEST 'control_ras_debug_intel' [27:16, 01:05](702 MB)
-PASS -- TEST 'control_diag_debug_intel' [27:08, 00:34](748 MB)
-PASS -- TEST 'control_debug_p8_intel' [27:04, 01:03](1521 MB)
-PASS -- TEST 'regional_debug_intel' [27:00, 01:09](630 MB)
-PASS -- TEST 'rap_control_debug_intel' [26:52, 00:50](1076 MB)
-PASS -- TEST 'hrrr_control_debug_intel' [26:28, 01:13](1069 MB)
-PASS -- TEST 'hrrr_gf_debug_intel' [26:07, 01:04](1073 MB)
-PASS -- TEST 'hrrr_c3_debug_intel' [26:01, 01:01](1073 MB)
-PASS -- TEST 'rap_unified_drag_suite_debug_intel' [25:51, 00:46](1075 MB)
-PASS -- TEST 'rap_diag_debug_intel' [24:38, 01:53](1160 MB)
-PASS -- TEST 'rap_cires_ugwp_debug_intel' [24:15, 00:32](1074 MB)
-PASS -- TEST 'rap_unified_ugwp_debug_intel' [24:10, 00:28](1078 MB)
-PASS -- TEST 'rap_lndp_debug_intel' [24:00, 00:35](1078 MB)
-PASS -- TEST 'rap_progcld_thompson_debug_intel' [23:38, 00:28](1077 MB)
-PASS -- TEST 'rap_noah_debug_intel' [23:12, 01:09](1071 MB)
-PASS -- TEST 'rap_sfcdiff_debug_intel' [22:57, 01:06](1071 MB)
-PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [22:24, 01:19](1074 MB)
-PASS -- TEST 'rrfs_v1beta_debug_intel' [22:17, 00:36](1068 MB)
-PASS -- TEST 'rap_clm_lake_debug_intel' [22:17, 00:29](1075 MB)
-PASS -- TEST 'rap_flake_debug_intel' [22:15, 00:30](1076 MB)
-PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [21:39, 02:02](1077 MB)
+PASS -- COMPILE 'atm_debug_dyn32_intel' [25:07, 23:53]
+PASS -- TEST 'control_CubedSphereGrid_debug_intel' [28:09, 01:21](689 MB)
+PASS -- TEST 'control_wrtGauss_netcdf_parallel_debug_intel' [28:09, 00:29](689 MB)
+PASS -- TEST 'control_stochy_debug_intel' [28:09, 01:01](693 MB)
+PASS -- TEST 'control_lndp_debug_intel' [28:09, 01:17](692 MB)
+PASS -- TEST 'control_csawmg_debug_intel' [28:09, 00:42](730 MB)
+PASS -- TEST 'control_csawmgt_debug_intel' [28:09, 00:44](732 MB)
+PASS -- TEST 'control_ras_debug_intel' [27:26, 01:11](702 MB)
+PASS -- TEST 'control_diag_debug_intel' [27:15, 01:14](746 MB)
+PASS -- TEST 'control_debug_p8_intel' [27:08, 01:11](1521 MB)
+PASS -- TEST 'regional_debug_intel' [25:12, 00:09](629 MB)
+PASS -- TEST 'rap_control_debug_intel' [25:13, 01:00](1077 MB)
+PASS -- TEST 'hrrr_control_debug_intel' [25:09, 01:08](1068 MB)
+PASS -- TEST 'hrrr_gf_debug_intel' [24:19, 01:03](1073 MB)
+PASS -- TEST 'hrrr_c3_debug_intel' [24:11, 01:01](1072 MB)
+PASS -- TEST 'rap_unified_drag_suite_debug_intel' [23:55, 01:00](1075 MB)
+PASS -- TEST 'rap_diag_debug_intel' [23:29, 00:56](1158 MB)
+PASS -- TEST 'rap_cires_ugwp_debug_intel' [23:28, 00:53](1073 MB)
+PASS -- TEST 'rap_unified_ugwp_debug_intel' [23:26, 00:53](1073 MB)
+PASS -- TEST 'rap_lndp_debug_intel' [22:55, 00:56](1078 MB)
+PASS -- TEST 'rap_progcld_thompson_debug_intel' [22:40, 01:00](1077 MB)
+PASS -- TEST 'rap_noah_debug_intel' [22:20, 01:08](1074 MB)
+PASS -- TEST 'rap_sfcdiff_debug_intel' [22:10, 01:00](1077 MB)
+PASS -- TEST 'rap_noah_sfcdiff_cires_ugwp_debug_intel' [22:10, 01:01](1075 MB)
+PASS -- TEST 'rrfs_v1beta_debug_intel' [21:58, 01:03](1067 MB)
+PASS -- TEST 'rap_clm_lake_debug_intel' [21:49, 01:13](1077 MB)
+PASS -- TEST 'rap_flake_debug_intel' [21:45, 00:59](1074 MB)
+PASS -- TEST 'gnv1_c96_no_nest_debug_intel' [21:43, 01:20](1078 MB)
 
-PASS -- COMPILE 'wam_debug_intel' [16:47, 13:14]
-PASS -- TEST 'control_wam_debug_intel' [37:04, 01:12](304 MB)
+PASS -- COMPILE 'wam_debug_intel' [18:53, 18:36]
+PASS -- TEST 'control_wam_debug_intel' [33:59, 00:58](297 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [27:13, 23:47]
-PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [21:40, 01:28](956 MB)
-PASS -- TEST 'rap_control_dyn32_phy32_intel' [21:10, 01:20](790 MB)
-PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [21:05, 01:53](785 MB)
-PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [20:43, 01:17](853 MB)
-PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [20:33, 01:20](837 MB)
-PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [20:13, 02:16](789 MB)
-PASS -- TEST 'rap_restart_dyn32_phy32_intel' [12:24, 01:14](688 MB)
-PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [14:12, 00:22](670 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_intel' [23:12, 22:19]
+PASS -- TEST 'regional_spp_sppt_shum_skeb_dyn32_phy32_intel' [10:11, 01:23](950 MB)
+PASS -- TEST 'rap_control_dyn32_phy32_intel' [10:10, 01:33](789 MB)
+PASS -- TEST 'hrrr_control_dyn32_phy32_intel' [10:10, 01:38](788 MB)
+PASS -- TEST 'rap_2threads_dyn32_phy32_intel' [10:10, 02:02](855 MB)
+PASS -- TEST 'hrrr_control_2threads_dyn32_phy32_intel' [10:11, 01:32](842 MB)
+PASS -- TEST 'hrrr_control_decomp_dyn32_phy32_intel' [10:10, 01:30](786 MB)
+PASS -- TEST 'rap_restart_dyn32_phy32_intel' [02:25, 01:14](687 MB)
+PASS -- TEST 'hrrr_control_restart_dyn32_phy32_intel' [04:57, 00:21](666 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [14:44, 11:23]
-PASS -- TEST 'conus13km_control_intel' [38:05, 00:55](1003 MB)
-PASS -- TEST 'conus13km_2threads_intel' [20:13, 01:13](1011 MB)
-PASS -- TEST 'conus13km_restart_mismatch_intel' [20:04, 01:10](880 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_faster_intel' [18:52, 17:42]
+PASS -- TEST 'conus13km_control_intel' [21:14, 01:07](1006 MB)
+PASS -- TEST 'conus13km_2threads_intel' [17:20, 00:58](1008 MB)
+PASS -- TEST 'conus13km_restart_mismatch_intel' [17:19, 00:49](882 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [13:38, 10:45]
-PASS -- TEST 'rap_control_dyn64_phy32_intel' [38:01, 01:32](811 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_intel' [15:47, 14:44]
+PASS -- TEST 'rap_control_dyn64_phy32_intel' [21:09, 01:32](812 MB)
 
-PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [10:32, 09:06]
-PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [19:45, 00:37](954 MB)
-PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [19:20, 00:54](950 MB)
-PASS -- TEST 'conus13km_debug_intel' [17:58, 00:46](1038 MB)
-PASS -- TEST 'conus13km_debug_qr_intel' [17:30, 00:32](710 MB)
-PASS -- TEST 'conus13km_debug_2threads_intel' [17:13, 00:54](1037 MB)
-PASS -- TEST 'conus13km_radar_tten_debug_intel' [17:11, 00:58](1104 MB)
+PASS -- COMPILE 'rrfs_dyn32_phy32_debug_intel' [05:22, 04:31]
+PASS -- TEST 'rap_control_debug_dyn32_phy32_intel' [36:16, 01:10](954 MB)
+PASS -- TEST 'hrrr_control_debug_dyn32_phy32_intel' [36:15, 00:16](954 MB)
+PASS -- TEST 'conus13km_debug_intel' [35:41, 00:52](1037 MB)
+PASS -- TEST 'conus13km_debug_qr_intel' [35:03, 00:31](708 MB)
+PASS -- TEST 'conus13km_debug_2threads_intel' [34:00, 00:40](1037 MB)
+PASS -- TEST 'conus13km_radar_tten_debug_intel' [33:27, 00:44](1105 MB)
 
-PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [08:29, 07:26]
-PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [17:03, 01:22](992 MB)
+PASS -- COMPILE 'rrfs_dyn64_phy32_debug_intel' [23:11, 22:28]
+PASS -- TEST 'rap_control_dyn64_phy32_debug_intel' [17:26, 01:06](980 MB)
 
-PASS -- COMPILE 'hafsw_intel' [27:11, 25:41]
-PASS -- TEST 'hafs_regional_atm_intel' [15:28, 01:55](618 MB)
-PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [15:27, 00:54](970 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_intel' [15:15, 01:49](664 MB)
-PASS -- TEST 'hafs_regional_atm_wav_intel' [15:13, 01:21](703 MB)
-PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [14:48, 01:30](708 MB)
-PASS -- TEST 'hafs_regional_1nest_atm_intel' [14:16, 01:08](393 MB)
-PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [14:14, 02:13](413 MB)
-PASS -- TEST 'hafs_global_1nest_atm_intel' [14:14, 00:53](281 MB)
-PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [14:16, 02:20](370 MB)
-PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [14:12, 01:34](420 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [14:07, 01:16](423 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [14:02, 01:42](491 MB)
-PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [14:00, 00:30](316 MB)
+PASS -- COMPILE 'hafsw_intel' [23:06, 22:31]
+PASS -- TEST 'hafs_regional_atm_intel' [16:33, 02:15](621 MB)
+PASS -- TEST 'hafs_regional_atm_thompson_gfdlsf_intel' [16:33, 00:35](967 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_intel' [16:31, 01:45](665 MB)
+PASS -- TEST 'hafs_regional_atm_wav_intel' [16:31, 01:48](697 MB)
+PASS -- TEST 'hafs_regional_atm_ocn_wav_intel' [16:32, 01:47](709 MB)
+PASS -- TEST 'hafs_regional_1nest_atm_intel' [16:22, 01:06](389 MB)
+PASS -- TEST 'hafs_regional_telescopic_2nests_atm_intel' [16:19, 02:13](412 MB)
+PASS -- TEST 'hafs_global_1nest_atm_intel' [16:08, 01:25](279 MB)
+PASS -- TEST 'hafs_global_multiple_4nests_atm_intel' [15:50, 02:27](369 MB)
+PASS -- TEST 'hafs_regional_specified_moving_1nest_atm_intel' [15:45, 01:27](414 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_intel' [15:35, 00:52](425 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_intel' [15:26, 00:56](487 MB)
+PASS -- TEST 'hafs_global_storm_following_1nest_atm_intel' [15:20, 01:12](310 MB)
 
-PASS -- COMPILE 'hafsw_debug_intel' [15:49, 14:01]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [16:55, 01:18](501 MB)
+PASS -- COMPILE 'hafsw_debug_intel' [05:21, 04:59]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_debug_intel' [31:21, 00:50](499 MB)
 
-PASS -- COMPILE 'hafsw_faster_intel' [12:50, 11:47]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [13:29, 01:26](526 MB)
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [12:27, 01:30](710 MB)
+PASS -- COMPILE 'hafsw_faster_intel' [22:07, 21:01]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_intel' [14:23, 00:55](527 MB)
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_inline_intel' [14:23, 00:47](711 MB)
 
-PASS -- COMPILE 'hafs_mom6w_intel' [11:46, 11:07]
-PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [12:25, 01:38](709 MB)
+PASS -- COMPILE 'hafs_mom6w_intel' [15:48, 15:24]
+PASS -- TEST 'hafs_regional_storm_following_1nest_atm_ocn_wav_mom6_intel' [18:38, 01:04](713 MB)
 
-PASS -- COMPILE 'hafs_all_intel' [21:08, 20:19]
-PASS -- TEST 'hafs_regional_docn_intel' [12:12, 01:24](663 MB)
-PASS -- TEST 'hafs_regional_docn_oisst_intel' [11:00, 01:57](645 MB)
-PASS -- TEST 'hafs_regional_datm_cdeps_intel' [10:35, 01:03](881 MB)
+PASS -- COMPILE 'hafs_all_intel' [12:41, 12:01]
+PASS -- TEST 'hafs_regional_docn_intel' [18:37, 01:19](661 MB)
+PASS -- TEST 'hafs_regional_docn_oisst_intel' [18:37, 01:14](644 MB)
+PASS -- TEST 'hafs_regional_datm_cdeps_intel' [18:35, 00:44](881 MB)
 
-PASS -- COMPILE 'atml_intel' [25:18, 24:45]
-PASS -- TEST 'control_p8_atmlnd_sbs_intel' [10:20, 01:33](1551 MB)
-PASS -- TEST 'control_p8_atmlnd_intel' [09:33, 02:16](1550 MB)
-PASS -- TEST 'control_restart_p8_atmlnd_intel' [58:48, 00:22](740 MB)
+PASS -- COMPILE 'atml_intel' [13:43, 13:05]
+PASS -- TEST 'control_p8_atmlnd_sbs_intel' [16:42, 01:12](1551 MB)
+PASS -- TEST 'control_p8_atmlnd_intel' [16:42, 02:15](1547 MB)
+PASS -- TEST 'control_restart_p8_atmlnd_intel' [08:54, 00:21](748 MB)
 
-PASS -- COMPILE 'atmaero_intel' [16:56, 16:13]
-PASS -- TEST 'atmaero_control_p8_intel' [09:08, 01:14](2854 MB)
-PASS -- TEST 'atmaero_control_p8_rad_intel' [08:48, 01:35](2909 MB)
-PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [08:18, 01:22](2921 MB)
+PASS -- COMPILE 'atmaero_intel' [18:55, 18:30]
+PASS -- TEST 'atmaero_control_p8_intel' [09:14, 01:42](2848 MB)
+PASS -- TEST 'atmaero_control_p8_rad_intel' [09:14, 01:04](2911 MB)
+PASS -- TEST 'atmaero_control_p8_rad_micro_intel' [09:14, 01:46](2926 MB)
 
-PASS -- COMPILE 'atmaq_intel' [10:40, 09:00]
+PASS -- COMPILE 'atmaq_intel' [19:00, 17:59]
 
-PASS -- COMPILE 'atmaq_debug_intel' [08:29, 08:04]
-PASS -- TEST 'regional_atmaq_debug_intel' [07:33, 01:05](4437 MB)
+PASS -- COMPILE 'atmaq_debug_intel' [07:26, 07:00]
+PASS -- TEST 'regional_atmaq_debug_intel' [19:43, 01:40](4438 MB)
 
 SYNOPSIS:
-Starting Date/Time: 20240313 17:39:39
-Ending Date/Time: 20240313 19:20:18
-Total Time: 01h:41m:22s
+Starting Date/Time: 20240315 18:50:23
+Ending Date/Time: 20240315 20:07:29
+Total Time: 01h:17m:44s
 Compiles Completed: 31/31
 Tests Completed: 157/157
 

--- a/tests/test_changes.list
+++ b/tests/test_changes.list
@@ -1,0 +1,14 @@
+conus13km_control intel
+conus13km_2threads intel
+conus13km_restart_mismatch intel
+conus13km_debug intel
+conus13km_debug_qr intel
+conus13km_debug_2threads intel
+conus13km_radar_tten_debug intel
+conus13km_control gnu
+conus13km_2threads gnu
+conus13km_restart_mismatch gnu
+conus13km_debug gnu
+conus13km_debug_qr gnu
+conus13km_debug_2threads gnu
+conus13km_radar_tten_debug gnu

--- a/tests/test_changes.list
+++ b/tests/test_changes.list
@@ -1,2 +1,0 @@
-cpld_control_c48 intel
-hafs_regional_storm_following_1nest_atm_ocn_wav_mom6 intel


### PR DESCRIPTION
## Commit Queue Requirements:
- [x] Fill out all sections of this template.
- [x] All sub component pull requests have been reviewed by their code managers.
- [x] Run the full Intel+GNU RT suite (compared to current baselines) on either Hera/Derecho/Hercules
    - done before and after the ccpp-physics discussion/code changes
- [x] Commit 'test_changes.list' from previous step
---
## Description:
This PR updates the submodule pointer for the changes in fv3atm, ccpp-framework and ccpp-physics described in the associated PRs below: in ccpp-framework, merge feature/capgen into main; in ccpp-physics and fv3atm, use `flashes per minute` as the unit for lightning threat and then scale to `flashes per 5 minute` in the diagnostic output.

The ccpp-physics and fv3atm change leads to different answers for the `conus13km_*` regression tests (confirmed by @SamuelTrahanNOAA).

### Commit Message:
```
* UFSWM - 
  * AQM - 
  * CDEPS - 
  * CICE - 
  * CMEPS - 
  * CMakeModules - 
  * FV3 - Update submodule pointers for ccpp-framework and ccpp-physics. Change units flashes 5 min-1 to flashes min-1 and update long name to make clear this is per 5 minutes.
    * ccpp-physics - In physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.meta: change units flashes 5 min-1 to flashes min-1 and update long name to make clear this is per 5 minutes.
    * ccpp-framework - Update main from feature/capgen as of 2024-03-08 (includes optional argument updates in feature/capgen). Only commit on top of the merge is https://github.com/NCAR/ccpp-framework/commit/6cdd38a032d89d0f79c66f37f0c7172e59f135cd which is required to parse the metadata in the Unified Forecast System / ccpp-physics (underscores in units, e.g. degree_north).
    * atmos_cubed_sphere - 
  * GOCART - 
  * HYCOM - 
  * MOM6 - 
  * NOAHMP - 
  * WW3 - 
  * stochastic_physics - 
```

### Priority:

* Normal

## Git Tracking

### UFSWM:
This set of PRs is part of the broader issue of transitioning the CCPP Framework code generator from `ccpp_prebuild` to `capgen`. Specifically, this issue is required for https://github.com/NCAR/ccpp-framework/issues/540 which in turn is required to fix the `-check all` issues with unallocated arrays.

### Sub component Pull Requests:

* AQM:
* CDEPS:
* CICE:
* CMEPS:
* CMakeModules:
* FV3 - https://github.com/NOAA-EMC/fv3atm/pull/796
  * ccpp-physics - https://github.com/ufs-community/ccpp-physics/pull/182
  * ccpp-framework - https://github.com/NCAR/ccpp-framework/pull/546
  * atmos_cubed_sphere:
* GOCART:
* HYCOM:
* MOM6:
* NOAHMP:
* WW3:
* stochastic_physics:
* None

### UFSWM Blocking Dependencies:
* None

---
## Changes
### Regression Test Changes (Please commit test_changes.list):
* Baseline changes (thanks to @SamuelTrahanNOAA for retesting after the ccpp-physics discussion):
    * All conus13km tests fail, as expected:
```
[dheinzel@hercules-login-2 tests]$ cat fail_test_conus13km_*
conus13km_control_gnu failed in check_result
conus13km_control_gnu failed in run_test
conus13km_control_intel failed in check_result
conus13km_control_intel failed in run_test
conus13km_debug_2threads_gnu failed in check_result
conus13km_debug_2threads_gnu failed in run_test
conus13km_debug_2threads_intel failed in check_result
conus13km_debug_2threads_intel failed in run_test
conus13km_debug_gnu failed in check_result
conus13km_debug_gnu failed in run_test
conus13km_debug_intel failed in check_result
conus13km_debug_intel failed in run_test
conus13km_debug_qr_gnu failed in check_result
conus13km_debug_qr_gnu failed in run_test
conus13km_debug_qr_intel failed in check_result
conus13km_debug_qr_intel failed in run_test
conus13km_radar_tten_debug_gnu failed in check_result
conus13km_radar_tten_debug_gnu failed in run_test
conus13km_radar_tten_debug_intel failed in check_result
conus13km_radar_tten_debug_intel failed in run_test
```
    * Lightning threat differences are on the order of 1e-7 or less, indicating it all works.
    * All other tests passed.

### Input data Changes:
* None.

### Library Changes/Upgrades:
* No Updates
  
---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [x] Hera
  - [x] Orion
  - [x] Hercules
  - [x] Jet
  - [x] Gaea
  - [x] Derecho
- WCOSS2
  - [x] Dogwood/Cactus
  - [ ] Acorn
- [x] CI
- [ ] opnReqTest (complete task if unnecessary)