### PR TITLE
[production/RRFS.v1] Fix improperly assigned fire emissions for ebb_dcycle==1 for retrospectives (NOT operational!)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = production/RRFS.v1
+  url = https://github.com/jordanschnell/fv3atm
+  branch = ebb_dcycle_fix
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/jordanschnell/fv3atm
-  branch = ebb_dcycle_fix
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = production/RRFS.v1
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/bl_date.conf
+++ b/tests/bl_date.conf
@@ -1,1 +1,1 @@
-export BL_DATE=20240318
+export BL_DATE=20240410

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,31 +1,31 @@
-Fri Apr  5 17:20:22 UTC 2024
+Thu Apr 11 01:37:25 UTC 2024
 Start Regression test
 
-Testing UFSWM Hash: 2d89d4be248f3322186b6f8e4d72013cd69d6b4c
+Testing UFSWM Hash: 0bb1b4aeb04a97e1ac3999af108249f138fe0d94
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 8125331f3ffba7d1a3cdbde52065a42a4962a846 FV3 (heads/ebb_dcycle_fix)
+ 09956cd2e58b80fd53cfa6e8a4dacbb408898839 FV3 (remotes/origin/ebb_dcycle_fix)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 302 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 596 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 591 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 573 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 231 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 592 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 623 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 291 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 595 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 228 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 592 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 572 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 217 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 573 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 599 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 452.190111
-  0: The maximum resident set size (KB)                   = 1122056
+  0: The total amount of wall time                        = 454.668097
+  0: The maximum resident set size (KB)                   = 1100740
 
 Test 001 rap_control_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_spp_sppt_shum_skeb_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 235.649017
-  0: The maximum resident set size (KB)                   = 1327204
+  0: The total amount of wall time                        = 239.209102
+  0: The maximum resident set size (KB)                   = 1295032
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_decomp_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 475.157062
-  0: The maximum resident set size (KB)                   = 1048512
+  0: The total amount of wall time                        = 477.797045
+  0: The maximum resident set size (KB)                   = 1023244
 
 Test 003 rap_decomp_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_2threads_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 424.849236
-  0: The maximum resident set size (KB)                   = 1205132
+  0: The total amount of wall time                        = 428.730535
+  0: The maximum resident set size (KB)                   = 1181456
 
 Test 004 rap_2threads_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_restart_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 231.544816
-  0: The maximum resident set size (KB)                   = 1107120
+  0: The total amount of wall time                        = 232.857638
+  0: The maximum resident set size (KB)                   = 1098048
 
 Test 005 rap_restart_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 449.354067
-  0: The maximum resident set size (KB)                   = 1117792
+  0: The total amount of wall time                        = 453.694440
+  0: The maximum resident set size (KB)                   = 1095388
 
 Test 006 rap_sfcdiff_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_decomp_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 478.352091
-  0: The maximum resident set size (KB)                   = 1061056
+  0: The total amount of wall time                        = 478.904378
+  0: The maximum resident set size (KB)                   = 1030508
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_restart_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 338.713706
-  0: The maximum resident set size (KB)                   = 1134720
+  0: The total amount of wall time                        = 340.296365
+  0: The maximum resident set size (KB)                   = 1117672
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 227.115598
-  0: The maximum resident set size (KB)                   = 1048788
+  0: The total amount of wall time                        = 228.287507
+  0: The maximum resident set size (KB)                   = 1026716
 
 Test 009 hrrr_control_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_decomp_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.274685
-  0: The maximum resident set size (KB)                   = 1035760
+  0: The total amount of wall time                        = 238.120667
+  0: The maximum resident set size (KB)                   = 1022780
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_2threads_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 209.586389
-  0: The maximum resident set size (KB)                   = 1115968
+  0: The total amount of wall time                        = 210.141749
+  0: The maximum resident set size (KB)                   = 1089796
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_restart_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 118.799424
-  0: The maximum resident set size (KB)                   = 1009260
+  0: The total amount of wall time                        = 119.363398
+  0: The maximum resident set size (KB)                   = 989192
 
 Test 012 hrrr_control_restart_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1beta_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1beta_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 443.793978
-  0: The maximum resident set size (KB)                   = 1114040
+  0: The total amount of wall time                        = 450.377141
+  0: The maximum resident set size (KB)                   = 1093640
 
 Test 013 rrfs_v1beta_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1nssl_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 542.739976
-  0: The maximum resident set size (KB)                   = 1988616
+  0: The total amount of wall time                        = 548.917266
+  0: The maximum resident set size (KB)                   = 1980016
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 522.984332
-  0: The maximum resident set size (KB)                   = 2075008
+  0: The total amount of wall time                        = 527.834281
+  0: The maximum resident set size (KB)                   = 2057420
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_p8_faster_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_p8_faster_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 145.780958
-  0: The maximum resident set size (KB)                   = 1639616
+  0: The total amount of wall time                        = 147.389805
+  0: The maximum resident set size (KB)                   = 1612088
 
 Test 016 control_p8_faster_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_control_faster_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_control_faster_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_control_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 269.686488
-  0: The maximum resident set size (KB)                   = 886052
+  0: The total amount of wall time                        = 272.330872
+  0: The maximum resident set size (KB)                   = 862000
 
 Test 017 regional_control_faster_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_CubedSphereGrid_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_CubedSphereGrid_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_CubedSphereGrid_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 149.545571
-  0: The maximum resident set size (KB)                   = 822792
+  0: The total amount of wall time                        = 150.215663
+  0: The maximum resident set size (KB)                   = 783328
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_wrtGauss_netcdf_parallel_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.648529
-  0: The maximum resident set size (KB)                   = 818572
+  0: The total amount of wall time                        = 147.823136
+  0: The maximum resident set size (KB)                   = 784904
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_stochy_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_stochy_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_stochy_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 173.305540
-  0: The maximum resident set size (KB)                   = 823340
+  0: The total amount of wall time                        = 171.015480
+  0: The maximum resident set size (KB)                   = 781416
 
 Test 020 control_stochy_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_lndp_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_lndp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.289796
-  0: The maximum resident set size (KB)                   = 824156
+  0: The total amount of wall time                        = 152.093599
+  0: The maximum resident set size (KB)                   = 783024
 
 Test 021 control_lndp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_csawmg_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_csawmg_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmg_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 240.180091
-  0: The maximum resident set size (KB)                   = 868016
+  0: The total amount of wall time                        = 244.431055
+  0: The maximum resident set size (KB)                   = 830732
 
 Test 022 control_csawmg_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_csawmgt_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_csawmgt_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmgt_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 238.761101
-  0: The maximum resident set size (KB)                   = 874408
+  0: The total amount of wall time                        = 238.369685
+  0: The maximum resident set size (KB)                   = 827812
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_ras_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_ras_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_ras_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.937415
-  0: The maximum resident set size (KB)                   = 835980
+  0: The total amount of wall time                        = 152.178617
+  0: The maximum resident set size (KB)                   = 793908
 
 Test 024 control_ras_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_diag_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_diag_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.153981
-  0: The maximum resident set size (KB)                   = 876072
+  0: The total amount of wall time                        = 157.387070
+  0: The maximum resident set size (KB)                   = 837508
 
 Test 025 control_diag_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_debug_p8_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_debug_p8_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.765904
-  0: The maximum resident set size (KB)                   = 1648144
+  0: The total amount of wall time                        = 161.655988
+  0: The maximum resident set size (KB)                   = 1614152
 
 Test 026 control_debug_p8_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1057.669542
-  0: The maximum resident set size (KB)                   = 886628
+  0: The total amount of wall time                        = 1025.284315
+  0: The maximum resident set size (KB)                   = 814212
 
 Test 027 regional_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.788591
-  0: The maximum resident set size (KB)                   = 1209060
+  0: The total amount of wall time                        = 287.259044
+  0: The maximum resident set size (KB)                   = 1164404
 
 Test 028 rap_control_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.998086
-  0: The maximum resident set size (KB)                   = 1211224
+  0: The total amount of wall time                        = 280.936484
+  0: The maximum resident set size (KB)                   = 1169652
 
 Test 029 hrrr_control_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_gf_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_gf_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_gf_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.093186
-  0: The maximum resident set size (KB)                   = 1217932
+  0: The total amount of wall time                        = 287.049679
+  0: The maximum resident set size (KB)                   = 1177232
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_c3_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_c3_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_c3_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.079750
-  0: The maximum resident set size (KB)                   = 1211600
+  0: The total amount of wall time                        = 286.301830
+  0: The maximum resident set size (KB)                   = 1172096
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_unified_drag_suite_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.878061
-  0: The maximum resident set size (KB)                   = 1209736
+  0: The total amount of wall time                        = 284.939101
+  0: The maximum resident set size (KB)                   = 1140604
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_diag_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_diag_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.253624
-  0: The maximum resident set size (KB)                   = 1293344
+  0: The total amount of wall time                        = 305.322536
+  0: The maximum resident set size (KB)                   = 1256636
 
 Test 033 rap_diag_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_cires_ugwp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.891117
-  0: The maximum resident set size (KB)                   = 1208468
+  0: The total amount of wall time                        = 288.452291
+  0: The maximum resident set size (KB)                   = 1176680
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_unified_ugwp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.825277
-  0: The maximum resident set size (KB)                   = 1208256
+  0: The total amount of wall time                        = 294.234199
+  0: The maximum resident set size (KB)                   = 1171484
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_lndp_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_lndp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.962573
-  0: The maximum resident set size (KB)                   = 1213524
+  0: The total amount of wall time                        = 293.257115
+  0: The maximum resident set size (KB)                   = 1168684
 
 Test 036 rap_lndp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_progcld_thompson_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_progcld_thompson_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_progcld_thompson_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.931961
-  0: The maximum resident set size (KB)                   = 1209788
+  0: The total amount of wall time                        = 283.236391
+  0: The maximum resident set size (KB)                   = 1171904
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_noah_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_noah_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 277.166874
-  0: The maximum resident set size (KB)                   = 1208420
+  0: The total amount of wall time                        = 284.580214
+  0: The maximum resident set size (KB)                   = 1168580
 
 Test 038 rap_noah_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.134581
-  0: The maximum resident set size (KB)                   = 1216948
+  0: The total amount of wall time                        = 284.244623
+  0: The maximum resident set size (KB)                   = 1175328
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_noah_sfcdiff_cires_ugwp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 477.022228
-  0: The maximum resident set size (KB)                   = 1208676
+  0: The total amount of wall time                        = 464.450564
+  0: The maximum resident set size (KB)                   = 1170028
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1beta_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1beta_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.151955
-  0: The maximum resident set size (KB)                   = 1208140
+  0: The total amount of wall time                        = 282.780067
+  0: The maximum resident set size (KB)                   = 1161384
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_clm_lake_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_clm_lake_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_clm_lake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 353.484985
-  0: The maximum resident set size (KB)                   = 1214280
+  0: The total amount of wall time                        = 360.096504
+  0: The maximum resident set size (KB)                   = 1169672
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_flake_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_flake_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_flake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.335783
-  0: The maximum resident set size (KB)                   = 1210764
+  0: The total amount of wall time                        = 286.506105
+  0: The maximum resident set size (KB)                   = 1167428
 
 Test 043 rap_flake_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/gnv1_c96_no_nest_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/gnv1_c96_no_nest_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/gnv1_c96_no_nest_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 492.642454
-  0: The maximum resident set size (KB)                   = 1211976
+  0: The total amount of wall time                        = 509.310915
+  0: The maximum resident set size (KB)                   = 1176852
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 221.392327
-  0: The maximum resident set size (KB)                   = 1184468
+  0: The total amount of wall time                        = 225.914711
+  0: The maximum resident set size (KB)                   = 1169500
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 376.388405
-  0: The maximum resident set size (KB)                   = 1072140
+  0: The total amount of wall time                        = 376.046300
+  0: The maximum resident set size (KB)                   = 1042072
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.609140
-  0: The maximum resident set size (KB)                   = 998632
+  0: The total amount of wall time                        = 192.113336
+  0: The maximum resident set size (KB)                   = 970044
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_2threads_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 354.997900
-  0: The maximum resident set size (KB)                   = 1116088
+  0: The total amount of wall time                        = 357.504843
+  0: The maximum resident set size (KB)                   = 1090988
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_2threads_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 178.666224
-  0: The maximum resident set size (KB)                   = 968128
+  0: The total amount of wall time                        = 179.942501
+  0: The maximum resident set size (KB)                   = 947476
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_decomp_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.432668
-  0: The maximum resident set size (KB)                   = 931540
+  0: The total amount of wall time                        = 204.149406
+  0: The maximum resident set size (KB)                   = 923496
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_restart_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,51 +1510,77 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 282.239013
-  0: The maximum resident set size (KB)                   = 1040096
+  0: The total amount of wall time                        = 279.987049
+  0: The maximum resident set size (KB)                   = 1017036
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_restart_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 100.760429
-  0: The maximum resident set size (KB)                   = 947700
+  0: The total amount of wall time                        = 100.893527
+  0: The maximum resident set size (KB)                   = 928472
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_control_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_control_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......NOT OK
- Comparing sfcf001.nc ............ALT CHECK......NOT OK
- Comparing sfcf002.nc ............ALT CHECK......NOT OK
- Comparing atmf000.nc ............ALT CHECK......NOT OK
- Comparing atmf001.nc ............ALT CHECK......NOT OK
- Comparing atmf002.nc ............ALT CHECK......NOT OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
  Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 114.945972
-  0: The maximum resident set size (KB)                   = 1172704
+  0: The total amount of wall time                        = 109.419504
+  0: The maximum resident set size (KB)                   = 1186408
 
-Test 053 conus13km_control_intel FAIL Tries: 2
+Test 053 conus13km_control_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn64_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_dyn64_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/conus13km_2threads_intel
+Checking test 054 conus13km_2threads_intel results ....
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+
+  0: The total amount of wall time                        = 42.638755
+  0: The maximum resident set size (KB)                   = 1102268
+
+Test 054 conus13km_2threads_intel PASS
+
+
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_restart_mismatch_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/conus13km_restart_mismatch_intel
+Checking test 055 conus13km_restart_mismatch_intel results ....
+ Comparing sfcf002.nc .........OK
+ Comparing atmf002.nc .........OK
+
+  0: The total amount of wall time                        = 61.683388
+  0: The maximum resident set size (KB)                   = 1097484
+
+Test 055 conus13km_restart_mismatch_intel PASS
+
+
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1601,135 +1627,124 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 241.814259
-  0: The maximum resident set size (KB)                   = 997788
+  0: The total amount of wall time                        = 241.564738
+  0: The maximum resident set size (KB)                   = 979324
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_debug_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.138030
-  0: The maximum resident set size (KB)                   = 1092844
+  0: The total amount of wall time                        = 280.436778
+  0: The maximum resident set size (KB)                   = 1049660
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_debug_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.993983
-  0: The maximum resident set size (KB)                   = 1084116
+  0: The total amount of wall time                        = 275.550124
+  0: The maximum resident set size (KB)                   = 1040212
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......NOT OK
- Comparing sfcf001.nc ............ALT CHECK......NOT OK
- Comparing atmf000.nc ............ALT CHECK......NOT OK
- Comparing atmf001.nc ............ALT CHECK......NOT OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
  Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
+ Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 828.629654
-  0: The maximum resident set size (KB)                   = 1242336
+  0: The total amount of wall time                        = 803.087524
+  0: The maximum resident set size (KB)                   = 1184036
 
-Test 059 conus13km_debug_intel FAIL Tries: 2
+Test 059 conus13km_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_debug_qr_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......NOT OK
- Comparing sfcf001.nc ............ALT CHECK......NOT OK
- Comparing atmf000.nc ............ALT CHECK......NOT OK
- Comparing atmf001.nc ............ALT CHECK......NOT OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
- Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
+ Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 838.094692
-  0: The maximum resident set size (KB)                   = 884572
+  0: The total amount of wall time                        = 832.158053
+  0: The maximum resident set size (KB)                   = 886592
 
-Test 060 conus13km_debug_qr_intel FAIL Tries: 2
+Test 060 conus13km_debug_qr_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_debug_2threads_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......NOT OK
- Comparing sfcf001.nc ............ALT CHECK......NOT OK
- Comparing atmf000.nc ............ALT CHECK......NOT OK
- Comparing atmf001.nc ............ALT CHECK......NOT OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 451.518030
-  0: The maximum resident set size (KB)                   = 1168312
+  0: The total amount of wall time                        = 462.072122
+  0: The maximum resident set size (KB)                   = 1102464
 
-Test 061 conus13km_debug_2threads_intel FAIL Tries: 2
+Test 061 conus13km_debug_2threads_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_radar_tten_debug_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_radar_tten_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_radar_tten_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......NOT OK
- Comparing sfcf001.nc ............ALT CHECK......NOT OK
- Comparing atmf000.nc ............ALT CHECK......NOT OK
- Comparing atmf001.nc ............ALT CHECK......NOT OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 831.583075
-  0: The maximum resident set size (KB)                   = 1288092
+  0: The total amount of wall time                        = 805.976565
+  0: The maximum resident set size (KB)                   = 1249980
 
-Test 062 conus13km_radar_tten_debug_intel FAIL Tries: 2
+Test 062 conus13km_radar_tten_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn64_phy32_intel
-working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_dyn64_phy32_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_2009611/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.128196
-  0: The maximum resident set size (KB)                   = 1136028
+  0: The total amount of wall time                        = 291.649833
+  0: The maximum resident set size (KB)                   = 1097240
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
-FAILED TESTS: 
-053 conus13km_control_intel failed in check_result
-conus13km_control_intel 053 failed in run_test
-059 conus13km_debug_intel failed in check_result
-conus13km_debug_intel 059 failed in run_test
-060 conus13km_debug_qr_intel failed in check_result
-conus13km_debug_qr_intel 060 failed in run_test
-061 conus13km_debug_2threads_intel failed in check_result
-conus13km_debug_2threads_intel 061 failed in run_test
-062 conus13km_radar_tten_debug_intel failed in check_result
-conus13km_radar_tten_debug_intel 062 failed in run_test
 
-REGRESSION TEST FAILED
-Fri Apr  5 17:59:16 UTC 2024
-Elapsed time: 00h:38m:54s. Have a nice day!
+REGRESSION TEST WAS SUCCESSFUL
+Thu Apr 11 02:11:47 UTC 2024
+Elapsed time: 00h:34m:22s. Have a nice day!

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,31 +1,31 @@
-Mon Apr  1 18:58:18 UTC 2024
+Fri Apr  5 17:20:22 UTC 2024
 Start Regression test
 
-Testing UFSWM Hash: f43f5c75b7067f12bfd4020949d1c25a8cb8e37f
+Testing UFSWM Hash: 2d89d4be248f3322186b6f8e4d72013cd69d6b4c
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- ef553376b00b6e67201a9ae3504d7985ba381336 FV3 (remotes/origin/rrfs_v1_write_netcdf_hangs)
+ 8125331f3ffba7d1a3cdbde52065a42a4962a846 FV3 (heads/ebb_dcycle_fix)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 312 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 610 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 233 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 583 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 576 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 225 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 586 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 606 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 302 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 596 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 235 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 591 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 573 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 231 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 592 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 623 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_control_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 451.497231
-  0: The maximum resident set size (KB)                   = 1123840
+  0: The total amount of wall time                        = 452.190111
+  0: The maximum resident set size (KB)                   = 1122056
 
 Test 001 rap_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/regional_spp_sppt_shum_skeb_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 239.506562
-  0: The maximum resident set size (KB)                   = 1322252
+  0: The total amount of wall time                        = 235.649017
+  0: The maximum resident set size (KB)                   = 1327204
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_decomp_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 475.953935
-  0: The maximum resident set size (KB)                   = 1048380
+  0: The total amount of wall time                        = 475.157062
+  0: The maximum resident set size (KB)                   = 1048512
 
 Test 003 rap_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_2threads_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 425.535409
-  0: The maximum resident set size (KB)                   = 1197444
+  0: The total amount of wall time                        = 424.849236
+  0: The maximum resident set size (KB)                   = 1205132
 
 Test 004 rap_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_restart_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.444086
-  0: The maximum resident set size (KB)                   = 1090432
+  0: The total amount of wall time                        = 231.544816
+  0: The maximum resident set size (KB)                   = 1107120
 
 Test 005 rap_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_sfcdiff_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 450.558424
-  0: The maximum resident set size (KB)                   = 1121504
+  0: The total amount of wall time                        = 449.354067
+  0: The maximum resident set size (KB)                   = 1117792
 
 Test 006 rap_sfcdiff_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_sfcdiff_decomp_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 477.381560
-  0: The maximum resident set size (KB)                   = 1056588
+  0: The total amount of wall time                        = 478.352091
+  0: The maximum resident set size (KB)                   = 1061056
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_sfcdiff_restart_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 336.871626
-  0: The maximum resident set size (KB)                   = 1145332
+  0: The total amount of wall time                        = 338.713706
+  0: The maximum resident set size (KB)                   = 1134720
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.987115
-  0: The maximum resident set size (KB)                   = 1051064
+  0: The total amount of wall time                        = 227.115598
+  0: The maximum resident set size (KB)                   = 1048788
 
 Test 009 hrrr_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_decomp_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.681575
-  0: The maximum resident set size (KB)                   = 1036080
+  0: The total amount of wall time                        = 235.274685
+  0: The maximum resident set size (KB)                   = 1035760
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_2threads_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 209.457566
-  0: The maximum resident set size (KB)                   = 1112624
+  0: The total amount of wall time                        = 209.586389
+  0: The maximum resident set size (KB)                   = 1115968
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_restart_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 119.937103
-  0: The maximum resident set size (KB)                   = 1009828
+  0: The total amount of wall time                        = 118.799424
+  0: The maximum resident set size (KB)                   = 1009260
 
 Test 012 hrrr_control_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1beta_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rrfs_v1beta_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 446.557544
-  0: The maximum resident set size (KB)                   = 1107460
+  0: The total amount of wall time                        = 443.793978
+  0: The maximum resident set size (KB)                   = 1114040
 
 Test 013 rrfs_v1beta_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rrfs_v1nssl_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 543.912066
-  0: The maximum resident set size (KB)                   = 1989444
+  0: The total amount of wall time                        = 542.739976
+  0: The maximum resident set size (KB)                   = 1988616
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 529.066403
-  0: The maximum resident set size (KB)                   = 2062292
+  0: The total amount of wall time                        = 522.984332
+  0: The maximum resident set size (KB)                   = 2075008
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_p8_faster_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 147.246072
-  0: The maximum resident set size (KB)                   = 1631024
+  0: The total amount of wall time                        = 145.780958
+  0: The maximum resident set size (KB)                   = 1639616
 
 Test 016 control_p8_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_control_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/regional_control_faster_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 271.851340
-  0: The maximum resident set size (KB)                   = 886500
+  0: The total amount of wall time                        = 269.686488
+  0: The maximum resident set size (KB)                   = 886052
 
 Test 017 regional_control_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_CubedSphereGrid_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_CubedSphereGrid_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 149.959893
-  0: The maximum resident set size (KB)                   = 822084
+  0: The total amount of wall time                        = 149.545571
+  0: The maximum resident set size (KB)                   = 822792
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.446203
-  0: The maximum resident set size (KB)                   = 824668
+  0: The total amount of wall time                        = 150.648529
+  0: The maximum resident set size (KB)                   = 818572
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_stochy_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_stochy_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.738915
-  0: The maximum resident set size (KB)                   = 821388
+  0: The total amount of wall time                        = 173.305540
+  0: The maximum resident set size (KB)                   = 823340
 
 Test 020 control_stochy_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_lndp_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.054951
-  0: The maximum resident set size (KB)                   = 821520
+  0: The total amount of wall time                        = 152.289796
+  0: The maximum resident set size (KB)                   = 824156
 
 Test 021 control_lndp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_csawmg_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_csawmg_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.085734
-  0: The maximum resident set size (KB)                   = 873968
+  0: The total amount of wall time                        = 240.180091
+  0: The maximum resident set size (KB)                   = 868016
 
 Test 022 control_csawmg_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_csawmgt_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_csawmgt_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.530448
-  0: The maximum resident set size (KB)                   = 877976
+  0: The total amount of wall time                        = 238.761101
+  0: The maximum resident set size (KB)                   = 874408
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_ras_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_ras_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.354041
-  0: The maximum resident set size (KB)                   = 841188
+  0: The total amount of wall time                        = 155.937415
+  0: The maximum resident set size (KB)                   = 835980
 
 Test 024 control_ras_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_diag_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.016346
-  0: The maximum resident set size (KB)                   = 875976
+  0: The total amount of wall time                        = 160.153981
+  0: The maximum resident set size (KB)                   = 876072
 
 Test 025 control_diag_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/control_debug_p8_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.183383
-  0: The maximum resident set size (KB)                   = 1652520
+  0: The total amount of wall time                        = 160.765904
+  0: The maximum resident set size (KB)                   = 1648144
 
 Test 026 control_debug_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/regional_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1002.600785
-  0: The maximum resident set size (KB)                   = 860424
+  0: The total amount of wall time                        = 1057.669542
+  0: The maximum resident set size (KB)                   = 886628
 
 Test 027 regional_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_control_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.084990
-  0: The maximum resident set size (KB)                   = 1211480
+  0: The total amount of wall time                        = 288.788591
+  0: The maximum resident set size (KB)                   = 1209060
 
 Test 028 rap_control_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.084634
-  0: The maximum resident set size (KB)                   = 1208008
+  0: The total amount of wall time                        = 278.998086
+  0: The maximum resident set size (KB)                   = 1211224
 
 Test 029 hrrr_control_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_gf_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_gf_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.388905
-  0: The maximum resident set size (KB)                   = 1213400
+  0: The total amount of wall time                        = 284.093186
+  0: The maximum resident set size (KB)                   = 1217932
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_c3_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_c3_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.769959
-  0: The maximum resident set size (KB)                   = 1213612
+  0: The total amount of wall time                        = 286.079750
+  0: The maximum resident set size (KB)                   = 1211600
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_unified_drag_suite_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.360140
-  0: The maximum resident set size (KB)                   = 1211180
+  0: The total amount of wall time                        = 285.878061
+  0: The maximum resident set size (KB)                   = 1209736
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_diag_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 301.154000
-  0: The maximum resident set size (KB)                   = 1295708
+  0: The total amount of wall time                        = 296.253624
+  0: The maximum resident set size (KB)                   = 1293344
 
 Test 033 rap_diag_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.190533
-  0: The maximum resident set size (KB)                   = 1219200
+  0: The total amount of wall time                        = 289.891117
+  0: The maximum resident set size (KB)                   = 1208468
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_unified_ugwp_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.164581
-  0: The maximum resident set size (KB)                   = 1216256
+  0: The total amount of wall time                        = 290.825277
+  0: The maximum resident set size (KB)                   = 1208256
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_lndp_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.680357
-  0: The maximum resident set size (KB)                   = 1210540
+  0: The total amount of wall time                        = 285.962573
+  0: The maximum resident set size (KB)                   = 1213524
 
 Test 036 rap_lndp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_progcld_thompson_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_progcld_thompson_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.656339
-  0: The maximum resident set size (KB)                   = 1209072
+  0: The total amount of wall time                        = 283.931961
+  0: The maximum resident set size (KB)                   = 1209788
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_noah_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_noah_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.124481
-  0: The maximum resident set size (KB)                   = 1214312
+  0: The total amount of wall time                        = 277.166874
+  0: The maximum resident set size (KB)                   = 1208420
 
 Test 038 rap_noah_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_sfcdiff_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.402117
-  0: The maximum resident set size (KB)                   = 1210536
+  0: The total amount of wall time                        = 285.134581
+  0: The maximum resident set size (KB)                   = 1216948
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 474.521169
-  0: The maximum resident set size (KB)                   = 1211604
+  0: The total amount of wall time                        = 477.022228
+  0: The maximum resident set size (KB)                   = 1208676
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1beta_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rrfs_v1beta_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 286.692561
-  0: The maximum resident set size (KB)                   = 1208284
+  0: The total amount of wall time                        = 278.151955
+  0: The maximum resident set size (KB)                   = 1208140
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_clm_lake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_clm_lake_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 354.189295
-  0: The maximum resident set size (KB)                   = 1212240
+  0: The total amount of wall time                        = 353.484985
+  0: The maximum resident set size (KB)                   = 1214280
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_flake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_flake_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.207798
-  0: The maximum resident set size (KB)                   = 1217120
+  0: The total amount of wall time                        = 281.335783
+  0: The maximum resident set size (KB)                   = 1210764
 
 Test 043 rap_flake_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/gnv1_c96_no_nest_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/gnv1_c96_no_nest_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 492.897083
-  0: The maximum resident set size (KB)                   = 1216572
+  0: The total amount of wall time                        = 492.642454
+  0: The maximum resident set size (KB)                   = 1211976
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 220.963614
-  0: The maximum resident set size (KB)                   = 1186316
+  0: The total amount of wall time                        = 221.392327
+  0: The maximum resident set size (KB)                   = 1184468
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 372.712552
-  0: The maximum resident set size (KB)                   = 1062452
+  0: The total amount of wall time                        = 376.388405
+  0: The maximum resident set size (KB)                   = 1072140
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.798922
-  0: The maximum resident set size (KB)                   = 997928
+  0: The total amount of wall time                        = 191.609140
+  0: The maximum resident set size (KB)                   = 998632
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_2threads_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 354.758172
-  0: The maximum resident set size (KB)                   = 1111852
+  0: The total amount of wall time                        = 354.997900
+  0: The maximum resident set size (KB)                   = 1116088
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 178.531656
-  0: The maximum resident set size (KB)                   = 971932
+  0: The total amount of wall time                        = 178.666224
+  0: The maximum resident set size (KB)                   = 968128
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 203.482154
-  0: The maximum resident set size (KB)                   = 946100
+  0: The total amount of wall time                        = 203.432668
+  0: The maximum resident set size (KB)                   = 931540
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_restart_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,77 +1510,51 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 278.449981
-  0: The maximum resident set size (KB)                   = 1042716
+  0: The total amount of wall time                        = 282.239013
+  0: The maximum resident set size (KB)                   = 1040096
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.495658
-  0: The maximum resident set size (KB)                   = 932652
+  0: The total amount of wall time                        = 100.760429
+  0: The maximum resident set size (KB)                   = 947700
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/conus13km_control_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing sfcf002.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
- Comparing atmf002.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......NOT OK
+ Comparing sfcf001.nc ............ALT CHECK......NOT OK
+ Comparing sfcf002.nc ............ALT CHECK......NOT OK
+ Comparing atmf000.nc ............ALT CHECK......NOT OK
+ Comparing atmf001.nc ............ALT CHECK......NOT OK
+ Comparing atmf002.nc ............ALT CHECK......NOT OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
  Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
+ Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......NOT OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 108.146444
-  0: The maximum resident set size (KB)                   = 1201688
+  0: The total amount of wall time                        = 114.945972
+  0: The maximum resident set size (KB)                   = 1172704
 
-Test 053 conus13km_control_intel PASS
-
-
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/conus13km_2threads_intel
-Checking test 054 conus13km_2threads_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
-
-  0: The total amount of wall time                        = 41.586097
-  0: The maximum resident set size (KB)                   = 1123152
-
-Test 054 conus13km_2threads_intel PASS
-
-
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_restart_mismatch_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/conus13km_restart_mismatch_intel
-Checking test 055 conus13km_restart_mismatch_intel results ....
- Comparing sfcf002.nc .........OK
- Comparing atmf002.nc .........OK
-
-  0: The total amount of wall time                        = 62.205465
-  0: The maximum resident set size (KB)                   = 1112824
-
-Test 055 conus13km_restart_mismatch_intel PASS
+Test 053 conus13km_control_intel FAIL Tries: 2
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_control_dyn64_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1627,124 +1601,135 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 241.444212
-  0: The maximum resident set size (KB)                   = 995028
+  0: The total amount of wall time                        = 241.814259
+  0: The maximum resident set size (KB)                   = 997788
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 502.377109
-  0: The maximum resident set size (KB)                   = 1092876
+  0: The total amount of wall time                        = 281.138030
+  0: The maximum resident set size (KB)                   = 1092844
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 276.625910
-  0: The maximum resident set size (KB)                   = 1089188
+  0: The total amount of wall time                        = 272.993983
+  0: The maximum resident set size (KB)                   = 1084116
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/conus13km_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......NOT OK
+ Comparing sfcf001.nc ............ALT CHECK......NOT OK
+ Comparing atmf000.nc ............ALT CHECK......NOT OK
+ Comparing atmf001.nc ............ALT CHECK......NOT OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
  Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/20210512.170000.phy_data.nc .........OK
+ Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......NOT OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 835.109007
-  0: The maximum resident set size (KB)                   = 1268336
+  0: The total amount of wall time                        = 828.629654
+  0: The maximum resident set size (KB)                   = 1242336
 
-Test 059 conus13km_debug_intel PASS
+Test 059 conus13km_debug_intel FAIL Tries: 2
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/conus13km_debug_qr_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......NOT OK
+ Comparing sfcf001.nc ............ALT CHECK......NOT OK
+ Comparing atmf000.nc ............ALT CHECK......NOT OK
+ Comparing atmf001.nc ............ALT CHECK......NOT OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.fv_srf_wnd.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......OK
- Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
+ Comparing RESTART/20210512.170000.fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
+ Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......NOT OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 833.017999
-  0: The maximum resident set size (KB)                   = 921548
+  0: The total amount of wall time                        = 838.094692
+  0: The maximum resident set size (KB)                   = 884572
 
-Test 060 conus13km_debug_qr_intel PASS
+Test 060 conus13km_debug_qr_intel FAIL Tries: 2
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/conus13km_debug_2threads_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......NOT OK
+ Comparing sfcf001.nc ............ALT CHECK......NOT OK
+ Comparing atmf000.nc ............ALT CHECK......NOT OK
+ Comparing atmf001.nc ............ALT CHECK......NOT OK
 
-  0: The total amount of wall time                        = 458.887836
-  0: The maximum resident set size (KB)                   = 1163508
+  0: The total amount of wall time                        = 451.518030
+  0: The maximum resident set size (KB)                   = 1168312
 
-Test 061 conus13km_debug_2threads_intel PASS
+Test 061 conus13km_debug_2threads_intel FAIL Tries: 2
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_radar_tten_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/conus13km_radar_tten_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
- Comparing sfcf000.nc .........OK
- Comparing sfcf001.nc .........OK
- Comparing atmf000.nc .........OK
- Comparing atmf001.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......NOT OK
+ Comparing sfcf001.nc ............ALT CHECK......NOT OK
+ Comparing atmf000.nc ............ALT CHECK......NOT OK
+ Comparing atmf001.nc ............ALT CHECK......NOT OK
 
-  0: The total amount of wall time                        = 836.234226
-  0: The maximum resident set size (KB)                   = 1279008
+  0: The total amount of wall time                        = 831.583075
+  0: The maximum resident set size (KB)                   = 1288092
 
-Test 062 conus13km_radar_tten_debug_intel PASS
+Test 062 conus13km_radar_tten_debug_intel FAIL Tries: 2
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_71580/rap_control_dyn64_phy32_debug_intel
+working dir  = /scratch1/BMC/gmtb/Grant.Firl/stmp2/Grant.Firl/FV3_RT/rt_2262449/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.924119
-  0: The maximum resident set size (KB)                   = 1140396
+  0: The total amount of wall time                        = 288.128196
+  0: The maximum resident set size (KB)                   = 1136028
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
+FAILED TESTS: 
+053 conus13km_control_intel failed in check_result
+conus13km_control_intel 053 failed in run_test
+059 conus13km_debug_intel failed in check_result
+conus13km_debug_intel 059 failed in run_test
+060 conus13km_debug_qr_intel failed in check_result
+conus13km_debug_qr_intel 060 failed in run_test
+061 conus13km_debug_2threads_intel failed in check_result
+conus13km_debug_2threads_intel 061 failed in run_test
+062 conus13km_radar_tten_debug_intel failed in check_result
+conus13km_radar_tten_debug_intel 062 failed in run_test
 
-REGRESSION TEST WAS SUCCESSFUL
-Mon Apr  1 19:32:46 UTC 2024
-Elapsed time: 00h:34m:28s. Have a nice day!
+REGRESSION TEST FAILED
+Fri Apr  5 17:59:16 UTC 2024
+Elapsed time: 00h:38m:54s. Have a nice day!

--- a/tests/logs/RegressionTests_hercules.log
+++ b/tests/logs/RegressionTests_hercules.log
@@ -1,38 +1,38 @@
-Mon Apr  1 12:28:56 CDT 2024
+Wed Apr 10 13:36:17 CDT 2024
 Start Regression test
 
-Testing UFSWM Hash: 9b28016df72839141f8a367650647300a9f3c095
+Testing UFSWM Hash: 19ad8451fb3f1c34a503ebecef9e8e209247cd98
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- ef553376b00b6e67201a9ae3504d7985ba381336 FV3 (remotes/origin/rrfs_v1_write_netcdf_hangs)
+ 09956cd2e58b80fd53cfa6e8a4dacbb408898839 FV3 (remotes/origin/ebb_dcycle_fix)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 307 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 578 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 260 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 574 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 435 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 260 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 446 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 456 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 303 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 567 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 263 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 541 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 431 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 263 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 436 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 453 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_control_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_control_intel
 Checking test 001 rap_control_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -72,39 +72,39 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 382.639483
-  0: The maximum resident set size (KB)                   = 1204908
+  0: The total amount of wall time                        = 397.843809
+  0: The maximum resident set size (KB)                   = 1205372
 
 Test 001 rap_control_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/regional_spp_sppt_shum_skeb_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf001.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf001.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
  Comparing PRSLEV.GrbF00 .........OK
  Comparing PRSLEV.GrbF01 .........OK
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 216.335642
-  0: The maximum resident set size (KB)                   = 1419456
+  0: The total amount of wall time                        = 221.036946
+  0: The maximum resident set size (KB)                   = 1473560
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_decomp_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -144,21 +144,21 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 407.505456
-  0: The maximum resident set size (KB)                   = 1133012
+  0: The total amount of wall time                        = 406.953839
+  0: The maximum resident set size (KB)                   = 1144620
 
 Test 003 rap_decomp_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_2threads_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -198,17 +198,17 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 365.183515
-  0: The maximum resident set size (KB)                   = 1387772
+  0: The total amount of wall time                        = 371.764762
+  0: The maximum resident set size (KB)                   = 1390560
 
 Test 004 rap_2threads_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_restart_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF24 .........OK
  Comparing RESTART/20210323.060000.coupler.res .........OK
@@ -244,21 +244,21 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 195.260751
-  0: The maximum resident set size (KB)                   = 1133668
+  0: The total amount of wall time                        = 210.257990
+  0: The maximum resident set size (KB)                   = 1145652
 
 Test 005 rap_restart_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_sfcdiff_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -298,21 +298,21 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 384.164344
-  0: The maximum resident set size (KB)                   = 1225076
+  0: The total amount of wall time                        = 385.793027
+  0: The maximum resident set size (KB)                   = 1197464
 
 Test 006 rap_sfcdiff_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_sfcdiff_decomp_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -352,17 +352,17 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 416.908823
-  0: The maximum resident set size (KB)                   = 1153020
+  0: The total amount of wall time                        = 407.010929
+  0: The maximum resident set size (KB)                   = 1184292
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_sfcdiff_restart_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210323.060000.coupler.res .........OK
@@ -398,21 +398,21 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 284.851339
-  0: The maximum resident set size (KB)                   = 1195540
+  0: The total amount of wall time                        = 289.974605
+  0: The maximum resident set size (KB)                   = 1197900
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -452,21 +452,21 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 196.547583
-  0: The maximum resident set size (KB)                   = 1091628
+  0: The total amount of wall time                        = 203.949028
+  0: The maximum resident set size (KB)                   = 1076244
 
 Test 009 hrrr_control_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_decomp_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -506,21 +506,21 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 197.687350
-  0: The maximum resident set size (KB)                   = 1042896
+  0: The total amount of wall time                        = 199.306109
+  0: The maximum resident set size (KB)                   = 1047532
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_2threads_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -560,35 +560,35 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.076520
-  0: The maximum resident set size (KB)                   = 1120852
+  0: The total amount of wall time                        = 185.450701
+  0: The maximum resident set size (KB)                   = 1128860
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_restart_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 104.325490
-  0: The maximum resident set size (KB)                   = 1017572
+  0: The total amount of wall time                        = 108.285258
+  0: The maximum resident set size (KB)                   = 1017836
 
 Test 012 hrrr_control_restart_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1beta_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rrfs_v1beta_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -628,21 +628,21 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 372.530372
-  0: The maximum resident set size (KB)                   = 1199528
+  0: The total amount of wall time                        = 381.462255
+  0: The maximum resident set size (KB)                   = 1198888
 
 Test 013 rrfs_v1beta_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rrfs_v1nssl_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -650,21 +650,21 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 454.251092
-  0: The maximum resident set size (KB)                   = 2003780
+  0: The total amount of wall time                        = 452.935567
+  0: The maximum resident set size (KB)                   = 2008832
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -672,21 +672,21 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 442.634144
-  0: The maximum resident set size (KB)                   = 2168316
+  0: The total amount of wall time                        = 490.832752
+  0: The maximum resident set size (KB)                   = 2157500
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_p8_faster_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_p8_faster_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_p8_faster_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -726,32 +726,32 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.630275
-  0: The maximum resident set size (KB)                   = 1650364
+  0: The total amount of wall time                        = 130.947608
+  0: The maximum resident set size (KB)                   = 1637604
 
 Test 016 control_p8_faster_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_control_faster_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/regional_control_faster_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_control_faster_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf006.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf006.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF00 .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 235.553586
-  0: The maximum resident set size (KB)                   = 991952
+  0: The total amount of wall time                        = 244.763443
+  0: The maximum resident set size (KB)                   = 992732
 
 Test 017 regional_control_faster_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_CubedSphereGrid_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_CubedSphereGrid_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_CubedSphereGrid_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,371 +778,371 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 124.750396
-  0: The maximum resident set size (KB)                   = 823884
+  0: The total amount of wall time                        = 125.179056
+  0: The maximum resident set size (KB)                   = 820780
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_wrtGauss_netcdf_parallel_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
+ Comparing sfcf001.nc .........OK
  Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 126.715819
-  0: The maximum resident set size (KB)                   = 827444
+  0: The total amount of wall time                        = 127.090122
+  0: The maximum resident set size (KB)                   = 834320
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_stochy_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_stochy_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_stochy_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 142.659256
-  0: The maximum resident set size (KB)                   = 834408
+  0: The total amount of wall time                        = 141.022600
+  0: The maximum resident set size (KB)                   = 843384
 
 Test 020 control_stochy_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_lndp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_lndp_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_lndp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 128.030407
-  0: The maximum resident set size (KB)                   = 836004
+  0: The total amount of wall time                        = 127.986688
+  0: The maximum resident set size (KB)                   = 838848
 
 Test 021 control_lndp_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_csawmg_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_csawmg_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmg_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 198.260933
-  0: The maximum resident set size (KB)                   = 878192
+  0: The total amount of wall time                        = 197.492823
+  0: The maximum resident set size (KB)                   = 885020
 
 Test 022 control_csawmg_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_csawmgt_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_csawmgt_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmgt_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.114945
-  0: The maximum resident set size (KB)                   = 875164
+  0: The total amount of wall time                        = 195.130616
+  0: The maximum resident set size (KB)                   = 876896
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_ras_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_ras_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_ras_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 130.436815
-  0: The maximum resident set size (KB)                   = 842560
+  0: The total amount of wall time                        = 129.611973
+  0: The maximum resident set size (KB)                   = 836704
 
 Test 024 control_ras_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_diag_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_diag_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_diag_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 134.486597
-  0: The maximum resident set size (KB)                   = 897836
+  0: The total amount of wall time                        = 133.212419
+  0: The maximum resident set size (KB)                   = 893100
 
 Test 025 control_diag_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/control_debug_p8_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/control_debug_p8_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_debug_p8_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 136.987105
-  0: The maximum resident set size (KB)                   = 1663800
+  0: The total amount of wall time                        = 136.250254
+  0: The maximum resident set size (KB)                   = 1662792
 
 Test 026 control_debug_p8_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/regional_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf001.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf001.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 832.474127
-  0: The maximum resident set size (KB)                   = 900400
+  0: The total amount of wall time                        = 851.177525
+  0: The maximum resident set size (KB)                   = 901700
 
 Test 027 regional_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_control_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.270282
-  0: The maximum resident set size (KB)                   = 1222476
+  0: The total amount of wall time                        = 244.376246
+  0: The maximum resident set size (KB)                   = 1220952
 
 Test 028 rap_control_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.005759
-  0: The maximum resident set size (KB)                   = 1213764
+  0: The total amount of wall time                        = 235.492314
+  0: The maximum resident set size (KB)                   = 1217424
 
 Test 029 hrrr_control_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_gf_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_gf_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_gf_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 235.147281
-  0: The maximum resident set size (KB)                   = 1227448
+  0: The total amount of wall time                        = 242.980946
+  0: The maximum resident set size (KB)                   = 1225192
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_c3_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_c3_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_c3_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 241.198575
-  0: The maximum resident set size (KB)                   = 1222216
+  0: The total amount of wall time                        = 239.828903
+  0: The maximum resident set size (KB)                   = 1216576
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_unified_drag_suite_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 237.247894
-  0: The maximum resident set size (KB)                   = 1223040
+  0: The total amount of wall time                        = 242.819353
+  0: The maximum resident set size (KB)                   = 1220340
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_diag_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_diag_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_diag_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 244.204974
-  0: The maximum resident set size (KB)                   = 1301452
+  0: The total amount of wall time                        = 253.231193
+  0: The maximum resident set size (KB)                   = 1312648
 
 Test 033 rap_diag_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_cires_ugwp_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 238.026731
-  0: The maximum resident set size (KB)                   = 1222820
+  0: The total amount of wall time                        = 281.306742
+  0: The maximum resident set size (KB)                   = 1217496
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_unified_ugwp_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.200731
-  0: The maximum resident set size (KB)                   = 1214848
+  0: The total amount of wall time                        = 250.581438
+  0: The maximum resident set size (KB)                   = 1224032
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_lndp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_lndp_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_lndp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.095021
-  0: The maximum resident set size (KB)                   = 1211776
+  0: The total amount of wall time                        = 240.391425
+  0: The maximum resident set size (KB)                   = 1216624
 
 Test 036 rap_lndp_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_progcld_thompson_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_progcld_thompson_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_progcld_thompson_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.933229
-  0: The maximum resident set size (KB)                   = 1230072
+  0: The total amount of wall time                        = 238.611684
+  0: The maximum resident set size (KB)                   = 1228736
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_noah_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_noah_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.038215
-  0: The maximum resident set size (KB)                   = 1211556
+  0: The total amount of wall time                        = 241.569116
+  0: The maximum resident set size (KB)                   = 1214368
 
 Test 038 rap_noah_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_sfcdiff_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_sfcdiff_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 237.280436
-  0: The maximum resident set size (KB)                   = 1231228
+  0: The total amount of wall time                        = 243.009580
+  0: The maximum resident set size (KB)                   = 1226064
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_noah_sfcdiff_cires_ugwp_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 386.640430
-  0: The maximum resident set size (KB)                   = 1235108
+  0: The total amount of wall time                        = 399.014080
+  0: The maximum resident set size (KB)                   = 1222844
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rrfs_v1beta_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rrfs_v1beta_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 229.376786
-  0: The maximum resident set size (KB)                   = 1212136
+  0: The total amount of wall time                        = 230.428209
+  0: The maximum resident set size (KB)                   = 1220960
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_clm_lake_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_clm_lake_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_clm_lake_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.990386
-  0: The maximum resident set size (KB)                   = 1226112
+  0: The total amount of wall time                        = 289.424602
+  0: The maximum resident set size (KB)                   = 1223112
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_flake_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_flake_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_flake_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.184911
-  0: The maximum resident set size (KB)                   = 1211316
+  0: The total amount of wall time                        = 239.244900
+  0: The maximum resident set size (KB)                   = 1217028
 
 Test 043 rap_flake_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/gnv1_c96_no_nest_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/gnv1_c96_no_nest_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/gnv1_c96_no_nest_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing sfcf002.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
- Comparing atmf002.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
  Comparing RESTART/20210322.070000.coupler.res .........OK
  Comparing RESTART/20210322.070000.fv_core.res.nc .........OK
  Comparing RESTART/20210322.070000.fv_core.res.tile1.nc .........OK
@@ -1176,39 +1176,39 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 404.532378
-  0: The maximum resident set size (KB)                   = 1229284
+  0: The total amount of wall time                        = 412.540598
+  0: The maximum resident set size (KB)                   = 1232452
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf001.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf001.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
  Comparing PRSLEV.GrbF00 .........OK
  Comparing PRSLEV.GrbF01 .........OK
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 199.170024
-  0: The maximum resident set size (KB)                   = 1300208
+  0: The total amount of wall time                        = 205.624229
+  0: The maximum resident set size (KB)                   = 1295260
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_control_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1248,21 +1248,21 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 318.371265
-  0: The maximum resident set size (KB)                   = 1157848
+  0: The total amount of wall time                        = 322.069090
+  0: The maximum resident set size (KB)                   = 1151188
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1302,21 +1302,21 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.141416
-  0: The maximum resident set size (KB)                   = 1043968
+  0: The total amount of wall time                        = 167.957705
+  0: The maximum resident set size (KB)                   = 1034332
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_2threads_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1356,21 +1356,21 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 304.574119
-  0: The maximum resident set size (KB)                   = 1302092
+  0: The total amount of wall time                        = 308.506109
+  0: The maximum resident set size (KB)                   = 1316456
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_2threads_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1410,21 +1410,21 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.277084
-  0: The maximum resident set size (KB)                   = 1048200
+  0: The total amount of wall time                        = 156.887858
+  0: The maximum resident set size (KB)                   = 1052988
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_decomp_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1464,17 +1464,17 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 176.008362
-  0: The maximum resident set size (KB)                   = 995096
+  0: The total amount of wall time                        = 177.236367
+  0: The maximum resident set size (KB)                   = 1006144
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_restart_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210323.060000.coupler.res .........OK
@@ -1510,35 +1510,35 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.789812
-  0: The maximum resident set size (KB)                   = 1116068
+  0: The total amount of wall time                        = 244.960966
+  0: The maximum resident set size (KB)                   = 1107288
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_restart_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 86.706454
-  0: The maximum resident set size (KB)                   = 965888
+  0: The total amount of wall time                        = 94.511240
+  0: The maximum resident set size (KB)                   = 964108
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/conus13km_control_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing sfcf002.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
- Comparing atmf002.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
@@ -1547,47 +1547,47 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 90.879450
-  0: The maximum resident set size (KB)                   = 1302464
+  0: The total amount of wall time                        = 105.366904
+  0: The maximum resident set size (KB)                   = 1300480
 
 Test 053 conus13km_control_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/conus13km_2threads_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 37.725389
-  0: The maximum resident set size (KB)                   = 1201700
+  0: The total amount of wall time                        = 41.379798
+  0: The maximum resident set size (KB)                   = 1204688
 
 Test 054 conus13km_2threads_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_restart_mismatch_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/conus13km_restart_mismatch_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_restart_mismatch_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/conus13km_restart_mismatch_intel
 Checking test 055 conus13km_restart_mismatch_intel results ....
- Comparing sfcf002.nc ............ALT CHECK......OK
- Comparing atmf002.nc ............ALT CHECK......OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 52.278468
-  0: The maximum resident set size (KB)                   = 1149896
+  0: The total amount of wall time                        = 53.391988
+  0: The maximum resident set size (KB)                   = 1143524
 
 Test 055 conus13km_restart_mismatch_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_dyn64_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_control_dyn64_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn64_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1627,47 +1627,47 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.929072
-  0: The maximum resident set size (KB)                   = 1103024
+  0: The total amount of wall time                        = 221.127306
+  0: The maximum resident set size (KB)                   = 1101084
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_control_debug_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.069536
-  0: The maximum resident set size (KB)                   = 1097164
+  0: The total amount of wall time                        = 234.457637
+  0: The maximum resident set size (KB)                   = 1100016
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/hrrr_control_debug_dyn32_phy32_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 226.030643
-  0: The maximum resident set size (KB)                   = 1108492
+  0: The total amount of wall time                        = 230.913832
+  0: The maximum resident set size (KB)                   = 1096000
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/conus13km_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
@@ -1676,19 +1676,19 @@ Checking test 059 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 665.307928
-  0: The maximum resident set size (KB)                   = 1356932
+  0: The total amount of wall time                        = 673.844013
+  0: The maximum resident set size (KB)                   = 1336984
 
 Test 059 conus13km_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/conus13km_debug_qr_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc ............ALT CHECK......OK
@@ -1697,54 +1697,54 @@ Checking test 060 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 672.451761
-  0: The maximum resident set size (KB)                   = 997216
+  0: The total amount of wall time                        = 679.494337
+  0: The maximum resident set size (KB)                   = 1009456
 
 Test 060 conus13km_debug_qr_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/conus13km_debug_2threads_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 381.270803
-  0: The maximum resident set size (KB)                   = 1247820
+  0: The total amount of wall time                        = 394.847747
+  0: The maximum resident set size (KB)                   = 1246236
 
 Test 061 conus13km_debug_2threads_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/conus13km_radar_tten_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/conus13km_radar_tten_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_radar_tten_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 664.254007
-  0: The maximum resident set size (KB)                   = 1418392
+  0: The total amount of wall time                        = 671.095015
+  0: The maximum resident set size (KB)                   = 1407904
 
 Test 062 conus13km_radar_tten_debug_intel PASS
 
 
-baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn64_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1760817/rap_control_dyn64_phy32_debug_intel
+baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn64_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_1392590/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.994460
-  0: The maximum resident set size (KB)                   = 1155420
+  0: The total amount of wall time                        = 232.701261
+  0: The maximum resident set size (KB)                   = 1159412
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Apr  1 13:00:23 CDT 2024
-Elapsed time: 00h:31m:28s. Have a nice day!
+Wed Apr 10 15:06:19 CDT 2024
+Elapsed time: 01h:30m:03s. Have a nice day!

--- a/tests/logs/RegressionTests_wcoss2.log
+++ b/tests/logs/RegressionTests_wcoss2.log
@@ -1,38 +1,38 @@
-Mon Apr  1 16:02:54 UTC 2024
+Wed Apr 10 16:08:00 UTC 2024
 Start Regression test
 
-Testing UFSWM Hash: f43f5c75b7067f12bfd4020949d1c25a8cb8e37f
+Testing UFSWM Hash: 19ad8451fb3f1c34a503ebecef9e8e209247cd98
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- ef553376b00b6e67201a9ae3504d7985ba381336 FV3 (remotes/origin/rrfs_v1_write_netcdf_hangs)
+ 09956cd2e58b80fd53cfa6e8a4dacbb408898839 FV3 (remotes/origin/ebb_dcycle_fix)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 695 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 1039 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 200 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 487 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 470 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 817 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 630 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 830 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 393 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 511 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 309 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 643 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 540 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 574 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 521 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 1038 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_control_intel
 Checking test 001 rap_control_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -72,39 +72,39 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 419.650593
-The maximum resident set size (KB)                   = 916708
+The total amount of wall time                        = 413.703197
+The maximum resident set size (KB)                   = 913324
 
 Test 001 rap_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/regional_spp_sppt_shum_skeb_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf001.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf001.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
  Comparing PRSLEV.GrbF00 .........OK
  Comparing PRSLEV.GrbF01 .........OK
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 250.191482
-The maximum resident set size (KB)                   = 1119724
+The total amount of wall time                        = 268.085807
+The maximum resident set size (KB)                   = 1114580
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -144,21 +144,21 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 424.392963
-The maximum resident set size (KB)                   = 917364
+The total amount of wall time                        = 437.868146
+The maximum resident set size (KB)                   = 914620
 
 Test 003 rap_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -198,17 +198,17 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 374.006736
-The maximum resident set size (KB)                   = 1001832
+The total amount of wall time                        = 393.190192
+The maximum resident set size (KB)                   = 1003696
 
 Test 004 rap_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF24 .........OK
  Comparing GFSPRS.GrbF24 .........OK
  Comparing RESTART/20210323.060000.coupler.res .........OK
@@ -244,21 +244,21 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 208.123009
-The maximum resident set size (KB)                   = 788324
+The total amount of wall time                        = 218.638559
+The maximum resident set size (KB)                   = 789888
 
 Test 005 rap_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_sfcdiff_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -298,21 +298,21 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 408.765335
-The maximum resident set size (KB)                   = 911744
+The total amount of wall time                        = 413.860267
+The maximum resident set size (KB)                   = 911028
 
 Test 006 rap_sfcdiff_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_sfcdiff_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -352,17 +352,17 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 427.806580
-The maximum resident set size (KB)                   = 916392
+The total amount of wall time                        = 440.246638
+The maximum resident set size (KB)                   = 914224
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_sfcdiff_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210323.060000.coupler.res .........OK
@@ -398,21 +398,21 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 302.569197
-The maximum resident set size (KB)                   = 789028
+The total amount of wall time                        = 316.560560
+The maximum resident set size (KB)                   = 787128
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -452,21 +452,21 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 211.334554
-The maximum resident set size (KB)                   = 906700
+The total amount of wall time                        = 220.536427
+The maximum resident set size (KB)                   = 906672
 
 Test 009 hrrr_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -506,21 +506,21 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 214.132557
-The maximum resident set size (KB)                   = 909836
+The total amount of wall time                        = 237.114812
+The maximum resident set size (KB)                   = 906948
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -560,35 +560,35 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 189.046072
-The maximum resident set size (KB)                   = 992256
+The total amount of wall time                        = 206.656118
+The maximum resident set size (KB)                   = 993604
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 112.235270
-The maximum resident set size (KB)                   = 740080
+The total amount of wall time                        = 117.239399
+The maximum resident set size (KB)                   = 740708
 
 Test 012 hrrr_control_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rrfs_v1beta_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -628,21 +628,21 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 398.111310
-The maximum resident set size (KB)                   = 909076
+The total amount of wall time                        = 416.541709
+The maximum resident set size (KB)                   = 910044
 
 Test 013 rrfs_v1beta_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rrfs_v1nssl_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -650,21 +650,21 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 491.579838
-The maximum resident set size (KB)                   = 1875088
+The total amount of wall time                        = 501.770060
+The maximum resident set size (KB)                   = 1873732
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -672,21 +672,21 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 475.748111
-The maximum resident set size (KB)                   = 1859488
+The total amount of wall time                        = 491.288224
+The maximum resident set size (KB)                   = 1860644
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_p8_faster_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf021.nc ............ALT CHECK......OK
- Comparing sfcf024.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf021.nc ............ALT CHECK......OK
- Comparing atmf024.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf021.nc .........OK
+ Comparing sfcf024.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf021.nc .........OK
+ Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF21 .........OK
  Comparing GFSFLX.GrbF24 .........OK
@@ -726,32 +726,32 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 160.679273
-The maximum resident set size (KB)                   = 1499020
+The total amount of wall time                        = 168.362839
+The maximum resident set size (KB)                   = 1509440
 
 Test 016 control_p8_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/regional_control_faster_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf006.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf006.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf006.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf006.nc .........OK
  Comparing PRSLEV.GrbF00 .........OK
  Comparing PRSLEV.GrbF06 .........OK
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 276.771826
-The maximum resident set size (KB)                   = 643388
+The total amount of wall time                        = 295.114460
+The maximum resident set size (KB)                   = 639892
 
 Test 017 regional_control_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_CubedSphereGrid_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,371 +778,371 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 169.480361
-The maximum resident set size (KB)                   = 683892
+The total amount of wall time                        = 167.346094
+The maximum resident set size (KB)                   = 687624
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_wrtGauss_netcdf_parallel_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 164.703336
-The maximum resident set size (KB)                   = 684960
+The total amount of wall time                        = 164.757207
+The maximum resident set size (KB)                   = 685428
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_stochy_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 188.059370
-The maximum resident set size (KB)                   = 692892
+The total amount of wall time                        = 188.435749
+The maximum resident set size (KB)                   = 692332
 
 Test 020 control_stochy_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_lndp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.316988
-The maximum resident set size (KB)                   = 691716
+The total amount of wall time                        = 169.328464
+The maximum resident set size (KB)                   = 691180
 
 Test 021 control_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_csawmg_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 260.695367
-The maximum resident set size (KB)                   = 729240
+The total amount of wall time                        = 259.030812
+The maximum resident set size (KB)                   = 731200
 
 Test 022 control_csawmg_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_csawmgt_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 255.371333
-The maximum resident set size (KB)                   = 730168
+The total amount of wall time                        = 259.745550
+The maximum resident set size (KB)                   = 730868
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_ras_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 171.903428
-The maximum resident set size (KB)                   = 702240
+The total amount of wall time                        = 172.558059
+The maximum resident set size (KB)                   = 701448
 
 Test 024 control_ras_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_diag_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 175.053592
-The maximum resident set size (KB)                   = 746372
+The total amount of wall time                        = 171.424096
+The maximum resident set size (KB)                   = 746576
 
 Test 025 control_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/control_debug_p8_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 177.253604
-The maximum resident set size (KB)                   = 1520640
+The total amount of wall time                        = 176.119031
+The maximum resident set size (KB)                   = 1524280
 
 Test 026 control_debug_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/regional_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf001.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf001.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1065.822073
-The maximum resident set size (KB)                   = 636672
+The total amount of wall time                        = 1060.028322
+The maximum resident set size (KB)                   = 637816
 
 Test 027 regional_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_control_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 316.187275
-The maximum resident set size (KB)                   = 1076780
+The total amount of wall time                        = 312.663004
+The maximum resident set size (KB)                   = 1076532
 
 Test 028 rap_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.560609
-The maximum resident set size (KB)                   = 1065548
+The total amount of wall time                        = 306.172384
+The maximum resident set size (KB)                   = 1069060
 
 Test 029 hrrr_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_gf_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_gf_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_gf_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 314.038568
-The maximum resident set size (KB)                   = 1079948
+The total amount of wall time                        = 319.468819
+The maximum resident set size (KB)                   = 1074860
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_c3_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_c3_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_c3_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 311.668490
-The maximum resident set size (KB)                   = 1071968
+The total amount of wall time                        = 307.781581
+The maximum resident set size (KB)                   = 1079292
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_unified_drag_suite_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 310.950763
-The maximum resident set size (KB)                   = 1071752
+The total amount of wall time                        = 317.393063
+The maximum resident set size (KB)                   = 1075196
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_diag_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 327.352219
-The maximum resident set size (KB)                   = 1157468
+The total amount of wall time                        = 321.383858
+The maximum resident set size (KB)                   = 1159312
 
 Test 033 rap_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_cires_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 319.772662
-The maximum resident set size (KB)                   = 1072148
+The total amount of wall time                        = 320.463149
+The maximum resident set size (KB)                   = 1076496
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_unified_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 318.125784
-The maximum resident set size (KB)                   = 1075880
+The total amount of wall time                        = 321.983204
+The maximum resident set size (KB)                   = 1076256
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_lndp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 316.378347
-The maximum resident set size (KB)                   = 1075856
+The total amount of wall time                        = 316.712557
+The maximum resident set size (KB)                   = 1072948
 
 Test 036 rap_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_progcld_thompson_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 313.378524
-The maximum resident set size (KB)                   = 1072232
+The total amount of wall time                        = 310.152782
+The maximum resident set size (KB)                   = 1076640
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_noah_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 304.459387
-The maximum resident set size (KB)                   = 1070456
+The total amount of wall time                        = 304.655864
+The maximum resident set size (KB)                   = 1066744
 
 Test 038 rap_noah_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_sfcdiff_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 312.378956
-The maximum resident set size (KB)                   = 1074832
+The total amount of wall time                        = 312.847292
+The maximum resident set size (KB)                   = 1075140
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_noah_sfcdiff_cires_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 510.298796
-The maximum resident set size (KB)                   = 1072564
+The total amount of wall time                        = 498.120032
+The maximum resident set size (KB)                   = 1068924
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rrfs_v1beta_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 305.332079
-The maximum resident set size (KB)                   = 1067840
+The total amount of wall time                        = 303.532976
+The maximum resident set size (KB)                   = 1068672
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_clm_lake_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 354.250258
-The maximum resident set size (KB)                   = 1076176
+The total amount of wall time                        = 383.215801
+The maximum resident set size (KB)                   = 1072856
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_flake_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 305.871516
-The maximum resident set size (KB)                   = 1076848
+The total amount of wall time                        = 310.889224
+The maximum resident set size (KB)                   = 1079804
 
 Test 043 rap_flake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/gnv1_c96_no_nest_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/gnv1_c96_no_nest_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/gnv1_c96_no_nest_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing sfcf002.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
- Comparing atmf002.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
  Comparing RESTART/20210322.070000.coupler.res .........OK
  Comparing RESTART/20210322.070000.fv_core.res.nc .........OK
  Comparing RESTART/20210322.070000.fv_core.res.tile1.nc .........OK
@@ -1176,39 +1176,39 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 534.212834
-The maximum resident set size (KB)                   = 1077884
+The total amount of wall time                        = 543.471196
+The maximum resident set size (KB)                   = 1077584
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
- Comparing dynf000.nc ............ALT CHECK......OK
- Comparing dynf001.nc ............ALT CHECK......OK
- Comparing phyf000.nc ............ALT CHECK......OK
- Comparing phyf001.nc ............ALT CHECK......OK
+ Comparing dynf000.nc .........OK
+ Comparing dynf001.nc .........OK
+ Comparing phyf000.nc .........OK
+ Comparing phyf001.nc .........OK
  Comparing PRSLEV.GrbF00 .........OK
  Comparing PRSLEV.GrbF01 .........OK
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 232.751072
-The maximum resident set size (KB)                   = 978400
+The total amount of wall time                        = 234.767891
+The maximum resident set size (KB)                   = 972168
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_control_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1248,21 +1248,21 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 336.374735
-The maximum resident set size (KB)                   = 790584
+The total amount of wall time                        = 348.161528
+The maximum resident set size (KB)                   = 786208
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1302,21 +1302,21 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 176.301266
-The maximum resident set size (KB)                   = 786360
+The total amount of wall time                        = 181.286809
+The maximum resident set size (KB)                   = 785692
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_2threads_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1356,21 +1356,21 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 308.134652
-The maximum resident set size (KB)                   = 849144
+The total amount of wall time                        = 333.519761
+The maximum resident set size (KB)                   = 854808
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_2threads_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1410,21 +1410,21 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 164.096709
-The maximum resident set size (KB)                   = 846336
+The total amount of wall time                        = 175.881459
+The maximum resident set size (KB)                   = 843216
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_decomp_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1464,17 +1464,17 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 184.482711
-The maximum resident set size (KB)                   = 788932
+The total amount of wall time                        = 194.557190
+The maximum resident set size (KB)                   = 787104
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_restart_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
  Comparing RESTART/20210323.060000.coupler.res .........OK
@@ -1510,35 +1510,35 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 251.540656
-The maximum resident set size (KB)                   = 696020
+The total amount of wall time                        = 269.205479
+The maximum resident set size (KB)                   = 692616
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_restart_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 93.889402
-The maximum resident set size (KB)                   = 674476
+The total amount of wall time                        = 105.798800
+The maximum resident set size (KB)                   = 669960
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/conus13km_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing sfcf002.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
- Comparing atmf002.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
+ Comparing atmf002.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
@@ -1547,47 +1547,47 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 119.995393
-The maximum resident set size (KB)                   = 1007792
+The total amount of wall time                        = 118.192631
+The maximum resident set size (KB)                   = 1007712
 
 Test 053 conus13km_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/conus13km_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 77.876799
-The maximum resident set size (KB)                   = 1010560
+The total amount of wall time                        = 76.058433
+The maximum resident set size (KB)                   = 1009344
 
 Test 054 conus13km_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/conus13km_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/conus13km_restart_mismatch_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_restart_mismatch_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/conus13km_restart_mismatch_intel
 Checking test 055 conus13km_restart_mismatch_intel results ....
- Comparing sfcf002.nc ............ALT CHECK......OK
- Comparing atmf002.nc ............ALT CHECK......OK
+ Comparing sfcf002.nc .........OK
+ Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 79.995884
-The maximum resident set size (KB)                   = 881224
+The total amount of wall time                        = 75.712664
+The maximum resident set size (KB)                   = 882812
 
 Test 055 conus13km_restart_mismatch_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_control_dyn64_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf009.nc ............ALT CHECK......OK
- Comparing sfcf012.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf009.nc ............ALT CHECK......OK
- Comparing atmf012.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf009.nc .........OK
+ Comparing sfcf012.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf009.nc .........OK
+ Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
  Comparing GFSFLX.GrbF09 .........OK
  Comparing GFSFLX.GrbF12 .........OK
@@ -1627,47 +1627,47 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 241.247083
-The maximum resident set size (KB)                   = 810464
+The total amount of wall time                        = 243.562447
+The maximum resident set size (KB)                   = 806556
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_control_debug_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 297.416581
-The maximum resident set size (KB)                   = 954564
+The total amount of wall time                        = 302.597450
+The maximum resident set size (KB)                   = 957252
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/hrrr_control_debug_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 292.121131
-The maximum resident set size (KB)                   = 953676
+The total amount of wall time                        = 299.135577
+The maximum resident set size (KB)                   = 955760
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/conus13km_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc .........OK
@@ -1676,19 +1676,19 @@ Checking test 059 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 853.170081
-The maximum resident set size (KB)                   = 1038392
+The total amount of wall time                        = 859.664248
+The maximum resident set size (KB)                   = 1041720
 
 Test 059 conus13km_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/conus13km_debug_qr_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
  Comparing RESTART/20210512.170000.coupler.res .........OK
  Comparing RESTART/20210512.170000.fv_core.res.nc .........OK
  Comparing RESTART/20210512.170000.fv_core.res.tile1.nc ............ALT CHECK......OK
@@ -1697,54 +1697,54 @@ Checking test 060 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 860.497834
-The maximum resident set size (KB)                   = 712500
+The total amount of wall time                        = 865.770976
+The maximum resident set size (KB)                   = 713104
 
 Test 060 conus13km_debug_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/conus13km_debug_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 489.486843
-The maximum resident set size (KB)                   = 1039940
+The total amount of wall time                        = 497.036539
+The maximum resident set size (KB)                   = 1042008
 
 Test 061 conus13km_debug_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/conus13km_radar_tten_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/conus13km_radar_tten_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_radar_tten_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 855.442773
-The maximum resident set size (KB)                   = 1107452
+The total amount of wall time                        = 855.609772
+The maximum resident set size (KB)                   = 1109568
 
 Test 062 conus13km_radar_tten_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240318/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_169371/rap_control_dyn64_phy32_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_189959/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
- Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf001.nc ............ALT CHECK......OK
- Comparing atmf000.nc ............ALT CHECK......OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing sfcf000.nc .........OK
+ Comparing sfcf001.nc .........OK
+ Comparing atmf000.nc .........OK
+ Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.375738
-The maximum resident set size (KB)                   = 976376
+The total amount of wall time                        = 304.262878
+The maximum resident set size (KB)                   = 979364
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Apr  1 16:43:30 UTC 2024
-Elapsed time: 00h:40m:37s. Have a nice day!
+Wed Apr 10 16:43:27 UTC 2024
+Elapsed time: 00h:35m:28s. Have a nice day!


### PR DESCRIPTION
<!-- INSTRUCTIONS: 
- PLEASE READ/FOLLOW THE DIRECTIONS IN EACH SECTION
- Complete the 'Commit Queue Requirements' below
- Please use github markup as much as possible (https://docs.github.com/en/get-started/writing-on-github)
- Please leave your PR in a draft state until all underlying work is completed.
-->
## Commit Queue Requirements:
<!--
- Please complete the items that follow this.
- Please "check off" completed items. Use [X] for a filled in checkbox or leave it [ ] for an empty checkbox
- Your PR will not be considered until all requirements are met.
- THIS IS YOUR RESPONSIBILITY
 -->
- [X] Fill out all sections of this template.
- [] All sub component pull requests have been reviewed by their code managers.
- [X] Run the full Intel+GNU RT suite (compared to current baselines) on either Hera/Derecho/Hercules
- [X] Commit 'test_changes.list' from previous step
---
## Description:
For ebb_dcycle==1 (retrospective fire emissions), the 3-d emissions were incorrectly assgined assigned at all levels using the surface data.


### Commit Message:
Fix improperly assigned fire emissions for ebb_dcycle==1 for retrospectives (NOT operational!)
```
* UFSWM - 
  * AQM - 
  * CDEPS - 
  * CICE - 
  * CMEPS - 
  * CMakeModules - 
  * FV3 - 
    * ccpp-physics - Fix improperly assigned fire emissions for ebb_dcycle==1 for retrospectives (NOT operational!)
    * atmos_cubed_sphere - 
  * GOCART - 
  * HYCOM - 
  * MOM6 - 
  * NOAHMP - 
  * WW3 - 
  * stochastic_physics - 
```

### Priority:
* High: Time-sensitive project.
* High: Reason: Retrospective experiments with smoke and ebb_dcycle=1 will use the wrong wildfire emissions


## Git Tracking

### Sub component Pull Requests:
* FV3: NOAA-EMC/fv3atm#812
  * ccpp-physics: ufs-community/ccpp-physics#191


### UFSWM Blocking Dependencies:
* None

---
## Changes
### Regression Test Changes (Please commit test_changes.list):
053 conus13km_control_intel failed in check_result
conus13km_control_intel 053 failed in run_test
059 conus13km_debug_intel failed in check_result
conus13km_debug_intel 059 failed in run_test
060 conus13km_debug_qr_intel failed in check_result
conus13km_debug_qr_intel 060 failed in run_test
061 conus13km_debug_2threads_intel failed in check_result
conus13km_debug_2threads_intel 061 failed in run_test
062 conus13km_radar_tten_debug_intel failed in check_result
conus13km_radar_tten_debug_intel 062 failed in run_test

### Input data Changes:
* None.

### Library Changes/Upgrades:
* No Updates  

---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Hercules
  - [ ] Jet
  - [ ] Gaea
  - [ ] Derecho
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- [ ] CI
- [ ] opnReqTest (complete task if unnecessary)