### PR TITLE
[production/RRFS.v1] Add clear-sky shortwave downward at surface flux to available diagnostics.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = production/RRFS.v1
+  url = https://github.com/dustinswales/fv3atm
+  branch = production/RRFS.v1/swdnclrskyflx_diag
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/dustinswales/fv3atm
-  branch = production/RRFS.v1/swdnclrskyflx_diag
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = production/RRFS.v1
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,31 +1,31 @@
-Fri May  3 13:03:25 UTC 2024
+Mon May  6 16:54:39 UTC 2024
 Start Regression test
 
-Testing UFSWM Hash: f8c716a0b493099685c554014ede13634c51132c
+Testing UFSWM Hash: 59e852da92f3bf506fabc4f6294b7151a4a58680
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 594260f2d287035141a861be9dcd9566e4d4a8c0 FV3 (remotes/origin/feature/paraio)
+ e2b55dfa0cdf576a2947effed32dfebf2827ef2f FV3 (remotes/origin/production/RRFS.v1/swdnclrskyflx_diag)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 301 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 608 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 221 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 589 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 565 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 215 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 577 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 603 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 317 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 615 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 224 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 599 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 582 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 241 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 592 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 606 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 459.790806
-  0: The maximum resident set size (KB)                   = 1098944
+  0: The total amount of wall time                        = 458.105838
+  0: The maximum resident set size (KB)                   = 1129100
 
 Test 001 rap_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/regional_spp_sppt_shum_skeb_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 251.770939
-  0: The maximum resident set size (KB)                   = 1361344
+  0: The total amount of wall time                        = 242.584358
+  0: The maximum resident set size (KB)                   = 1385940
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 480.982342
-  0: The maximum resident set size (KB)                   = 1043532
+  0: The total amount of wall time                        = 488.087930
+  0: The maximum resident set size (KB)                   = 1067628
 
 Test 003 rap_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 441.608202
-  0: The maximum resident set size (KB)                   = 1194524
+  0: The total amount of wall time                        = 432.666456
+  0: The maximum resident set size (KB)                   = 1218740
 
 Test 004 rap_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 234.509876
-  0: The maximum resident set size (KB)                   = 1095688
+  0: The total amount of wall time                        = 233.638121
+  0: The maximum resident set size (KB)                   = 1120116
 
 Test 005 rap_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 460.452209
-  0: The maximum resident set size (KB)                   = 1106884
+  0: The total amount of wall time                        = 456.909365
+  0: The maximum resident set size (KB)                   = 1133540
 
 Test 006 rap_sfcdiff_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_sfcdiff_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 489.422162
-  0: The maximum resident set size (KB)                   = 1039716
+  0: The total amount of wall time                        = 485.910263
+  0: The maximum resident set size (KB)                   = 1064064
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_sfcdiff_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 343.459267
-  0: The maximum resident set size (KB)                   = 1124448
+  0: The total amount of wall time                        = 339.507203
+  0: The maximum resident set size (KB)                   = 1141012
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 233.538214
-  0: The maximum resident set size (KB)                   = 1051580
+  0: The total amount of wall time                        = 230.880605
+  0: The maximum resident set size (KB)                   = 1066316
 
 Test 009 hrrr_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_decomp_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 239.908525
-  0: The maximum resident set size (KB)                   = 1041564
+  0: The total amount of wall time                        = 237.022792
+  0: The maximum resident set size (KB)                   = 1057708
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 217.316336
-  0: The maximum resident set size (KB)                   = 1113064
+  0: The total amount of wall time                        = 214.218121
+  0: The maximum resident set size (KB)                   = 1133280
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_restart_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 122.576427
-  0: The maximum resident set size (KB)                   = 1007792
+  0: The total amount of wall time                        = 123.542724
+  0: The maximum resident set size (KB)                   = 1025088
 
 Test 012 hrrr_control_restart_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rrfs_v1beta_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 450.745944
-  0: The maximum resident set size (KB)                   = 1086212
+  0: The total amount of wall time                        = 448.545589
+  0: The maximum resident set size (KB)                   = 1112520
 
 Test 013 rrfs_v1beta_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rrfs_v1nssl_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 550.846431
-  0: The maximum resident set size (KB)                   = 1990104
+  0: The total amount of wall time                        = 552.086648
+  0: The maximum resident set size (KB)                   = 2001960
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 540.274070
-  0: The maximum resident set size (KB)                   = 2044776
+  0: The total amount of wall time                        = 539.019816
+  0: The maximum resident set size (KB)                   = 2067124
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.215990
-  0: The maximum resident set size (KB)                   = 1619704
+  0: The total amount of wall time                        = 153.258640
+  0: The maximum resident set size (KB)                   = 1644584
 
 Test 016 control_p8_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_control_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/regional_control_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 279.565296
-  0: The maximum resident set size (KB)                   = 894512
+  0: The total amount of wall time                        = 279.692371
+  0: The maximum resident set size (KB)                   = 915840
 
 Test 017 regional_control_faster_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_CubedSphereGrid_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_CubedSphereGrid_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 153.170059
-  0: The maximum resident set size (KB)                   = 790636
+  0: The total amount of wall time                        = 150.300850
+  0: The maximum resident set size (KB)                   = 833928
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
- Comparing sfcf000.nc .........OK
+ Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
- Comparing atmf001.nc ............ALT CHECK......OK
+ Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.432531
-  0: The maximum resident set size (KB)                   = 795996
+  0: The total amount of wall time                        = 149.247739
+  0: The maximum resident set size (KB)                   = 836280
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_stochy_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_stochy_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.514026
-  0: The maximum resident set size (KB)                   = 798828
+  0: The total amount of wall time                        = 169.104911
+  0: The maximum resident set size (KB)                   = 839372
 
 Test 020 control_stochy_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 151.773541
-  0: The maximum resident set size (KB)                   = 798016
+  0: The total amount of wall time                        = 152.300497
+  0: The maximum resident set size (KB)                   = 836864
 
 Test 021 control_lndp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmg_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_csawmg_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 241.395781
-  0: The maximum resident set size (KB)                   = 847844
+  0: The total amount of wall time                        = 242.128172
+  0: The maximum resident set size (KB)                   = 883836
 
 Test 022 control_csawmg_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmgt_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_csawmgt_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.964981
-  0: The maximum resident set size (KB)                   = 843924
+  0: The total amount of wall time                        = 232.982691
+  0: The maximum resident set size (KB)                   = 879760
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_ras_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_ras_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 156.328891
-  0: The maximum resident set size (KB)                   = 807948
+  0: The total amount of wall time                        = 153.598659
+  0: The maximum resident set size (KB)                   = 845364
 
 Test 024 control_ras_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.176021
-  0: The maximum resident set size (KB)                   = 852560
+  0: The total amount of wall time                        = 159.588607
+  0: The maximum resident set size (KB)                   = 889392
 
 Test 025 control_diag_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/control_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.837366
-  0: The maximum resident set size (KB)                   = 1619808
+  0: The total amount of wall time                        = 163.344914
+  0: The maximum resident set size (KB)                   = 1657236
 
 Test 026 control_debug_p8_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/regional_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1060.990430
-  0: The maximum resident set size (KB)                   = 854124
+  0: The total amount of wall time                        = 1020.890800
+  0: The maximum resident set size (KB)                   = 872768
 
 Test 027 regional_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.073045
-  0: The maximum resident set size (KB)                   = 1196764
+  0: The total amount of wall time                        = 290.257487
+  0: The maximum resident set size (KB)                   = 1233304
 
 Test 028 rap_control_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.415930
-  0: The maximum resident set size (KB)                   = 1190844
+  0: The total amount of wall time                        = 281.582931
+  0: The maximum resident set size (KB)                   = 1227900
 
 Test 029 hrrr_control_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_gf_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_gf_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.207908
-  0: The maximum resident set size (KB)                   = 1189444
+  0: The total amount of wall time                        = 281.989730
+  0: The maximum resident set size (KB)                   = 1229232
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_c3_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_c3_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.773919
-  0: The maximum resident set size (KB)                   = 1197400
+  0: The total amount of wall time                        = 288.941453
+  0: The maximum resident set size (KB)                   = 1234348
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_unified_drag_suite_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.142381
-  0: The maximum resident set size (KB)                   = 1190024
+  0: The total amount of wall time                        = 283.689999
+  0: The maximum resident set size (KB)                   = 1233080
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 298.573218
-  0: The maximum resident set size (KB)                   = 1272700
+  0: The total amount of wall time                        = 296.856162
+  0: The maximum resident set size (KB)                   = 1318264
 
 Test 033 rap_diag_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.331329
-  0: The maximum resident set size (KB)                   = 1186796
+  0: The total amount of wall time                        = 290.389210
+  0: The maximum resident set size (KB)                   = 1234628
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_unified_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.636339
-  0: The maximum resident set size (KB)                   = 1195716
+  0: The total amount of wall time                        = 286.791168
+  0: The maximum resident set size (KB)                   = 1237400
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.187588
-  0: The maximum resident set size (KB)                   = 1191788
+  0: The total amount of wall time                        = 291.681233
+  0: The maximum resident set size (KB)                   = 1234380
 
 Test 036 rap_lndp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_progcld_thompson_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_progcld_thompson_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 288.865981
-  0: The maximum resident set size (KB)                   = 1187956
+  0: The total amount of wall time                        = 283.236157
+  0: The maximum resident set size (KB)                   = 1232768
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_noah_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.082828
-  0: The maximum resident set size (KB)                   = 1190280
+  0: The total amount of wall time                        = 276.627180
+  0: The maximum resident set size (KB)                   = 1237716
 
 Test 038 rap_noah_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_sfcdiff_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.777328
-  0: The maximum resident set size (KB)                   = 1191508
+  0: The total amount of wall time                        = 290.175601
+  0: The maximum resident set size (KB)                   = 1228132
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 466.940701
-  0: The maximum resident set size (KB)                   = 1193840
+  0: The total amount of wall time                        = 468.101426
+  0: The maximum resident set size (KB)                   = 1232444
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rrfs_v1beta_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.578136
-  0: The maximum resident set size (KB)                   = 1189804
+  0: The total amount of wall time                        = 285.839423
+  0: The maximum resident set size (KB)                   = 1229668
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_clm_lake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_clm_lake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 343.526054
-  0: The maximum resident set size (KB)                   = 1193620
+  0: The total amount of wall time                        = 356.381242
+  0: The maximum resident set size (KB)                   = 1233856
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_flake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_flake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 290.195881
-  0: The maximum resident set size (KB)                   = 1195708
+  0: The total amount of wall time                        = 287.081084
+  0: The maximum resident set size (KB)                   = 1237792
 
 Test 043 rap_flake_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/gnv1_c96_no_nest_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/gnv1_c96_no_nest_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 509.032469
-  0: The maximum resident set size (KB)                   = 1192664
+  0: The total amount of wall time                        = 497.878868
+  0: The maximum resident set size (KB)                   = 1235056
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 231.074270
-  0: The maximum resident set size (KB)                   = 1220624
+  0: The total amount of wall time                        = 232.549920
+  0: The maximum resident set size (KB)                   = 1238292
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 387.251667
-  0: The maximum resident set size (KB)                   = 1050304
+  0: The total amount of wall time                        = 412.699392
+  0: The maximum resident set size (KB)                   = 1072728
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 199.486884
-  0: The maximum resident set size (KB)                   = 964732
+  0: The total amount of wall time                        = 194.782846
+  0: The maximum resident set size (KB)                   = 1007540
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_2threads_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 366.377998
-  0: The maximum resident set size (KB)                   = 1105060
+  0: The total amount of wall time                        = 360.901555
+  0: The maximum resident set size (KB)                   = 1119520
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 187.299611
-  0: The maximum resident set size (KB)                   = 971824
+  0: The total amount of wall time                        = 185.359708
+  0: The maximum resident set size (KB)                   = 981176
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 208.224144
-  0: The maximum resident set size (KB)                   = 923896
+  0: The total amount of wall time                        = 206.284537
+  0: The maximum resident set size (KB)                   = 946104
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_restart_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,28 +1510,28 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 286.350465
-  0: The maximum resident set size (KB)                   = 1031584
+  0: The total amount of wall time                        = 286.430978
+  0: The maximum resident set size (KB)                   = 1047924
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 103.573155
-  0: The maximum resident set size (KB)                   = 933016
+  0: The total amount of wall time                        = 105.757988
+  0: The maximum resident set size (KB)                   = 945676
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/conus13km_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1547,40 +1547,40 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 114.499228
-  0: The maximum resident set size (KB)                   = 1244408
+  0: The total amount of wall time                        = 111.928453
+  0: The maximum resident set size (KB)                   = 1261024
 
 Test 053 conus13km_control_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/conus13km_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 49.846049
-  0: The maximum resident set size (KB)                   = 1145584
+  0: The total amount of wall time                        = 48.867968
+  0: The maximum resident set size (KB)                   = 1161696
 
 Test 054 conus13km_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_restart_mismatch_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/conus13km_restart_mismatch_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/conus13km_restart_mismatch_intel
 Checking test 055 conus13km_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 65.424481
-  0: The maximum resident set size (KB)                   = 1123004
+  0: The total amount of wall time                        = 64.162545
+  0: The maximum resident set size (KB)                   = 1141132
 
 Test 055 conus13km_restart_mismatch_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_control_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1627,42 +1627,42 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 246.735155
-  0: The maximum resident set size (KB)                   = 992772
+  0: The total amount of wall time                        = 245.997807
+  0: The maximum resident set size (KB)                   = 1021252
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.121385
-  0: The maximum resident set size (KB)                   = 1069908
+  0: The total amount of wall time                        = 282.749495
+  0: The maximum resident set size (KB)                   = 1111080
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.900893
-  0: The maximum resident set size (KB)                   = 1073068
+  0: The total amount of wall time                        = 279.940394
+  0: The maximum resident set size (KB)                   = 1107132
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 059 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 834.236287
-  0: The maximum resident set size (KB)                   = 1232396
+  0: The total amount of wall time                        = 842.245248
+  0: The maximum resident set size (KB)                   = 1303140
 
 Test 059 conus13km_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/conus13km_debug_qr_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1697,54 +1697,54 @@ Checking test 060 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 819.556444
-  0: The maximum resident set size (KB)                   = 949036
+  0: The total amount of wall time                        = 820.868655
+  0: The maximum resident set size (KB)                   = 999088
 
 Test 060 conus13km_debug_qr_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/conus13km_debug_2threads_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 463.556998
-  0: The maximum resident set size (KB)                   = 1145472
+  0: The total amount of wall time                        = 471.688159
+  0: The maximum resident set size (KB)                   = 1198828
 
 Test 061 conus13km_debug_2threads_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_radar_tten_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/conus13km_radar_tten_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 835.725383
-  0: The maximum resident set size (KB)                   = 1306032
+  0: The total amount of wall time                        = 824.418341
+  0: The maximum resident set size (KB)                   = 1344612
 
 Test 062 conus13km_radar_tten_debug_intel PASS
 
 
 baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_511107/rap_control_dyn64_phy32_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_618229/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 293.049913
-  0: The maximum resident set size (KB)                   = 1146836
+  0: The total amount of wall time                        = 290.737443
+  0: The maximum resident set size (KB)                   = 1184672
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  3 13:35:55 UTC 2024
-Elapsed time: 00h:32m:30s. Have a nice day!
+Mon May  6 17:28:25 UTC 2024
+Elapsed time: 00h:33m:46s. Have a nice day!

--- a/tests/logs/RegressionTests_hercules.log
+++ b/tests/logs/RegressionTests_hercules.log
@@ -1,31 +1,31 @@
-Fri May  3 08:16:20 CDT 2024
+Mon May  6 05:46:37 PM CDT 2024
 Start Regression test
 
-Testing UFSWM Hash: f8c716a0b493099685c554014ede13634c51132c
+Testing UFSWM Hash: 538033264f02810dbb2582a98852021cb2a95445
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 594260f2d287035141a861be9dcd9566e4d4a8c0 FV3 (remotes/origin/feature/paraio)
+ e2b55dfa0cdf576a2947effed32dfebf2827ef2f FV3 (remotes/origin/production/RRFS.v1/swdnclrskyflx_diag)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 238 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 540 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 369 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 742 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 383 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 383 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 638 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 406 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 326 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 578 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 291 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 577 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 456 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 291 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 452 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 523 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 377.890397
-  0: The maximum resident set size (KB)                   = 1228920
+  0: The total amount of wall time                        = 389.791669
+  0: The maximum resident set size (KB)                   = 1209456
 
 Test 001 rap_control_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/regional_spp_sppt_shum_skeb_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 194.552374
-  0: The maximum resident set size (KB)                   = 1523088
+  0: The total amount of wall time                        = 203.100709
+  0: The maximum resident set size (KB)                   = 1502160
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_decomp_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 401.386930
-  0: The maximum resident set size (KB)                   = 1185028
+  0: The total amount of wall time                        = 401.893594
+  0: The maximum resident set size (KB)                   = 1141132
 
 Test 003 rap_decomp_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_2threads_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 354.406809
-  0: The maximum resident set size (KB)                   = 1396980
+  0: The total amount of wall time                        = 364.006139
+  0: The maximum resident set size (KB)                   = 1379660
 
 Test 004 rap_2threads_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_restart_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 197.106417
-  0: The maximum resident set size (KB)                   = 1169180
+  0: The total amount of wall time                        = 195.625243
+  0: The maximum resident set size (KB)                   = 1169460
 
 Test 005 rap_restart_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_sfcdiff_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 378.093700
-  0: The maximum resident set size (KB)                   = 1222424
+  0: The total amount of wall time                        = 385.152803
+  0: The maximum resident set size (KB)                   = 1211292
 
 Test 006 rap_sfcdiff_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_sfcdiff_decomp_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 397.234735
-  0: The maximum resident set size (KB)                   = 1173332
+  0: The total amount of wall time                        = 402.349787
+  0: The maximum resident set size (KB)                   = 1184284
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_sfcdiff_restart_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 282.100886
-  0: The maximum resident set size (KB)                   = 1227712
+  0: The total amount of wall time                        = 285.718529
+  0: The maximum resident set size (KB)                   = 1217172
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 188.433579
-  0: The maximum resident set size (KB)                   = 1108628
+  0: The total amount of wall time                        = 198.469724
+  0: The maximum resident set size (KB)                   = 1096284
 
 Test 009 hrrr_control_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_decomp_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 193.623355
-  0: The maximum resident set size (KB)                   = 1067440
+  0: The total amount of wall time                        = 200.976347
+  0: The maximum resident set size (KB)                   = 1068964
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_2threads_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 173.209553
-  0: The maximum resident set size (KB)                   = 1153884
+  0: The total amount of wall time                        = 184.071565
+  0: The maximum resident set size (KB)                   = 1158524
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_restart_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 103.314020
-  0: The maximum resident set size (KB)                   = 1061036
+  0: The total amount of wall time                        = 105.654962
+  0: The maximum resident set size (KB)                   = 1061320
 
 Test 012 hrrr_control_restart_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rrfs_v1beta_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 377.598837
-  0: The maximum resident set size (KB)                   = 1214044
+  0: The total amount of wall time                        = 374.248266
+  0: The maximum resident set size (KB)                   = 1204680
 
 Test 013 rrfs_v1beta_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rrfs_v1nssl_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 449.788314
-  0: The maximum resident set size (KB)                   = 2035360
+  0: The total amount of wall time                        = 455.200329
+  0: The maximum resident set size (KB)                   = 2038648
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 437.768845
-  0: The maximum resident set size (KB)                   = 2194380
+  0: The total amount of wall time                        = 443.341333
+  0: The maximum resident set size (KB)                   = 2188776
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_p8_faster_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_p8_faster_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.183031
-  0: The maximum resident set size (KB)                   = 1655260
+  0: The total amount of wall time                        = 130.585768
+  0: The maximum resident set size (KB)                   = 1651548
 
 Test 016 control_p8_faster_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_control_faster_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/regional_control_faster_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 231.942666
-  0: The maximum resident set size (KB)                   = 1002804
+  0: The total amount of wall time                        = 239.195994
+  0: The maximum resident set size (KB)                   = 1005248
 
 Test 017 regional_control_faster_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_CubedSphereGrid_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_CubedSphereGrid_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 127.217922
-  0: The maximum resident set size (KB)                   = 849216
+  0: The total amount of wall time                        = 124.880301
+  0: The maximum resident set size (KB)                   = 840864
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc ............ALT CHECK......OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 127.915847
-  0: The maximum resident set size (KB)                   = 851304
+  0: The total amount of wall time                        = 125.482200
+  0: The maximum resident set size (KB)                   = 842024
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_stochy_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_stochy_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 138.593453
-  0: The maximum resident set size (KB)                   = 857044
+  0: The total amount of wall time                        = 143.308179
+  0: The maximum resident set size (KB)                   = 856108
 
 Test 020 control_stochy_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_lndp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_lndp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 126.904902
-  0: The maximum resident set size (KB)                   = 856332
+  0: The total amount of wall time                        = 127.549593
+  0: The maximum resident set size (KB)                   = 848100
 
 Test 021 control_lndp_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmg_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_csawmg_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 193.371890
-  0: The maximum resident set size (KB)                   = 890152
+  0: The total amount of wall time                        = 198.233709
+  0: The maximum resident set size (KB)                   = 900604
 
 Test 022 control_csawmg_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_csawmgt_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_csawmgt_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 188.646249
-  0: The maximum resident set size (KB)                   = 885468
+  0: The total amount of wall time                        = 195.749195
+  0: The maximum resident set size (KB)                   = 900336
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_ras_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_ras_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 127.051003
-  0: The maximum resident set size (KB)                   = 864808
+  0: The total amount of wall time                        = 130.271129
+  0: The maximum resident set size (KB)                   = 857768
 
 Test 024 control_ras_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_diag_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_diag_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 129.994309
-  0: The maximum resident set size (KB)                   = 912304
+  0: The total amount of wall time                        = 131.124408
+  0: The maximum resident set size (KB)                   = 907648
 
 Test 025 control_diag_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/control_debug_p8_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/control_debug_p8_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 134.002989
-  0: The maximum resident set size (KB)                   = 1671876
+  0: The total amount of wall time                        = 136.181450
+  0: The maximum resident set size (KB)                   = 1680392
 
 Test 026 control_debug_p8_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/regional_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 836.109516
-  0: The maximum resident set size (KB)                   = 919712
+  0: The total amount of wall time                        = 846.208263
+  0: The maximum resident set size (KB)                   = 929760
 
 Test 027 regional_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_control_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.385021
-  0: The maximum resident set size (KB)                   = 1253512
+  0: The total amount of wall time                        = 236.678678
+  0: The maximum resident set size (KB)                   = 1239604
 
 Test 028 rap_control_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 227.959206
-  0: The maximum resident set size (KB)                   = 1239212
+  0: The total amount of wall time                        = 228.444012
+  0: The maximum resident set size (KB)                   = 1239016
 
 Test 029 hrrr_control_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_gf_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_gf_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 230.336978
-  0: The maximum resident set size (KB)                   = 1247532
+  0: The total amount of wall time                        = 233.253805
+  0: The maximum resident set size (KB)                   = 1247388
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_c3_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_c3_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.156005
-  0: The maximum resident set size (KB)                   = 1249568
+  0: The total amount of wall time                        = 236.411707
+  0: The maximum resident set size (KB)                   = 1259520
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_unified_drag_suite_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.793931
-  0: The maximum resident set size (KB)                   = 1248884
+  0: The total amount of wall time                        = 234.352915
+  0: The maximum resident set size (KB)                   = 1241456
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_diag_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_diag_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 243.896548
-  0: The maximum resident set size (KB)                   = 1325384
+  0: The total amount of wall time                        = 243.923433
+  0: The maximum resident set size (KB)                   = 1329852
 
 Test 033 rap_diag_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_cires_ugwp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 240.828443
-  0: The maximum resident set size (KB)                   = 1250404
+  0: The total amount of wall time                        = 241.447045
+  0: The maximum resident set size (KB)                   = 1250256
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_unified_ugwp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 238.547488
-  0: The maximum resident set size (KB)                   = 1250132
+  0: The total amount of wall time                        = 238.539753
+  0: The maximum resident set size (KB)                   = 1242176
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_lndp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_lndp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 234.902052
-  0: The maximum resident set size (KB)                   = 1244744
+  0: The total amount of wall time                        = 238.625926
+  0: The maximum resident set size (KB)                   = 1250500
 
 Test 036 rap_lndp_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_progcld_thompson_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_progcld_thompson_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.613840
-  0: The maximum resident set size (KB)                   = 1247304
+  0: The total amount of wall time                        = 236.605851
+  0: The maximum resident set size (KB)                   = 1249176
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_noah_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.814947
-  0: The maximum resident set size (KB)                   = 1242472
+  0: The total amount of wall time                        = 233.739118
+  0: The maximum resident set size (KB)                   = 1232096
 
 Test 038 rap_noah_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_sfcdiff_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_sfcdiff_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.875944
-  0: The maximum resident set size (KB)                   = 1244796
+  0: The total amount of wall time                        = 235.430304
+  0: The maximum resident set size (KB)                   = 1241688
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 379.457552
-  0: The maximum resident set size (KB)                   = 1252152
+  0: The total amount of wall time                        = 383.891716
+  0: The maximum resident set size (KB)                   = 1241108
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rrfs_v1beta_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rrfs_v1beta_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.427013
-  0: The maximum resident set size (KB)                   = 1242588
+  0: The total amount of wall time                        = 239.323884
+  0: The maximum resident set size (KB)                   = 1235444
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_clm_lake_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_clm_lake_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 283.798541
-  0: The maximum resident set size (KB)                   = 1245488
+  0: The total amount of wall time                        = 288.806738
+  0: The maximum resident set size (KB)                   = 1247500
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_flake_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_flake_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.965079
-  0: The maximum resident set size (KB)                   = 1246520
+  0: The total amount of wall time                        = 235.321468
+  0: The maximum resident set size (KB)                   = 1245616
 
 Test 043 rap_flake_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/gnv1_c96_no_nest_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/gnv1_c96_no_nest_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 406.583941
-  0: The maximum resident set size (KB)                   = 1243400
+  0: The total amount of wall time                        = 414.055674
+  0: The maximum resident set size (KB)                   = 1243204
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 187.309260
-  0: The maximum resident set size (KB)                   = 1377248
+  0: The total amount of wall time                        = 191.354256
+  0: The maximum resident set size (KB)                   = 1374792
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 318.801536
-  0: The maximum resident set size (KB)                   = 1150136
+  0: The total amount of wall time                        = 324.867624
+  0: The maximum resident set size (KB)                   = 1154904
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 162.879972
-  0: The maximum resident set size (KB)                   = 1038584
+  0: The total amount of wall time                        = 167.229967
+  0: The maximum resident set size (KB)                   = 1049036
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_2threads_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 296.606849
-  0: The maximum resident set size (KB)                   = 1316736
+  0: The total amount of wall time                        = 303.080540
+  0: The maximum resident set size (KB)                   = 1317044
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 148.883760
-  0: The maximum resident set size (KB)                   = 1059524
+  0: The total amount of wall time                        = 157.848592
+  0: The maximum resident set size (KB)                   = 1060992
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 170.370743
-  0: The maximum resident set size (KB)                   = 1024928
+  0: The total amount of wall time                        = 177.368009
+  0: The maximum resident set size (KB)                   = 994984
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_restart_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,28 +1510,28 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 239.881893
-  0: The maximum resident set size (KB)                   = 1117692
+  0: The total amount of wall time                        = 238.799497
+  0: The maximum resident set size (KB)                   = 1126132
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 89.433316
-  0: The maximum resident set size (KB)                   = 989544
+  0: The total amount of wall time                        = 89.695366
+  0: The maximum resident set size (KB)                   = 982420
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/conus13km_control_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1547,40 +1547,40 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 87.031908
-  0: The maximum resident set size (KB)                   = 1354660
+  0: The total amount of wall time                        = 90.978674
+  0: The maximum resident set size (KB)                   = 1366364
 
 Test 053 conus13km_control_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_control_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/conus13km_2threads_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 33.584247
-  0: The maximum resident set size (KB)                   = 1250680
+  0: The total amount of wall time                        = 39.337723
+  0: The maximum resident set size (KB)                   = 1255576
 
 Test 054 conus13km_2threads_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_restart_mismatch_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/conus13km_restart_mismatch_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/conus13km_restart_mismatch_intel
 Checking test 055 conus13km_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 49.816381
-  0: The maximum resident set size (KB)                   = 1188160
+  0: The total amount of wall time                        = 54.723068
+  0: The maximum resident set size (KB)                   = 1214396
 
 Test 055 conus13km_restart_mismatch_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_dyn64_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_control_dyn64_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1627,42 +1627,42 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 211.579568
-  0: The maximum resident set size (KB)                   = 1111268
+  0: The total amount of wall time                        = 216.364299
+  0: The maximum resident set size (KB)                   = 1127028
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_control_debug_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 229.418327
-  0: The maximum resident set size (KB)                   = 1126952
+  0: The total amount of wall time                        = 226.252586
+  0: The maximum resident set size (KB)                   = 1131220
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 224.292371
-  0: The maximum resident set size (KB)                   = 1126812
+  0: The total amount of wall time                        = 225.633889
+  0: The maximum resident set size (KB)                   = 1126732
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/conus13km_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 059 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 657.460996
-  0: The maximum resident set size (KB)                   = 1396728
+  0: The total amount of wall time                        = 659.151642
+  0: The maximum resident set size (KB)                   = 1419532
 
 Test 059 conus13km_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/conus13km_debug_qr_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1697,54 +1697,54 @@ Checking test 060 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 669.364558
-  0: The maximum resident set size (KB)                   = 1058836
+  0: The total amount of wall time                        = 665.319325
+  0: The maximum resident set size (KB)                   = 1074192
 
 Test 060 conus13km_debug_qr_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/conus13km_debug_2threads_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 372.916580
-  0: The maximum resident set size (KB)                   = 1291624
+  0: The total amount of wall time                        = 373.020285
+  0: The maximum resident set size (KB)                   = 1288364
 
 Test 061 conus13km_debug_2threads_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/conus13km_radar_tten_debug_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/conus13km_radar_tten_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 658.831123
-  0: The maximum resident set size (KB)                   = 1473784
+  0: The total amount of wall time                        = 673.099784
+  0: The maximum resident set size (KB)                   = 1482032
 
 Test 062 conus13km_radar_tten_debug_intel PASS
 
 
 baseline dir = /work/noaa/epic/hercules/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn64_phy32_intel
-working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_3565763/rap_control_dyn64_phy32_debug_intel
+working dir  = /work2/noaa/stmp/jongkim/stmp/jongkim/FV3_RT/rt_194271/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 232.483701
-  0: The maximum resident set size (KB)                   = 1205884
+  0: The total amount of wall time                        = 232.804612
+  0: The maximum resident set size (KB)                   = 1221568
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri May  3 08:46:48 CDT 2024
-Elapsed time: 00h:30m:29s. Have a nice day!
+Mon May  6 07:22:56 PM CDT 2024
+Elapsed time: 01h:36m:20s. Have a nice day!

--- a/tests/logs/RegressionTests_wcoss2.log
+++ b/tests/logs/RegressionTests_wcoss2.log
@@ -1,31 +1,31 @@
-Mon Apr 22 16:02:54 UTC 2024
+Tue May  7 11:18:26 UTC 2024
 Start Regression test
 
-Testing UFSWM Hash: 892580dfd10c9ba047b616cfa9c4f31fac673686
+Testing UFSWM Hash: 4716e3219807956b358e05fdbd171005792f6ac6
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 594260f2d287035141a861be9dcd9566e4d4a8c0 FV3 (heads/feature/paraio)
+ e2b55dfa0cdf576a2947effed32dfebf2827ef2f FV3 (remotes/origin/production/RRFS.v1/swdnclrskyflx_diag)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 914 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 1008 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 317 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 578 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 801 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 403 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 896 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 519 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 564 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 1068 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 709 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 488 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 477 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 494 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 540 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 520 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 408.894865
-The maximum resident set size (KB)                   = 926416
+The total amount of wall time                        = 405.041741
+The maximum resident set size (KB)                   = 926996
 
 Test 001 rap_control_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 241.292376
-The maximum resident set size (KB)                   = 1141524
+The total amount of wall time                        = 239.101947
+The maximum resident set size (KB)                   = 1137728
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 425.086399
-The maximum resident set size (KB)                   = 928740
+The total amount of wall time                        = 420.953252
+The maximum resident set size (KB)                   = 929984
 
 Test 003 rap_decomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 371.720137
-The maximum resident set size (KB)                   = 1007424
+The total amount of wall time                        = 368.478270
+The maximum resident set size (KB)                   = 1013800
 
 Test 004 rap_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_restart_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 209.896890
-The maximum resident set size (KB)                   = 793904
+The total amount of wall time                        = 208.180989
+The maximum resident set size (KB)                   = 793472
 
 Test 005 rap_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 406.073865
-The maximum resident set size (KB)                   = 923384
+The total amount of wall time                        = 405.309705
+The maximum resident set size (KB)                   = 920452
 
 Test 006 rap_sfcdiff_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_sfcdiff_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 423.975002
-The maximum resident set size (KB)                   = 923928
+The total amount of wall time                        = 421.438087
+The maximum resident set size (KB)                   = 926244
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_sfcdiff_restart_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 304.799271
-The maximum resident set size (KB)                   = 791592
+The total amount of wall time                        = 303.126944
+The maximum resident set size (KB)                   = 795004
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 208.959641
-The maximum resident set size (KB)                   = 919904
+The total amount of wall time                        = 207.749699
+The maximum resident set size (KB)                   = 923444
 
 Test 009 hrrr_control_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_decomp_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 213.543734
-The maximum resident set size (KB)                   = 919396
+The total amount of wall time                        = 212.543061
+The maximum resident set size (KB)                   = 917016
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 186.960447
-The maximum resident set size (KB)                   = 997692
+The total amount of wall time                        = 184.985425
+The maximum resident set size (KB)                   = 996320
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_restart_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 112.513364
-The maximum resident set size (KB)                   = 751276
+The total amount of wall time                        = 109.753435
+The maximum resident set size (KB)                   = 743544
 
 Test 012 hrrr_control_restart_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 399.388494
-The maximum resident set size (KB)                   = 920360
+The total amount of wall time                        = 396.096795
+The maximum resident set size (KB)                   = 920928
 
 Test 013 rrfs_v1beta_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 486.524381
-The maximum resident set size (KB)                   = 1876120
+The total amount of wall time                        = 492.114084
+The maximum resident set size (KB)                   = 1876008
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 468.985493
-The maximum resident set size (KB)                   = 1871424
+The total amount of wall time                        = 469.103935
+The maximum resident set size (KB)                   = 1870888
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 161.404868
-The maximum resident set size (KB)                   = 1505104
+The total amount of wall time                        = 160.685516
+The maximum resident set size (KB)                   = 1514228
 
 Test 016 control_p8_faster_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 274.995798
-The maximum resident set size (KB)                   = 660056
+The total amount of wall time                        = 274.656585
+The maximum resident set size (KB)                   = 659188
 
 Test 017 regional_control_faster_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 162.207644
-The maximum resident set size (KB)                   = 692876
+The total amount of wall time                        = 161.309155
+The maximum resident set size (KB)                   = 687980
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 160.899240
-The maximum resident set size (KB)                   = 690124
+The total amount of wall time                        = 159.919280
+The maximum resident set size (KB)                   = 693728
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 181.224626
-The maximum resident set size (KB)                   = 699980
+The total amount of wall time                        = 179.957113
+The maximum resident set size (KB)                   = 699180
 
 Test 020 control_stochy_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.877498
-The maximum resident set size (KB)                   = 697012
+The total amount of wall time                        = 162.287309
+The maximum resident set size (KB)                   = 695864
 
 Test 021 control_lndp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 260.300916
-The maximum resident set size (KB)                   = 733668
+The total amount of wall time                        = 252.551318
+The maximum resident set size (KB)                   = 736476
 
 Test 022 control_csawmg_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 247.467026
-The maximum resident set size (KB)                   = 730672
+The total amount of wall time                        = 249.040388
+The maximum resident set size (KB)                   = 736240
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.972618
-The maximum resident set size (KB)                   = 709280
+The total amount of wall time                        = 164.612476
+The maximum resident set size (KB)                   = 706788
 
 Test 024 control_ras_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 168.040373
-The maximum resident set size (KB)                   = 753920
+The total amount of wall time                        = 166.830719
+The maximum resident set size (KB)                   = 749812
 
 Test 025 control_diag_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 169.127436
-The maximum resident set size (KB)                   = 1528380
+The total amount of wall time                        = 170.949362
+The maximum resident set size (KB)                   = 1519648
 
 Test 026 control_debug_p8_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1063.169047
-The maximum resident set size (KB)                   = 660764
+The total amount of wall time                        = 1055.976704
+The maximum resident set size (KB)                   = 656892
 
 Test 027 regional_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.078054
-The maximum resident set size (KB)                   = 1083636
+The total amount of wall time                        = 303.314869
+The maximum resident set size (KB)                   = 1088720
 
 Test 028 rap_control_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 298.818306
-The maximum resident set size (KB)                   = 1083052
+The total amount of wall time                        = 296.829069
+The maximum resident set size (KB)                   = 1077168
 
 Test 029 hrrr_control_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_gf_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_gf_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 304.152300
-The maximum resident set size (KB)                   = 1086000
+The total amount of wall time                        = 302.649358
+The maximum resident set size (KB)                   = 1087064
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_c3_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_c3_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.141055
-The maximum resident set size (KB)                   = 1089900
+The total amount of wall time                        = 305.077480
+The maximum resident set size (KB)                   = 1082804
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_unified_drag_suite_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.782406
-The maximum resident set size (KB)                   = 1085564
+The total amount of wall time                        = 303.876405
+The maximum resident set size (KB)                   = 1088732
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 320.197597
-The maximum resident set size (KB)                   = 1170792
+The total amount of wall time                        = 317.830172
+The maximum resident set size (KB)                   = 1176408
 
 Test 033 rap_diag_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 316.422462
-The maximum resident set size (KB)                   = 1094236
+The total amount of wall time                        = 310.030618
+The maximum resident set size (KB)                   = 1083292
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_unified_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 317.036027
-The maximum resident set size (KB)                   = 1091088
+The total amount of wall time                        = 309.342160
+The maximum resident set size (KB)                   = 1087684
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 310.333294
-The maximum resident set size (KB)                   = 1091720
+The total amount of wall time                        = 306.433971
+The maximum resident set size (KB)                   = 1091724
 
 Test 036 rap_lndp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.774981
-The maximum resident set size (KB)                   = 1085480
+The total amount of wall time                        = 303.284059
+The maximum resident set size (KB)                   = 1085084
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.785943
-The maximum resident set size (KB)                   = 1084720
+The total amount of wall time                        = 298.205683
+The maximum resident set size (KB)                   = 1085140
 
 Test 038 rap_noah_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.481064
-The maximum resident set size (KB)                   = 1085268
+The total amount of wall time                        = 304.834535
+The maximum resident set size (KB)                   = 1087892
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 496.945849
-The maximum resident set size (KB)                   = 1082912
+The total amount of wall time                        = 494.115164
+The maximum resident set size (KB)                   = 1083548
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.119530
-The maximum resident set size (KB)                   = 1081444
+The total amount of wall time                        = 299.792012
+The maximum resident set size (KB)                   = 1082756
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 356.165018
-The maximum resident set size (KB)                   = 1086220
+The total amount of wall time                        = 353.619430
+The maximum resident set size (KB)                   = 1087688
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.250070
-The maximum resident set size (KB)                   = 1089464
+The total amount of wall time                        = 305.225981
+The maximum resident set size (KB)                   = 1088804
 
 Test 043 rap_flake_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/gnv1_c96_no_nest_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/gnv1_c96_no_nest_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 535.746289
-The maximum resident set size (KB)                   = 1095880
+The total amount of wall time                        = 531.540718
+The maximum resident set size (KB)                   = 1090528
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 229.164648
-The maximum resident set size (KB)                   = 997096
+The total amount of wall time                        = 227.011985
+The maximum resident set size (KB)                   = 1000212
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 338.627935
-The maximum resident set size (KB)                   = 804676
+The total amount of wall time                        = 335.698468
+The maximum resident set size (KB)                   = 804368
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 178.241083
-The maximum resident set size (KB)                   = 798680
+The total amount of wall time                        = 176.618443
+The maximum resident set size (KB)                   = 799760
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_2threads_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 309.104447
-The maximum resident set size (KB)                   = 856492
+The total amount of wall time                        = 307.423344
+The maximum resident set size (KB)                   = 855276
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_2threads_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 161.179794
-The maximum resident set size (KB)                   = 848024
+The total amount of wall time                        = 159.355536
+The maximum resident set size (KB)                   = 851148
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_decomp_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 185.745558
-The maximum resident set size (KB)                   = 798040
+The total amount of wall time                        = 184.367395
+The maximum resident set size (KB)                   = 799512
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_restart_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,28 +1510,28 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 254.406037
-The maximum resident set size (KB)                   = 696540
+The total amount of wall time                        = 250.868250
+The maximum resident set size (KB)                   = 698464
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_restart_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 98.136692
-The maximum resident set size (KB)                   = 680964
+The total amount of wall time                        = 96.747547
+The maximum resident set size (KB)                   = 676716
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1547,40 +1547,40 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 112.523571
-The maximum resident set size (KB)                   = 1038480
+The total amount of wall time                        = 111.284013
+The maximum resident set size (KB)                   = 1037180
 
 Test 053 conus13km_control_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/conus13km_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 56.531444
-The maximum resident set size (KB)                   = 1045200
+The total amount of wall time                        = 55.432987
+The maximum resident set size (KB)                   = 1042188
 
 Test 054 conus13km_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/conus13km_restart_mismatch_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/conus13km_restart_mismatch_intel
 Checking test 055 conus13km_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 67.764635
-The maximum resident set size (KB)                   = 933064
+The total amount of wall time                        = 68.855315
+The maximum resident set size (KB)                   = 932212
 
 Test 055 conus13km_restart_mismatch_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1627,42 +1627,42 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 231.988021
-The maximum resident set size (KB)                   = 836452
+The total amount of wall time                        = 229.724462
+The maximum resident set size (KB)                   = 832004
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.262569
-The maximum resident set size (KB)                   = 969028
+The total amount of wall time                        = 297.454151
+The maximum resident set size (KB)                   = 966220
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 291.967010
-The maximum resident set size (KB)                   = 963164
+The total amount of wall time                        = 291.857316
+The maximum resident set size (KB)                   = 962784
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 059 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 852.878444
-The maximum resident set size (KB)                   = 1072072
+The total amount of wall time                        = 849.182228
+The maximum resident set size (KB)                   = 1072644
 
 Test 059 conus13km_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/conus13km_debug_qr_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1697,54 +1697,54 @@ Checking test 060 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 859.512481
-The maximum resident set size (KB)                   = 762772
+The total amount of wall time                        = 859.119566
+The maximum resident set size (KB)                   = 763068
 
 Test 060 conus13km_debug_qr_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/conus13km_debug_2threads_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 493.478344
-The maximum resident set size (KB)                   = 1078536
+The total amount of wall time                        = 489.710712
+The maximum resident set size (KB)                   = 1078636
 
 Test 061 conus13km_debug_2threads_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/conus13km_radar_tten_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/conus13km_radar_tten_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 854.154061
-The maximum resident set size (KB)                   = 1140212
+The total amount of wall time                        = 851.694429
+The maximum resident set size (KB)                   = 1140680
 
 Test 062 conus13km_radar_tten_debug_intel PASS
 
 
 baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240410/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_194729/rap_control_dyn64_phy32_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_157306/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.574451
-The maximum resident set size (KB)                   = 998320
+The total amount of wall time                        = 300.796933
+The maximum resident set size (KB)                   = 996588
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Mon Apr 22 16:40:38 UTC 2024
-Elapsed time: 00h:37m:45s. Have a nice day!
+Tue May  7 11:54:52 UTC 2024
+Elapsed time: 00h:36m:27s. Have a nice day!


### PR DESCRIPTION
## Description:
This PR adds a new diagnostic, instantaneous downward shortwave flux at the surface assuming clear-sky conditions.
This is needed for RRFSv1.

Analogous to #2248 into develop.

### Commit Message:
N/A

### Priority:
High: Time-sensitive project. Needed for RRFSv1.

## Git Tracking
### UFSWM:
N/A

### Sub component Pull Requests:
* [FV3: NOAA-EMC/fv3atm#825](https://github.com/NOAA-EMC/fv3atm/pull/825)
* [ccpp-physics: ufs-community/ccpp-physics#198](https://github.com/ufs-community/ccpp-physics/pull/198)


---
## Changes
### Regression Test Changes (Please commit test_changes.list):
<!--
Please let us know if this PR creates new baselines, changes baselines or not.
Please delete what is not needed.
Please make sure you have properly submitted test_changes.list
-->
* PR Adds New Tests/Baselines.
* PR Updates/Changes Baselines.
* No Baseline Changes.

### Input data Changes:
* None.

### Library Changes/Upgrades:
* None.

---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [x] Hera
  - [ ] Orion
  - [x] Hercules
  - [ ] Jet
  - [ ] Gaea
  - [ ] Derecho
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- [ ] CI
- [ ] opnReqTest (complete task if unnecessary)