### PR TITLE
[production/RRFS.v1] saSAS sigmab initialization changes and and inline post bug fix for RUC LSM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-#  url = https://github.com/NOAA-EMC/fv3atm
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/fv3atm 
-  branch = sigmab_fix 
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = production/RRFS.v1
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = production/RRFS.v1
+#  url = https://github.com/NOAA-EMC/fv3atm
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/fv3atm 
+  branch = sigmab_fix 
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/tests/bl_date.conf
+++ b/tests/bl_date.conf
@@ -1,1 +1,1 @@
-export BL_DATE=20240627
+export BL_DATE=20250123

--- a/tests/logs/RegressionTests_hera.log
+++ b/tests/logs/RegressionTests_hera.log
@@ -1,31 +1,31 @@
-Tue Sep  3 17:11:23 UTC 2024
+Fri Jan 24 02:35:34 UTC 2025
 Start Regression test
 
-Testing UFSWM Hash: 140e5cf8bb2a11a6cd8d2572265507bbaef4eaa2
+Testing UFSWM Hash: b468cce5ef61fc664b8db1bceb7f58892ef9cb54
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- bc0d02a958345a0899091e5cef544e1a2306cf0c FV3 (remotes/origin/fix_ens_crash)
+ 89b620e0b4c3d30175afb1a099b6a28370568cc2 FV3 (remotes/origin/sigmab_fix)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 343 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 653 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 236 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 638 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_intel elapsed time 589 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 236 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 595 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 638 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 326 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 614 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 240 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 610 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_intel elapsed time 586 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 240 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 589 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 616 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_control_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 455.918062
-  0: The maximum resident set size (KB)                   = 1133772
+  0: The total amount of wall time                        = 478.295973
+  0: The maximum resident set size (KB)                   = 1079728
 
 Test 001 rap_control_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/regional_spp_sppt_shum_skeb_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/regional_spp_sppt_shum_skeb_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/regional_spp_sppt_shum_skeb_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 244.729772
-  0: The maximum resident set size (KB)                   = 1384028
+  0: The total amount of wall time                        = 239.934541
+  0: The maximum resident set size (KB)                   = 1350548
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_decomp_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 476.887842
-  0: The maximum resident set size (KB)                   = 1067312
+  0: The total amount of wall time                        = 478.680854
+  0: The maximum resident set size (KB)                   = 1045876
 
 Test 003 rap_decomp_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_2threads_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 427.741827
-  0: The maximum resident set size (KB)                   = 1211804
+  0: The total amount of wall time                        = 427.932906
+  0: The maximum resident set size (KB)                   = 1193100
 
 Test 004 rap_2threads_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_restart_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 230.968990
-  0: The maximum resident set size (KB)                   = 1117416
+  0: The total amount of wall time                        = 237.017512
+  0: The maximum resident set size (KB)                   = 1102844
 
 Test 005 rap_restart_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_sfcdiff_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 451.849906
-  0: The maximum resident set size (KB)                   = 1131544
+  0: The total amount of wall time                        = 456.954366
+  0: The maximum resident set size (KB)                   = 1111568
 
 Test 006 rap_sfcdiff_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_sfcdiff_decomp_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 477.844748
-  0: The maximum resident set size (KB)                   = 1066660
+  0: The total amount of wall time                        = 482.781811
+  0: The maximum resident set size (KB)                   = 1041952
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_sfcdiff_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_sfcdiff_restart_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_sfcdiff_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 340.632808
-  0: The maximum resident set size (KB)                   = 1155024
+  0: The total amount of wall time                        = 347.791366
+  0: The maximum resident set size (KB)                   = 1127448
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 228.606888
-  0: The maximum resident set size (KB)                   = 1071652
+  0: The total amount of wall time                        = 229.655477
+  0: The maximum resident set size (KB)                   = 1048536
 
 Test 009 hrrr_control_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_decomp_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 235.945358
-  0: The maximum resident set size (KB)                   = 1067224
+  0: The total amount of wall time                        = 236.641221
+  0: The maximum resident set size (KB)                   = 1039740
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_2threads_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 210.214786
-  0: The maximum resident set size (KB)                   = 1141164
+  0: The total amount of wall time                        = 212.646153
+  0: The maximum resident set size (KB)                   = 1112084
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_restart_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 119.733487
-  0: The maximum resident set size (KB)                   = 1029424
+  0: The total amount of wall time                        = 129.979567
+  0: The maximum resident set size (KB)                   = 1004608
 
 Test 012 hrrr_control_restart_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rrfs_v1beta_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rrfs_v1beta_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rrfs_v1beta_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 444.732267
-  0: The maximum resident set size (KB)                   = 1117644
+  0: The total amount of wall time                        = 449.915867
+  0: The maximum resident set size (KB)                   = 1098232
 
 Test 013 rrfs_v1beta_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rrfs_v1nssl_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rrfs_v1nssl_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rrfs_v1nssl_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 552.042011
-  0: The maximum resident set size (KB)                   = 2012216
+  0: The total amount of wall time                        = 550.327079
+  0: The maximum resident set size (KB)                   = 1994748
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 532.432204
-  0: The maximum resident set size (KB)                   = 2060296
+  0: The total amount of wall time                        = 543.863833
+  0: The maximum resident set size (KB)                   = 2023948
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_p8_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_p8_faster_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_p8_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 148.081419
-  0: The maximum resident set size (KB)                   = 1643180
+  0: The total amount of wall time                        = 148.416129
+  0: The maximum resident set size (KB)                   = 1625184
 
 Test 016 control_p8_faster_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/regional_control_faster_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/regional_control_faster_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/regional_control_faster_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 272.430973
-  0: The maximum resident set size (KB)                   = 908492
+  0: The total amount of wall time                        = 276.719147
+  0: The maximum resident set size (KB)                   = 885996
 
 Test 017 regional_control_faster_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_CubedSphereGrid_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_CubedSphereGrid_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_CubedSphereGrid_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 152.287041
-  0: The maximum resident set size (KB)                   = 836952
+  0: The total amount of wall time                        = 152.335851
+  0: The maximum resident set size (KB)                   = 800228
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_wrtGauss_netcdf_parallel_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.355751
-  0: The maximum resident set size (KB)                   = 836012
+  0: The total amount of wall time                        = 152.531171
+  0: The maximum resident set size (KB)                   = 795580
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_stochy_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_stochy_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_stochy_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 175.875842
-  0: The maximum resident set size (KB)                   = 841240
+  0: The total amount of wall time                        = 173.077851
+  0: The maximum resident set size (KB)                   = 795076
 
 Test 020 control_stochy_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_lndp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.873421
-  0: The maximum resident set size (KB)                   = 842488
+  0: The total amount of wall time                        = 154.560945
+  0: The maximum resident set size (KB)                   = 800584
 
 Test 021 control_lndp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_csawmg_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_csawmg_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_csawmg_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 241.230618
-  0: The maximum resident set size (KB)                   = 880532
+  0: The total amount of wall time                        = 240.823199
+  0: The maximum resident set size (KB)                   = 840300
 
 Test 022 control_csawmg_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_csawmgt_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_csawmgt_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_csawmgt_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.838719
-  0: The maximum resident set size (KB)                   = 877388
+  0: The total amount of wall time                        = 232.120305
+  0: The maximum resident set size (KB)                   = 844592
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_ras_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_ras_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_ras_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 155.905505
-  0: The maximum resident set size (KB)                   = 848128
+  0: The total amount of wall time                        = 169.814661
+  0: The maximum resident set size (KB)                   = 802664
 
 Test 024 control_ras_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_diag_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.008165
-  0: The maximum resident set size (KB)                   = 889752
+  0: The total amount of wall time                        = 163.071226
+  0: The maximum resident set size (KB)                   = 847240
 
 Test 025 control_diag_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/control_debug_p8_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/control_debug_p8_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/control_debug_p8_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 160.394820
-  0: The maximum resident set size (KB)                   = 1665128
+  0: The total amount of wall time                        = 167.918529
+  0: The maximum resident set size (KB)                   = 1619772
 
 Test 026 control_debug_p8_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/regional_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/regional_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/regional_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-  0: The total amount of wall time                        = 1019.885116
-  0: The maximum resident set size (KB)                   = 882812
+  0: The total amount of wall time                        = 1043.566609
+  0: The maximum resident set size (KB)                   = 839680
 
 Test 027 regional_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_control_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 291.628357
-  0: The maximum resident set size (KB)                   = 1235348
+  0: The total amount of wall time                        = 287.690370
+  0: The maximum resident set size (KB)                   = 1198324
 
 Test 028 rap_control_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 282.784123
-  0: The maximum resident set size (KB)                   = 1230940
+  0: The total amount of wall time                        = 282.851497
+  0: The maximum resident set size (KB)                   = 1185816
 
 Test 029 hrrr_control_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_gf_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_gf_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_gf_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.479051
-  0: The maximum resident set size (KB)                   = 1239416
+  0: The total amount of wall time                        = 283.747611
+  0: The maximum resident set size (KB)                   = 1192848
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_c3_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_c3_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_c3_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 285.823562
-  0: The maximum resident set size (KB)                   = 1235804
+  0: The total amount of wall time                        = 286.642151
+  0: The maximum resident set size (KB)                   = 1196136
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_unified_drag_suite_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.766833
-  0: The maximum resident set size (KB)                   = 1233776
+  0: The total amount of wall time                        = 285.396340
+  0: The maximum resident set size (KB)                   = 1198784
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_diag_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_diag_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_diag_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 299.763076
-  0: The maximum resident set size (KB)                   = 1319804
+  0: The total amount of wall time                        = 301.474507
+  0: The maximum resident set size (KB)                   = 1275080
 
 Test 033 rap_diag_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_cires_ugwp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.578252
-  0: The maximum resident set size (KB)                   = 1240988
+  0: The total amount of wall time                        = 293.873807
+  0: The maximum resident set size (KB)                   = 1195924
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_unified_ugwp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 296.206529
-  0: The maximum resident set size (KB)                   = 1250616
+  0: The total amount of wall time                        = 293.494554
+  0: The maximum resident set size (KB)                   = 1195680
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_lndp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_lndp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_lndp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 287.452099
-  0: The maximum resident set size (KB)                   = 1237096
+  0: The total amount of wall time                        = 290.872428
+  0: The maximum resident set size (KB)                   = 1193736
 
 Test 036 rap_lndp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_progcld_thompson_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_progcld_thompson_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_progcld_thompson_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 281.224531
-  0: The maximum resident set size (KB)                   = 1234176
+  0: The total amount of wall time                        = 291.285451
+  0: The maximum resident set size (KB)                   = 1193948
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_noah_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_noah_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_noah_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 279.777446
-  0: The maximum resident set size (KB)                   = 1234804
+  0: The total amount of wall time                        = 279.993239
+  0: The maximum resident set size (KB)                   = 1199780
 
 Test 038 rap_noah_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_sfcdiff_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_sfcdiff_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_sfcdiff_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 289.498601
-  0: The maximum resident set size (KB)                   = 1237996
+  0: The total amount of wall time                        = 282.431812
+  0: The maximum resident set size (KB)                   = 1193896
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_noah_sfcdiff_cires_ugwp_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 465.352975
-  0: The maximum resident set size (KB)                   = 1231444
+  0: The total amount of wall time                        = 472.720317
+  0: The maximum resident set size (KB)                   = 1194032
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rrfs_v1beta_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rrfs_v1beta_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rrfs_v1beta_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.301240
-  0: The maximum resident set size (KB)                   = 1227644
+  0: The total amount of wall time                        = 302.470086
+  0: The maximum resident set size (KB)                   = 1186988
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_clm_lake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_clm_lake_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_clm_lake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 345.594156
-  0: The maximum resident set size (KB)                   = 1240356
+  0: The total amount of wall time                        = 348.784204
+  0: The maximum resident set size (KB)                   = 1196892
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_flake_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_flake_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_flake_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 280.283575
-  0: The maximum resident set size (KB)                   = 1235420
+  0: The total amount of wall time                        = 285.987866
+  0: The maximum resident set size (KB)                   = 1194856
 
 Test 043 rap_flake_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/gnv1_c96_no_nest_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/gnv1_c96_no_nest_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/gnv1_c96_no_nest_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 504.233110
-  0: The maximum resident set size (KB)                   = 1234560
+  0: The total amount of wall time                        = 498.150070
+  0: The maximum resident set size (KB)                   = 1192376
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 223.367129
-  0: The maximum resident set size (KB)                   = 1244696
+  0: The total amount of wall time                        = 225.673147
+  0: The maximum resident set size (KB)                   = 1222812
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_control_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 375.275833
-  0: The maximum resident set size (KB)                   = 1054820
+  0: The total amount of wall time                        = 378.401934
+  0: The maximum resident set size (KB)                   = 1052052
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 192.522666
-  0: The maximum resident set size (KB)                   = 997768
+  0: The total amount of wall time                        = 194.604900
+  0: The maximum resident set size (KB)                   = 985700
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_2threads_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 355.521115
-  0: The maximum resident set size (KB)                   = 1121568
+  0: The total amount of wall time                        = 360.058709
+  0: The maximum resident set size (KB)                   = 1105580
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_2threads_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 180.514591
-  0: The maximum resident set size (KB)                   = 985036
+  0: The total amount of wall time                        = 181.642363
+  0: The maximum resident set size (KB)                   = 968756
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_decomp_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 206.385452
-  0: The maximum resident set size (KB)                   = 950000
+  0: The total amount of wall time                        = 207.837013
+  0: The maximum resident set size (KB)                   = 933248
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_restart_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,28 +1510,28 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 281.761488
-  0: The maximum resident set size (KB)                   = 1043788
+  0: The total amount of wall time                        = 298.186905
+  0: The maximum resident set size (KB)                   = 1026264
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_restart_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 101.216743
-  0: The maximum resident set size (KB)                   = 947676
+  0: The total amount of wall time                        = 104.398502
+  0: The maximum resident set size (KB)                   = 920488
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/conus13km_control_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/conus13km_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1547,40 +1547,40 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 108.398763
-  0: The maximum resident set size (KB)                   = 1263728
+  0: The total amount of wall time                        = 114.440469
+  0: The maximum resident set size (KB)                   = 1230740
 
 Test 053 conus13km_control_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/conus13km_control_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/conus13km_2threads_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/conus13km_control_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 42.232672
-  0: The maximum resident set size (KB)                   = 1154232
+  0: The total amount of wall time                        = 42.935458
+  0: The maximum resident set size (KB)                   = 1138600
 
 Test 054 conus13km_2threads_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/conus13km_restart_mismatch_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/conus13km_restart_mismatch_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/conus13km_restart_mismatch_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/conus13km_restart_mismatch_intel
 Checking test 055 conus13km_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 61.934285
-  0: The maximum resident set size (KB)                   = 1145472
+  0: The total amount of wall time                        = 68.863273
+  0: The maximum resident set size (KB)                   = 1118280
 
 Test 055 conus13km_restart_mismatch_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_control_dyn64_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1627,42 +1627,42 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 256.027666
-  0: The maximum resident set size (KB)                   = 1019772
+  0: The total amount of wall time                        = 257.439730
+  0: The maximum resident set size (KB)                   = 1002488
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_control_debug_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.278754
-  0: The maximum resident set size (KB)                   = 1112908
+  0: The total amount of wall time                        = 286.656155
+  0: The maximum resident set size (KB)                   = 1070256
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/hrrr_control_debug_dyn32_phy32_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 284.435824
-  0: The maximum resident set size (KB)                   = 1113052
+  0: The total amount of wall time                        = 281.544290
+  0: The maximum resident set size (KB)                   = 1073552
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/conus13km_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 059 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-  0: The total amount of wall time                        = 821.767593
-  0: The maximum resident set size (KB)                   = 1298560
+  0: The total amount of wall time                        = 839.441577
+  0: The maximum resident set size (KB)                   = 1229220
 
 Test 059 conus13km_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/conus13km_debug_qr_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1697,54 +1697,54 @@ Checking test 060 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 814.363217
-  0: The maximum resident set size (KB)                   = 997108
+  0: The total amount of wall time                        = 845.474447
+  0: The maximum resident set size (KB)                   = 945716
 
 Test 060 conus13km_debug_qr_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/conus13km_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/conus13km_debug_2threads_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/conus13km_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 468.710664
-  0: The maximum resident set size (KB)                   = 1199348
+  0: The total amount of wall time                        = 465.999446
+  0: The maximum resident set size (KB)                   = 1105400
 
 Test 061 conus13km_debug_2threads_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/conus13km_radar_tten_debug_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/conus13km_radar_tten_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/conus13km_radar_tten_debug_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 831.901025
-  0: The maximum resident set size (KB)                   = 1365132
+  0: The total amount of wall time                        = 825.390359
+  0: The maximum resident set size (KB)                   = 1295236
 
 Test 062 conus13km_radar_tten_debug_intel PASS
 
 
-baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20240627/rap_control_debug_dyn64_phy32_intel
-working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_607417/rap_control_dyn64_phy32_debug_intel
+baseline dir = /scratch2/NAGAPE/epic/UFS-WM_RT/RRFS.v1/NEMSfv3gfs/develop-20250123/rap_control_debug_dyn64_phy32_intel
+working dir  = /scratch1/NCEPDEV/stmp2/Jong.Kim/FV3_RT/rt_3020925/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 292.964942
-  0: The maximum resident set size (KB)                   = 1186800
+  0: The total amount of wall time                        = 292.047296
+  0: The maximum resident set size (KB)                   = 1142848
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Sep  3 17:45:48 UTC 2024
-Elapsed time: 00h:34m:26s. Have a nice day!
+Fri Jan 24 03:07:40 UTC 2025
+Elapsed time: 00h:32m:07s. Have a nice day!

--- a/tests/logs/RegressionTests_wcoss2.log
+++ b/tests/logs/RegressionTests_wcoss2.log
@@ -1,31 +1,31 @@
-Wed Sep  4 14:26:13 UTC 2024
+Fri Jan 24 14:54:18 UTC 2025
 Start Regression test
 
-Testing UFSWM Hash: c18369bda00909df7dc2f6b9b3b72f88d0de3d1f
+Testing UFSWM Hash: 42ea68dd8bf8ff6ba7cca9639bc0ed738c7e7b71
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
  13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- bc0d02a958345a0899091e5cef544e1a2306cf0c FV3 (remotes/origin/fix_ens_crash)
+ 89b620e0b4c3d30175afb1a099b6a28370568cc2 FV3 (remotes/origin/sigmab_fix)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  a5561802021d89a9a1e2b52cb69393efcdc6f71c stochastic_physics (ufs-v2.0.0-199-ga556180)
-Compile atm_debug_dyn32_intel elapsed time 287 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile atm_faster_dyn32_intel elapsed time 500 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 194 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 482 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile atm_debug_dyn32_intel elapsed time 284 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_faster_dyn32_intel elapsed time 502 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 205 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 488 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile rrfs_dyn32_phy32_intel elapsed time 471 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 193 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 479 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 521 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 481 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 522 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 404.223820
-The maximum resident set size (KB)                   = 924916
+The total amount of wall time                        = 421.266627
+The maximum resident set size (KB)                   = 1022852
 
 Test 001 rap_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/regional_spp_sppt_shum_skeb_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 237.760219
-The maximum resident set size (KB)                   = 1140740
+The total amount of wall time                        = 243.025647
+The maximum resident set size (KB)                   = 1237604
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 421.155258
-The maximum resident set size (KB)                   = 925716
+The total amount of wall time                        = 442.991968
+The maximum resident set size (KB)                   = 1019692
 
 Test 003 rap_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 367.639480
-The maximum resident set size (KB)                   = 1012284
+The total amount of wall time                        = 391.858805
+The maximum resident set size (KB)                   = 1098372
 
 Test 004 rap_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 208.121823
-The maximum resident set size (KB)                   = 788656
+The total amount of wall time                        = 211.673076
+The maximum resident set size (KB)                   = 895964
 
 Test 005 rap_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_sfcdiff_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 404.320157
-The maximum resident set size (KB)                   = 918728
+The total amount of wall time                        = 423.649933
+The maximum resident set size (KB)                   = 1018984
 
 Test 006 rap_sfcdiff_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_sfcdiff_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 421.167837
-The maximum resident set size (KB)                   = 925792
+The total amount of wall time                        = 435.005487
+The maximum resident set size (KB)                   = 1019796
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_sfcdiff_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 302.784584
-The maximum resident set size (KB)                   = 792868
+The total amount of wall time                        = 308.673911
+The maximum resident set size (KB)                   = 897308
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 206.529192
-The maximum resident set size (KB)                   = 920184
+The total amount of wall time                        = 210.965839
+The maximum resident set size (KB)                   = 1009852
 
 Test 009 hrrr_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 212.392755
-The maximum resident set size (KB)                   = 916992
+The total amount of wall time                        = 216.810130
+The maximum resident set size (KB)                   = 1014388
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 184.493988
-The maximum resident set size (KB)                   = 999852
+The total amount of wall time                        = 188.352821
+The maximum resident set size (KB)                   = 1096756
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 110.305146
-The maximum resident set size (KB)                   = 748020
+The total amount of wall time                        = 115.589373
+The maximum resident set size (KB)                   = 848084
 
 Test 012 hrrr_control_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rrfs_v1beta_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 396.874628
-The maximum resident set size (KB)                   = 915256
+The total amount of wall time                        = 409.238590
+The maximum resident set size (KB)                   = 1015956
 
 Test 013 rrfs_v1beta_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rrfs_v1nssl_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 485.161744
-The maximum resident set size (KB)                   = 1872280
+The total amount of wall time                        = 504.778895
+The maximum resident set size (KB)                   = 1971588
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 469.698968
-The maximum resident set size (KB)                   = 1864916
+The total amount of wall time                        = 482.383029
+The maximum resident set size (KB)                   = 1961116
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_p8_faster_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 158.728577
-The maximum resident set size (KB)                   = 1507176
+The total amount of wall time                        = 160.040276
+The maximum resident set size (KB)                   = 1598484
 
 Test 016 control_p8_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/regional_control_faster_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 276.788404
-The maximum resident set size (KB)                   = 659900
+The total amount of wall time                        = 296.805031
+The maximum resident set size (KB)                   = 674364
 
 Test 017 regional_control_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_CubedSphereGrid_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 164.158364
-The maximum resident set size (KB)                   = 688180
+The total amount of wall time                        = 160.634655
+The maximum resident set size (KB)                   = 796424
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_wrtGauss_netcdf_parallel_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 164.380746
-The maximum resident set size (KB)                   = 692896
+The total amount of wall time                        = 162.448141
+The maximum resident set size (KB)                   = 802336
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_stochy_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 183.662454
-The maximum resident set size (KB)                   = 698788
+The total amount of wall time                        = 181.621742
+The maximum resident set size (KB)                   = 813376
 
 Test 020 control_stochy_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_lndp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 165.351369
-The maximum resident set size (KB)                   = 694372
+The total amount of wall time                        = 166.434534
+The maximum resident set size (KB)                   = 804868
 
 Test 021 control_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_csawmg_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 255.425572
-The maximum resident set size (KB)                   = 733660
+The total amount of wall time                        = 255.568976
+The maximum resident set size (KB)                   = 843528
 
 Test 022 control_csawmg_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_csawmgt_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 251.331053
-The maximum resident set size (KB)                   = 735424
+The total amount of wall time                        = 250.390232
+The maximum resident set size (KB)                   = 842796
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_ras_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 166.467735
-The maximum resident set size (KB)                   = 708064
+The total amount of wall time                        = 165.852552
+The maximum resident set size (KB)                   = 812132
 
 Test 024 control_ras_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_diag_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 169.479523
-The maximum resident set size (KB)                   = 749308
+The total amount of wall time                        = 168.756009
+The maximum resident set size (KB)                   = 857632
 
 Test 025 control_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/control_debug_p8_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 170.565875
-The maximum resident set size (KB)                   = 1526276
+The total amount of wall time                        = 169.418241
+The maximum resident set size (KB)                   = 1636140
 
 Test 026 control_debug_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/regional_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1062.685325
-The maximum resident set size (KB)                   = 658068
+The total amount of wall time                        = 1057.763390
+The maximum resident set size (KB)                   = 690908
 
 Test 027 regional_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_control_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 308.517302
-The maximum resident set size (KB)                   = 1088872
+The total amount of wall time                        = 309.075459
+The maximum resident set size (KB)                   = 1192484
 
 Test 028 rap_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 299.026270
-The maximum resident set size (KB)                   = 1076764
+The total amount of wall time                        = 299.266067
+The maximum resident set size (KB)                   = 1190200
 
 Test 029 hrrr_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_gf_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_gf_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_gf_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 305.298672
-The maximum resident set size (KB)                   = 1085376
+The total amount of wall time                        = 304.233985
+The maximum resident set size (KB)                   = 1194240
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_c3_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_c3_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_c3_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.039645
-The maximum resident set size (KB)                   = 1085524
+The total amount of wall time                        = 308.116413
+The maximum resident set size (KB)                   = 1191608
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_unified_drag_suite_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.955395
-The maximum resident set size (KB)                   = 1083584
+The total amount of wall time                        = 311.078390
+The maximum resident set size (KB)                   = 1192984
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_diag_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 321.233612
-The maximum resident set size (KB)                   = 1174540
+The total amount of wall time                        = 322.857767
+The maximum resident set size (KB)                   = 1282136
 
 Test 033 rap_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_cires_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 313.333568
-The maximum resident set size (KB)                   = 1095276
+The total amount of wall time                        = 313.312706
+The maximum resident set size (KB)                   = 1193232
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_unified_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 314.670457
-The maximum resident set size (KB)                   = 1086180
+The total amount of wall time                        = 315.372761
+The maximum resident set size (KB)                   = 1198292
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_lndp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 309.632450
-The maximum resident set size (KB)                   = 1089152
+The total amount of wall time                        = 312.415098
+The maximum resident set size (KB)                   = 1197244
 
 Test 036 rap_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_progcld_thompson_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.879818
-The maximum resident set size (KB)                   = 1088376
+The total amount of wall time                        = 306.314581
+The maximum resident set size (KB)                   = 1192996
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_noah_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.764902
-The maximum resident set size (KB)                   = 1083144
+The total amount of wall time                        = 299.793912
+The maximum resident set size (KB)                   = 1191844
 
 Test 038 rap_noah_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_sfcdiff_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.804784
-The maximum resident set size (KB)                   = 1085012
+The total amount of wall time                        = 307.325658
+The maximum resident set size (KB)                   = 1193844
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_noah_sfcdiff_cires_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 502.108552
-The maximum resident set size (KB)                   = 1083256
+The total amount of wall time                        = 498.212627
+The maximum resident set size (KB)                   = 1191492
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rrfs_v1beta_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 302.463021
-The maximum resident set size (KB)                   = 1086284
+The total amount of wall time                        = 308.648160
+The maximum resident set size (KB)                   = 1182928
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_clm_lake_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 356.048976
-The maximum resident set size (KB)                   = 1089216
+The total amount of wall time                        = 359.846414
+The maximum resident set size (KB)                   = 1194576
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_flake_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 307.042359
-The maximum resident set size (KB)                   = 1086560
+The total amount of wall time                        = 314.102143
+The maximum resident set size (KB)                   = 1194160
 
 Test 043 rap_flake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/gnv1_c96_no_nest_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/gnv1_c96_no_nest_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/gnv1_c96_no_nest_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 538.151143
-The maximum resident set size (KB)                   = 1090732
+The total amount of wall time                        = 541.145773
+The maximum resident set size (KB)                   = 1199216
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 225.644500
-The maximum resident set size (KB)                   = 992328
+The total amount of wall time                        = 244.390536
+The maximum resident set size (KB)                   = 1092432
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_control_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 334.750693
-The maximum resident set size (KB)                   = 804416
+The total amount of wall time                        = 357.282763
+The maximum resident set size (KB)                   = 896232
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 176.125949
-The maximum resident set size (KB)                   = 798948
+The total amount of wall time                        = 181.635841
+The maximum resident set size (KB)                   = 895360
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_2threads_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 306.390951
-The maximum resident set size (KB)                   = 860692
+The total amount of wall time                        = 324.846205
+The maximum resident set size (KB)                   = 950648
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_2threads_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 159.964080
-The maximum resident set size (KB)                   = 854120
+The total amount of wall time                        = 173.061097
+The maximum resident set size (KB)                   = 950212
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_decomp_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 184.529926
-The maximum resident set size (KB)                   = 801376
+The total amount of wall time                        = 204.288458
+The maximum resident set size (KB)                   = 894364
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_restart_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,28 +1510,28 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 252.083539
-The maximum resident set size (KB)                   = 694676
+The total amount of wall time                        = 258.054743
+The maximum resident set size (KB)                   = 804340
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_restart_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 94.584627
-The maximum resident set size (KB)                   = 677368
+The total amount of wall time                        = 98.154257
+The maximum resident set size (KB)                   = 775140
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/conus13km_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1547,40 +1547,40 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 110.832332
-The maximum resident set size (KB)                   = 1038900
+The total amount of wall time                        = 110.455560
+The maximum resident set size (KB)                   = 1125544
 
 Test 053 conus13km_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/conus13km_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 55.206995
-The maximum resident set size (KB)                   = 1046048
+The total amount of wall time                        = 56.562999
+The maximum resident set size (KB)                   = 1109636
 
 Test 054 conus13km_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/conus13km_restart_mismatch_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/conus13km_restart_mismatch_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/conus13km_restart_mismatch_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/conus13km_restart_mismatch_intel
 Checking test 055 conus13km_restart_mismatch_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 68.362462
-The maximum resident set size (KB)                   = 929544
+The total amount of wall time                        = 68.418830
+The maximum resident set size (KB)                   = 1023724
 
 Test 055 conus13km_restart_mismatch_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_control_dyn64_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_control_dyn64_phy32_intel
 Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1627,42 +1627,42 @@ Checking test 056 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 231.747942
-The maximum resident set size (KB)                   = 831940
+The total amount of wall time                        = 235.457041
+The maximum resident set size (KB)                   = 927988
 
 Test 056 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_control_debug_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_control_debug_dyn32_phy32_intel
 Checking test 057 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.500469
-The maximum resident set size (KB)                   = 966436
+The total amount of wall time                        = 299.660180
+The maximum resident set size (KB)                   = 1070028
 
 Test 057 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/hrrr_control_debug_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/hrrr_control_debug_dyn32_phy32_intel
 Checking test 058 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 290.511962
-The maximum resident set size (KB)                   = 961324
+The total amount of wall time                        = 293.942598
+The maximum resident set size (KB)                   = 1073808
 
 Test 058 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/conus13km_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/conus13km_debug_intel
 Checking test 059 conus13km_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1676,14 +1676,14 @@ Checking test 059 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 852.943420
-The maximum resident set size (KB)                   = 1069652
+The total amount of wall time                        = 854.386453
+The maximum resident set size (KB)                   = 1173536
 
 Test 059 conus13km_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/conus13km_debug_qr_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/conus13km_debug_qr_intel
 Checking test 060 conus13km_debug_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1697,54 +1697,54 @@ Checking test 060 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 859.542376
-The maximum resident set size (KB)                   = 762608
+The total amount of wall time                        = 873.714150
+The maximum resident set size (KB)                   = 871652
 
 Test 060 conus13km_debug_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/conus13km_debug_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/conus13km_debug_2threads_intel
 Checking test 061 conus13km_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 490.503675
-The maximum resident set size (KB)                   = 1077460
+The total amount of wall time                        = 492.970419
+The maximum resident set size (KB)                   = 1163608
 
 Test 061 conus13km_debug_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/conus13km_radar_tten_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/conus13km_radar_tten_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/conus13km_radar_tten_debug_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/conus13km_radar_tten_debug_intel
 Checking test 062 conus13km_radar_tten_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 851.245609
-The maximum resident set size (KB)                   = 1139612
+The total amount of wall time                        = 855.690965
+The maximum resident set size (KB)                   = 1246088
 
 Test 062 conus13km_radar_tten_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20240627/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_77929/rap_control_dyn64_phy32_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20250123/rap_control_debug_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_2372557/rap_control_dyn64_phy32_debug_intel
 Checking test 063 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 300.530648
-The maximum resident set size (KB)                   = 1000748
+The total amount of wall time                        = 307.404551
+The maximum resident set size (KB)                   = 1108664
 
 Test 063 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Sep  4 14:52:41 UTC 2024
-Elapsed time: 00h:26m:29s. Have a nice day!
+Fri Jan 24 15:25:08 UTC 2025
+Elapsed time: 00h:30m:52s. Have a nice day!


### PR DESCRIPTION
<!-- INSTRUCTIONS: 
- PLEASE READ/FOLLOW THE DIRECTIONS IN EACH SECTION
- Complete the 'Commit Queue Requirements' below
- Please use github markup as much as possible (https://docs.github.com/en/get-started/writing-on-github)
- Please leave your PR in a draft state until all underlying work is completed.
-->
## Commit Queue Requirements:
<!--
- Please complete the items that follow this.
- Please "check off" completed items. Use [X] for a filled in checkbox or leave it [ ] for an empty checkbox
- Your PR will not be considered until all requirements are met.
- THIS IS YOUR RESPONSIBILITY
 -->
- [ ] Fill out all sections of this template.
- [ ] All sub component pull requests have been reviewed by their code managers.
- [ ] Run the full Intel+GNU RT suite (compared to current baselines) on either Hera/Derecho/Hercules
- [ ] Commit 'test_changes.list' from previous step
---
## Description:
<!--
Please provide a detailed verbose description of what this PR does
-->

This PR follows @JongilHan66  suggestion and aims to reduce the large convective reflectivity caused by saSAS adjustment in the first timestep during a warm start. The issue is likely related to the inconsistency when DA updates the moisture at t but not the moisture from the previous timestep (t-36s). The moisture from the previous timestep is needed for initializing sigmab (updraft area fraction) when calculating qadv (q advection or tendency term).

The PR forces qadv to zero in the first timestep when a namelist parameter sigmab_coldstart is set to .true. It also reduces the lower limit of sigmab from 0.01 to 0.0 in the first timestep.

The PR also resolves an issue found by @ericaligo-NOAA where inline post does not correctly output soil temperature and moisture in grib2 when using RUC LSM. We tracked this to post_fv3 where iSF_SURFACE_PHYSICS is not updated for RUC LSM. This parameter is used in UPP SURFACE.f for soil variables output. The initial iSF_SURFACE_PHYSICS = 2 in post_fv3 and should be updated to 3 when RUC LSM is used. In this PR we set iSF_SURFACE_PHYSICS =3 when nsoil=9 and successfully output the 9 level soil variables.

### Commit Message:
<!--
Please provide concise information for The UFS-WM and/or each sub-component:
Please delete what is not needed.
-->
```
* UFSWM - 
  * AQM - 
  * CDEPS - 
  * CICE - 
  * CMEPS - 
  * CMakeModules - 
  * FV3 - https://github.com/NOAA-EMC/fv3atm/pull/869
    * ccpp-physics - https://github.com/ufs-community/ccpp-physics/pull/225
    * atmos_cubed_sphere - 
  * GOCART - 
  * HYCOM - 
  * MOM6 - 
  * NOAHMP - 
  * WW3 - 
  * fire_behavior
  * stochastic_physics - 
```

### Priority:
<!--
Please provide the priority you would prefer this pull request to have.
* Critical Bugfix: Model is wrong.
* High: Time-sensitive project.
* Normal.
Please delete the ones that are not applicable
-->
* Critical Bugfix: Reason
* High: Reason
* Normal

## Git Tracking
### UFSWM:
<!--
Please add the UFS-WM github issue here if there is one
Please delete the one that is not applicable.
-->
* Closes #
* None

### Sub component Pull Requests:
<!--
Please provide a list of sub-components involved with this pull request.
Please provide links to the sub-component pull requests as shown below.
Please delete what is not needed.
Example:
* FV3: NOAA-EMC/fv3atm#734
  * ccpp-physics: ufs-community/ccpp-physics#33
* WW3: NOAA-EMC/WW3#321
-->
* AQM:
* CDEPS:
* CICE:
* CMEPS:
* CMakeModules:
* FV3:
  * ccpp-physics:
  * atmos_cubed_sphere:
* GOCART:
* HYCOM:
* MOM6:
* NOAHMP:
* WW3:
* fire_behavior:
* stochastic_physics:
* None

### UFSWM Blocking Dependencies:
<!--
If there are any UFSWM PR's that are needed to be completed before this one, please add links
to them here
Please delete what is not needed.
-->
* Blocked by #
* None

---
## Changes
### Regression Test Changes (Please commit test_changes.list):
<!--
Please let us know if this PR creates new baselines, changes baselines or not.
Please delete what is not needed.
Please make sure you have properly submitted test_changes.list
-->
* PR Adds New Tests/Baselines.
* PR Updates/Changes Baselines.
* No Baseline Changes.

### Input data Changes:
<!--
If there are any changes to input-data for a test, please provide information here.
Please delete what is not needed.
-->
* None.
* New input data.
* Updated input data.

### Library Changes/Upgrades:
<!-- Library updates take time. Please provide library and version information here.
** SPECIAL INSTRUCTIONS **
If this PR needs updates to libraries please make sure to accomplish the following tasks:
- Create separate issue in (https://github.com/JCSDA/spack-stack) asking for update to library. Include library name, library version.
- Add issue link from JCSDA/spack-stack following this item <!-- for example: "* JCSDA/spack-stack#1757"

Please delete what is not needed.
-->
* Required
  * Library names w/versions:
  * Git Stack Issue (JCSDA/spack-stack#)
* No Updates
  
---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Hercules
  - [ ] Jet
  - [ ] Gaea
  - [ ] Derecho
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- [ ] CI
- [ ] opnReqTest (complete task if unnecessary)