### PR TITLE
Feature/cicd bugfix to save metrics result files

### DIFF
--- a/.cicd/scripts/disk_usage.sh
+++ b/.cicd/scripts/disk_usage.sh
@@ -25,10 +25,10 @@ echo "script_dir=${script_dir}"
 declare workspace
 if [[ -d "${WORKSPACE}/${UFS_PLATFORM}" ]]; then
     workspace="${WORKSPACE}/${UFS_PLATFORM}"
-    outfile="${4:-${workspace}-${UFS_PLATFORM}-${UFS_COMPILER}-disk-usage${STAGE_NAME%% *}.csv}"
+    outfile="${4:-${WORKSPACE}/${UFS_PLATFORM}-${UFS_COMPILER}-disk-usage${STAGE_NAME%% *}.csv}"
 else
     workspace="$(cd -- "${script_dir}/../.." && pwd)"
-    outfile="${4:-${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-disk-usage${STAGE_NAME%% *}.csv}"
+    outfile="${4:-${WORKSPACE}/${UFS_PLATFORM}-${UFS_COMPILER}-disk-usage${STAGE_NAME%% *}.csv}"
 fi
 echo "workspace=${workspace}"
 echo "outfile=${outfile}"

--- a/.cicd/scripts/wm_build.sh
+++ b/.cicd/scripts/wm_build.sh
@@ -63,7 +63,7 @@ module list
 echo "Pipeline Building WM on ${UFS_PLATFORM} ${UFS_COMPILER} with Account=${ACCNR}."
 export CMAKE_FLAGS="-DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16"
 /usr/bin/time -p \
-	-o ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_build.json \
+	-o ${WORKSPACE:-$(pwd)}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_build.json \
 	-f '{\n  "cpu": "%P"\n, "memMax": "%M"\n, "mem": {"text": "%X", "data": "%D", "swaps": "%W", "context": "%c", "waits": "%w"}\n, "pagefaults": {"major": "%F", "minor": "%R"}\n, "filesystem": {"inputs": "%I", "outputs": "%O"}\n, "time": {"real": "%e", "user": "%U", "sys": "%S"}\n}' \
 	./build.sh | tee ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-wm_build-log.txt
 status=${PIPESTATUS[0]}

--- a/.cicd/scripts/wm_init.sh
+++ b/.cicd/scripts/wm_init.sh
@@ -35,6 +35,6 @@ fi
 echo "machine_id=<${machine_id}>"
 
 /usr/bin/time -p \
-	-o ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_init.json \
+	-o ${WORKSPACE:-$(pwd)}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_init.json \
 	-f '{\n  "cpu": "%P"\n, "memMax": "%M"\n, "mem": {"text": "%X", "data": "%D", "swaps": "%W", "context": "%c", "waits": "%w"}\n, "pagefaults": {"major": "%F", "minor": "%R"}\n, "filesystem": {"inputs": "%I", "outputs": "%O"}\n, "time": {"real": "%e", "user": "%U", "sys": "%S"}\n}' \
 	pwd

--- a/.cicd/scripts/wm_test.sh
+++ b/.cicd/scripts/wm_test.sh
@@ -102,7 +102,7 @@ if [[ ${WM_REGRESSION_TESTS} = true ]] ; then
 		ls -al .cicd/*
 		echo "Pipeline Creating Baseline Tests ${WM_OPERATIONAL_TESTS:=default} on ${UFS_PLATFORM} ${UFS_COMPILER}"
 		/usr/bin/time -p \
-			-o ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_test.json \
+			-o ${WORKSPACE:-$(pwd)}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_test.json \
 			-f '{\n  "cpu": "%P"\n, "memMax": "%M"\n, "mem": {"text": "%X", "data": "%D", "swaps": "%W", "context": "%c", "waits": "%w"}\n, "pagefaults": {"major": "%F", "minor": "%R"}\n, "filesystem": {"inputs": "%I", "outputs": "%O"}\n, "time": {"real": "%e", "user": "%U", "sys": "%S"}\n}' \
 			./.cicd/scripts/create_baseline.sh | tee -a ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-wm_test-log.txt
 		status=${PIPESTATUS[0]}
@@ -113,7 +113,7 @@ if [[ ${WM_REGRESSION_TESTS} = true ]] ; then
 		ls -al .cicd/*
 		echo "Pipeline Running Regression Tests ${WM_OPERATIONAL_TESTS:=default} on ${UFS_PLATFORM} ${UFS_COMPILER}"
 		/usr/bin/time -p \
-			-o ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_test.json \
+			-o ${WORKSPACE:-$(pwd)}/${UFS_PLATFORM}-${UFS_COMPILER}-time-wm_test.json \
 			-f '{\n  "cpu": "%P"\n, "memMax": "%M"\n, "mem": {"text": "%X", "data": "%D", "swaps": "%W", "context": "%c", "waits": "%w"}\n, "pagefaults": {"major": "%F", "minor": "%R"}\n, "filesystem": {"inputs": "%I", "outputs": "%O"}\n, "time": {"real": "%e", "user": "%U", "sys": "%S"}\n}' \
 			./.cicd/scripts/regression_test.sh | tee -a ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-wm_test-log.txt
 		status=${PIPESTATUS[0]}


### PR DESCRIPTION
## Commit Queue Requirements:
- [x] Fill out all sections of this template.
- [x] All sub component pull requests have been reviewed by their code managers.
- [x] Run the full Intel+GNU RT suite (compared to current baselines) on either Hera/Derecho/Hercules
- [x] Commit 'test_changes.list' from previous step
---
## Description:
The cicd scripts save performance metrics to JSON and CSV outfiles, but need to be saved to a common location in the workspace, defined by WORKSPACE env variable, or PWD when WORKSPACE is undefined.

### Commit Message:
Feature/cicd bugfix to save metrics result files.
```
* UFSWM - cicd automation metrics
```

### Priority:
* Normal

## Git Tracking
### UFSWM:
* None

### Sub component Pull Requests:
* None

### UFSWM Blocking Dependencies:
* None

---
## Changes
### Regression Test Changes (Please commit test_changes.list):
* No Baseline Changes.

### Input data Changes:
* None.

### Library Changes/Upgrades:
* No Updates
  
---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [ ] Hera
  - [ ] Orion
  - [ ] Hercules
  - [ ] Jet
  - [ ] GaeaC5
  - [ ] GaeaC6
  - [ ] Derecho
- WCOSS2
  - [ ] Dogwood/Cactus
  - [ ] Acorn
- [ ] CI
- [ ] opnReqTest (complete task if unnecessary)
