### PR TITLE
Fix to data pathway in UFS WM UG (USS-276)

### DIFF
--- a/doc/UsersGuide/source/InputsOutputs.rst
+++ b/doc/UsersGuide/source/InputsOutputs.rst
@@ -2081,8 +2081,7 @@ A sample subset of this namelist is shown below:
      FNABSC   = 'global_mxsnoalb.uariz.t126.384.190.rg.grb'
    /
 
-Additional variables for the ``&namsfc`` namelist can be found in the ``FV3/ccpp/physics/physics/sfcsub.F``
-file.
+Additional variables for the ``&namsfc`` namelist can be found in the ``FV3/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F`` file.
 
 .. _atmos_model_nml_section:
 


### PR DESCRIPTION
## Description:
<!--
Please provide a detailed verbose description of what this PR does
-->
Update data pathway for UFS WM UG. The line is in the UFS weather model users guide: ufs-weather-model/doc/UsersGuide/source/InputsOutputs.rst line 2070. There is a path to a file "FV3/ccpp/physics/physics/sfcsub.F", but this should be "FV3/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
