### PR TITLE
[production/GFSv17] Allow MOM6 to create hourly output file logs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,10 +24,8 @@
   branch = emc/develop
 [submodule "MOM6"]
   path = MOM6-interface/MOM6
-  #url = https://github.com/NOAA-EMC/MOM6
-  #branch = GFSV17
-  url = https://github.com/dpsarmie/MOM6
-  branch = v17/hourly_logs
+  url = https://github.com/NOAA-EMC/MOM6
+  branch = GFSV17
 [submodule "CICE"]
   path = CICE-interface/CICE
   url = https://github.com/NOAA-EMC/CICE

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,8 +24,10 @@
   branch = emc/develop
 [submodule "MOM6"]
   path = MOM6-interface/MOM6
-  url = https://github.com/NOAA-EMC/MOM6
-  branch = GFSV17
+  #url = https://github.com/NOAA-EMC/MOM6
+  #branch = GFSV17
+  url = https://github.com/dpsarmie/MOM6
+  branch = v17/hourly_logs
 [submodule "CICE"]
   path = CICE-interface/CICE
   url = https://github.com/NOAA-EMC/CICE


### PR DESCRIPTION
## Commit Queue Requirements:
- [x] All subcomponent pull requests (if any) have been reviewed by their code managers.
- [x] Run the full Intel+GNU RT suite (compared to current baselines), preferably on Ursa (Derecho or Hercules are acceptable alternatives). **Exceptions:** documentation-only PRs, CI-only PRs, etc.
- [X] Transparency in the use of generative AI is required by NOAA policy. Was GenAI used in this work? No
- [X] Fill out all sections of this template.

---

## Description:
The PR will bring in changes made to MOM6 that will allow log files to be written when hourly output files are created.  The changes are specific to GDAS and EnKFGDAS because of the particularities of MOM6 output when doing hourly output along with data that only has instantaneous data saved.

Therefore, this is a production only change. A more robust solution will be added for dev/emc and the development branches of UFSWM.


### Commit Message:
```
* UFSWM - Update MOM6 hash
  * MOM6 - Add hourly output file logging capability 
```

### Priority:
- [X] High: GFSv17 update before code handoff


### Sub component Pull Requests:

* UFSWM - 
  * MOM6 - https://github.com/NOAA-EMC/MOM6/pull/178

### UFSWM Blocking Dependencies:
- [X] None

### Documentation:
- [X] Documentation update NOT required. 

---
## Changes
### Regression Test Changes (Please commit test_changes.list):
- [X] No Baseline Changes.

### Input data Changes:
- [X] None.

### Library Changes/Upgrades:
- [X] No Updates
  
---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [X] Ursa
- WCOSS2
  - [X] Dogwood/Cactus


## Testing Remarks:
<!-- Lead CM: List (1) testing issues that we are bypassing (e.g., failing CI due to remarks or an early-merged component PR) 
(2) Issues that have been opened based on testing results (3) any other relevant info -->
- 
