### PR TITLE
[production/RRFS.v1] G-F and NSSL MP changes to reduce REFS instability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-#  url = https://github.com/NOAA-EMC/fv3atm
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/fv3atm.git 
-  branch = refs_stability 
+  url = https://github.com/NOAA-EMC/fv3atm
+  branch = production/RRFS.v1
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-EMC/fv3atm
-  branch = production/RRFS.v1
+#  url = https://github.com/NOAA-EMC/fv3atm
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/fv3atm.git 
+  branch = refs_stability 
 [submodule "WW3"]
   path = WW3
   url = https://github.com/NOAA-EMC/WW3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@
 # Required
 version: 2
 build: 
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools: 
-    python: "3.9"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/tests/bl_date.conf
+++ b/tests/bl_date.conf
@@ -1,1 +1,1 @@
-export BL_DATE=20260227
+export BL_DATE=20260717

--- a/tests/logs/RegressionTests_wcoss2.log
+++ b/tests/logs/RegressionTests_wcoss2.log
@@ -1,31 +1,31 @@
-Thu Mar 12 12:54:38 UTC 2026
+Mon Jul 20 18:31:38 UTC 2026
 Start Regression test
 
-Testing UFSWM Hash: 1c6e1a789050d3b92bfa3350faaff1b302e541f9
+Testing UFSWM Hash: 45645ae2ee4c968ab2b515d3035041fcae5cb7ba
 Testing With Submodule Hashes:
  37cbb7d6840ae7515a9a8f0dfd4d89461b3396d1 AQM (v0.2.0-37-g37cbb7d)
  89603d16f39675624fc8518da50d9515cd5f18c6 CDEPS-interface/CDEPS (cdeps0.4.17-39-g89603d1)
  620e48fe75d92aa607af7e21f2d8691baddd2851 CICE-interface/CICE (CICE6.0.0-445-g620e48f)
- 13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed059)
+ 13ed05982efc95c077efc3b9609688554e3a854c CMEPS-interface/CMEPS (cmeps_v0.4.1-2302-g13ed0598)
  cabd7753ae17f7bfcc6dad56daf10868aa51c3f4 CMakeModules (v1.0.0-28-gcabd775)
- 59f24fb97f4c985f60f45c75086f26fa3e262dc6 FV3 (remotes/origin/feature/smokehailcastfix)
+ 1b04982352e9bb45131038d215eb9b82ed678a36 FV3 (heads/refs_stability)
  041422934cae1570f2f0e67239d5d89f11c6e1b7 GOCART (sdr_v2.1.2.6-119-g0414229)
  35789c757766e07f688b4c0c7c5229816f224b09 HYCOM-interface/HYCOM (2.3.00-121-g35789c7)
  c8a7325c040b4cb1327c55c8248e8e66972239a5 MOM6-interface/MOM6 (dev/master/repository_split_2014.10.10-9878-gc8a7325c0)
  0cd3e23ae5d35ef93e205e4d0c3b13ccc0d851f5 NOAHMP-interface/noahmp (v3.7.1-423-g0cd3e23)
  4ffc47e10e3d3f3bbee50251aacb28b7e0165b92 WW3 (6.07.1-344-g4ffc47e1)
  b8eda189dabdbd33426e1875f97d550805dc8e73 stochastic_physics (ufs-v2.0.0-205-gb8eda18)
-Compile atm_debug_dyn32_intel elapsed time 284 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile atm_debug_dyn32_intel elapsed time 299 seconds. -DAPP=ATM -DDEBUG=ON -D32BIT=ON -DCCPP_SUITES=FV3_HRRR,FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_ras,FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km,FV3_RAP,FV3_RAP_unified_ugwp,FV3_RAP_cires_ugwp,FV3_RAP_flake,FV3_RAP_clm_lake,FV3_RAP_noah,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta,FV3_HRRR_c3,FV3_HRRR_gf,FV3_global_nest_v1 -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile atm_faster_dyn32_intel elapsed time 510 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DFASTER=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn32_phy32_debug_intel elapsed time 208 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn32_phy32_faster_intel elapsed time 491 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn32_phy32_debug_intel elapsed time 216 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR,FV3_HRRR_gf -D32BIT=ON -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn32_phy32_faster_intel elapsed time 530 seconds. -DAPP=ATM -DFASTER=ON -DCCPP_SUITES=FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 Compile rrfs_dyn32_phy32_intel elapsed time 481 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -D32BIT=ON -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_dyn64_phy32_debug_intel elapsed time 198 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile rrfs_dyn64_phy32_intel elapsed time 485 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile rrfs_intel elapsed time 527 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_dyn64_phy32_debug_intel elapsed time 211 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DDEBUG=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile rrfs_dyn64_phy32_intel elapsed time 495 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_HRRR -DCCPP_32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile rrfs_intel elapsed time 528 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DENABLE_PARALLELRESTART=NO -DENABLE_RRFS_WAR=NO -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_control_intel
 Checking test 001 rap_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -72,14 +72,14 @@ Checking test 001 rap_control_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 403.266977
-The maximum resident set size (KB)                   = 1022524
+The total amount of wall time                        = 403.523979
+The maximum resident set size (KB)                   = 1018148
 
 Test 001 rap_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/regional_spp_sppt_shum_skeb_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/regional_spp_sppt_shum_skeb_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/regional_spp_sppt_shum_skeb_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/regional_spp_sppt_shum_skeb_intel
 Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -90,14 +90,14 @@ Checking test 002 regional_spp_sppt_shum_skeb_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 229.221654
-The maximum resident set size (KB)                   = 1234276
+The total amount of wall time                        = 230.753080
+The maximum resident set size (KB)                   = 1236736
 
 Test 002 regional_spp_sppt_shum_skeb_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_decomp_intel
 Checking test 003 rap_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -144,14 +144,14 @@ Checking test 003 rap_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 420.774647
-The maximum resident set size (KB)                   = 1009792
+The total amount of wall time                        = 424.153453
+The maximum resident set size (KB)                   = 1013124
 
 Test 003 rap_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_2threads_intel
 Checking test 004 rap_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -198,14 +198,14 @@ Checking test 004 rap_2threads_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 370.550598
-The maximum resident set size (KB)                   = 1099300
+The total amount of wall time                        = 392.722952
+The maximum resident set size (KB)                   = 1103968
 
 Test 004 rap_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_restart_intel
 Checking test 005 rap_restart_intel results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -244,14 +244,14 @@ Checking test 005 rap_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 215.887632
-The maximum resident set size (KB)                   = 893936
+The total amount of wall time                        = 210.174553
+The maximum resident set size (KB)                   = 894412
 
 Test 005 rap_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_sfcdiff_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_sfcdiff_intel
 Checking test 006 rap_sfcdiff_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -298,14 +298,14 @@ Checking test 006 rap_sfcdiff_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 403.169580
-The maximum resident set size (KB)                   = 1012008
+The total amount of wall time                        = 437.804082
+The maximum resident set size (KB)                   = 1012160
 
 Test 006 rap_sfcdiff_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_sfcdiff_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_sfcdiff_decomp_intel
 Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -352,14 +352,14 @@ Checking test 007 rap_sfcdiff_decomp_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 423.260045
-The maximum resident set size (KB)                   = 1010568
+The total amount of wall time                        = 433.796206
+The maximum resident set size (KB)                   = 1019984
 
 Test 007 rap_sfcdiff_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_sfcdiff_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_sfcdiff_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_sfcdiff_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_sfcdiff_restart_intel
 Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -398,14 +398,14 @@ Checking test 008 rap_sfcdiff_restart_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 307.325891
-The maximum resident set size (KB)                   = 895108
+The total amount of wall time                        = 301.840753
+The maximum resident set size (KB)                   = 896788
 
 Test 008 rap_sfcdiff_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_intel
 Checking test 009 hrrr_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -452,14 +452,14 @@ Checking test 009 hrrr_control_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 206.253014
-The maximum resident set size (KB)                   = 1012944
+The total amount of wall time                        = 207.035254
+The maximum resident set size (KB)                   = 1015104
 
 Test 009 hrrr_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_decomp_intel
 Checking test 010 hrrr_control_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -506,14 +506,14 @@ Checking test 010 hrrr_control_decomp_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 211.575205
-The maximum resident set size (KB)                   = 1012648
+The total amount of wall time                        = 215.188983
+The maximum resident set size (KB)                   = 1015180
 
 Test 010 hrrr_control_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_2threads_intel
 Checking test 011 hrrr_control_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -560,28 +560,28 @@ Checking test 011 hrrr_control_2threads_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 192.995482
-The maximum resident set size (KB)                   = 1098708
+The total amount of wall time                        = 193.790179
+The maximum resident set size (KB)                   = 1081168
 
 Test 011 hrrr_control_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_restart_intel
 Checking test 012 hrrr_control_restart_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 108.371200
-The maximum resident set size (KB)                   = 846700
+The total amount of wall time                        = 111.981650
+The maximum resident set size (KB)                   = 846480
 
 Test 012 hrrr_control_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rrfs_v1beta_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rrfs_v1beta_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rrfs_v1beta_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rrfs_v1beta_intel
 Checking test 013 rrfs_v1beta_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -628,14 +628,14 @@ Checking test 013 rrfs_v1beta_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 405.180907
-The maximum resident set size (KB)                   = 1009096
+The total amount of wall time                        = 412.967770
+The maximum resident set size (KB)                   = 1015124
 
 Test 013 rrfs_v1beta_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rrfs_v1nssl_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rrfs_v1nssl_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rrfs_v1nssl_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rrfs_v1nssl_intel
 Checking test 014 rrfs_v1nssl_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -650,14 +650,14 @@ Checking test 014 rrfs_v1nssl_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 489.445764
-The maximum resident set size (KB)                   = 1974088
+The total amount of wall time                        = 491.310453
+The maximum resident set size (KB)                   = 1971752
 
 Test 014 rrfs_v1nssl_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rrfs_v1nssl_nohailnoccn_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rrfs_v1nssl_nohailnoccn_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rrfs_v1nssl_nohailnoccn_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rrfs_v1nssl_nohailnoccn_intel
 Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -672,14 +672,14 @@ Checking test 015 rrfs_v1nssl_nohailnoccn_intel results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 477.490337
-The maximum resident set size (KB)                   = 1964212
+The total amount of wall time                        = 491.086686
+The maximum resident set size (KB)                   = 1963012
 
 Test 015 rrfs_v1nssl_nohailnoccn_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_p8_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_p8_faster_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_p8_faster_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_p8_faster_intel
 Checking test 016 control_p8_faster_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -726,14 +726,14 @@ Checking test 016 control_p8_faster_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 160.048964
-The maximum resident set size (KB)                   = 1599048
+The total amount of wall time                        = 168.117782
+The maximum resident set size (KB)                   = 1609888
 
 Test 016 control_p8_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/regional_control_faster_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/regional_control_faster_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/regional_control_faster_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/regional_control_faster_intel
 Checking test 017 regional_control_faster_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -744,14 +744,14 @@ Checking test 017 regional_control_faster_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-The total amount of wall time                        = 278.363017
-The maximum resident set size (KB)                   = 674264
+The total amount of wall time                        = 285.007311
+The maximum resident set size (KB)                   = 678464
 
 Test 017 regional_control_faster_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_CubedSphereGrid_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_CubedSphereGrid_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_CubedSphereGrid_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_CubedSphereGrid_debug_intel
 Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -778,364 +778,364 @@ Checking test 018 control_CubedSphereGrid_debug_intel results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-The total amount of wall time                        = 170.101954
-The maximum resident set size (KB)                   = 802692
+The total amount of wall time                        = 160.949200
+The maximum resident set size (KB)                   = 798500
 
 Test 018 control_CubedSphereGrid_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_wrtGauss_netcdf_parallel_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_wrtGauss_netcdf_parallel_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_wrtGauss_netcdf_parallel_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_wrtGauss_netcdf_parallel_debug_intel
 Checking test 019 control_wrtGauss_netcdf_parallel_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.119635
-The maximum resident set size (KB)                   = 799764
+The total amount of wall time                        = 160.049495
+The maximum resident set size (KB)                   = 805120
 
 Test 019 control_wrtGauss_netcdf_parallel_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_stochy_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_stochy_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_stochy_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_stochy_debug_intel
 Checking test 020 control_stochy_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 189.216228
-The maximum resident set size (KB)                   = 814972
+The total amount of wall time                        = 185.525733
+The maximum resident set size (KB)                   = 806172
 
 Test 020 control_stochy_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_lndp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_lndp_debug_intel
 Checking test 021 control_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 167.670956
-The maximum resident set size (KB)                   = 807024
+The total amount of wall time                        = 165.484144
+The maximum resident set size (KB)                   = 812168
 
 Test 021 control_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_csawmg_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_csawmg_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_csawmg_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_csawmg_debug_intel
 Checking test 022 control_csawmg_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 255.836431
-The maximum resident set size (KB)                   = 847796
+The total amount of wall time                        = 255.614928
+The maximum resident set size (KB)                   = 847468
 
 Test 022 control_csawmg_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_csawmgt_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_csawmgt_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_csawmgt_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_csawmgt_debug_intel
 Checking test 023 control_csawmgt_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 250.391827
-The maximum resident set size (KB)                   = 845356
+The total amount of wall time                        = 248.701439
+The maximum resident set size (KB)                   = 847988
 
 Test 023 control_csawmgt_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_ras_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_ras_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_ras_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_ras_debug_intel
 Checking test 024 control_ras_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 163.697502
-The maximum resident set size (KB)                   = 815268
+The total amount of wall time                        = 164.171985
+The maximum resident set size (KB)                   = 815160
 
 Test 024 control_ras_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_diag_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_diag_debug_intel
 Checking test 025 control_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 173.992995
-The maximum resident set size (KB)                   = 863204
+The total amount of wall time                        = 168.209001
+The maximum resident set size (KB)                   = 861924
 
 Test 025 control_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/control_debug_p8_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/control_debug_p8_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/control_debug_p8_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/control_debug_p8_intel
 Checking test 026 control_debug_p8_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 180.199247
-The maximum resident set size (KB)                   = 1635880
+The total amount of wall time                        = 170.516531
+The maximum resident set size (KB)                   = 1639216
 
 Test 026 control_debug_p8_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/regional_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/regional_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/regional_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/regional_debug_intel
 Checking test 027 regional_debug_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
-The total amount of wall time                        = 1061.121083
-The maximum resident set size (KB)                   = 707408
+The total amount of wall time                        = 1064.684943
+The maximum resident set size (KB)                   = 692852
 
 Test 027 regional_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_control_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_control_debug_intel
 Checking test 028 rap_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 312.889074
-The maximum resident set size (KB)                   = 1193520
+The total amount of wall time                        = 307.077707
+The maximum resident set size (KB)                   = 1195612
 
 Test 028 rap_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_debug_intel
 Checking test 029 hrrr_control_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 306.811247
-The maximum resident set size (KB)                   = 1184144
+The total amount of wall time                        = 300.087257
+The maximum resident set size (KB)                   = 1193052
 
 Test 029 hrrr_control_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_gf_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_gf_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_gf_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_gf_debug_intel
 Checking test 030 hrrr_gf_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 313.406525
-The maximum resident set size (KB)                   = 1198780
+The total amount of wall time                        = 304.566366
+The maximum resident set size (KB)                   = 1194824
 
 Test 030 hrrr_gf_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_c3_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_c3_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_c3_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_c3_debug_intel
 Checking test 031 hrrr_c3_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 315.580505
-The maximum resident set size (KB)                   = 1193048
+The total amount of wall time                        = 306.766614
+The maximum resident set size (KB)                   = 1195696
 
 Test 031 hrrr_c3_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_unified_drag_suite_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_unified_drag_suite_debug_intel
 Checking test 032 rap_unified_drag_suite_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 309.869041
-The maximum resident set size (KB)                   = 1193988
+The total amount of wall time                        = 306.080590
+The maximum resident set size (KB)                   = 1191600
 
 Test 032 rap_unified_drag_suite_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_diag_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_diag_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_diag_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_diag_debug_intel
 Checking test 033 rap_diag_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 327.689147
-The maximum resident set size (KB)                   = 1271072
+The total amount of wall time                        = 322.901761
+The maximum resident set size (KB)                   = 1284760
 
 Test 033 rap_diag_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_cires_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_cires_ugwp_debug_intel
 Checking test 034 rap_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 318.013933
-The maximum resident set size (KB)                   = 1185360
+The total amount of wall time                        = 315.884455
+The maximum resident set size (KB)                   = 1188548
 
 Test 034 rap_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_unified_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_unified_ugwp_debug_intel
 Checking test 035 rap_unified_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 320.310204
-The maximum resident set size (KB)                   = 1196804
+The total amount of wall time                        = 311.488501
+The maximum resident set size (KB)                   = 1197804
 
 Test 035 rap_unified_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_lndp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_lndp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_lndp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_lndp_debug_intel
 Checking test 036 rap_lndp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 316.767767
-The maximum resident set size (KB)                   = 1190444
+The total amount of wall time                        = 308.349294
+The maximum resident set size (KB)                   = 1193392
 
 Test 036 rap_lndp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_progcld_thompson_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_progcld_thompson_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_progcld_thompson_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_progcld_thompson_debug_intel
 Checking test 037 rap_progcld_thompson_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 312.850055
-The maximum resident set size (KB)                   = 1187632
+The total amount of wall time                        = 305.568919
+The maximum resident set size (KB)                   = 1188400
 
 Test 037 rap_progcld_thompson_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_noah_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_noah_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_noah_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_noah_debug_intel
 Checking test 038 rap_noah_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 309.261178
-The maximum resident set size (KB)                   = 1188396
+The total amount of wall time                        = 299.596499
+The maximum resident set size (KB)                   = 1197908
 
 Test 038 rap_noah_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_sfcdiff_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_sfcdiff_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_sfcdiff_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_sfcdiff_debug_intel
 Checking test 039 rap_sfcdiff_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 314.979552
-The maximum resident set size (KB)                   = 1187148
+The total amount of wall time                        = 315.142575
+The maximum resident set size (KB)                   = 1193432
 
 Test 039 rap_sfcdiff_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_noah_sfcdiff_cires_ugwp_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_noah_sfcdiff_cires_ugwp_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_noah_sfcdiff_cires_ugwp_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_noah_sfcdiff_cires_ugwp_debug_intel
 Checking test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 503.358172
-The maximum resident set size (KB)                   = 1194060
+The total amount of wall time                        = 498.996954
+The maximum resident set size (KB)                   = 1189552
 
 Test 040 rap_noah_sfcdiff_cires_ugwp_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rrfs_v1beta_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rrfs_v1beta_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rrfs_v1beta_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rrfs_v1beta_debug_intel
 Checking test 041 rrfs_v1beta_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 301.285814
-The maximum resident set size (KB)                   = 1181812
+The total amount of wall time                        = 301.267910
+The maximum resident set size (KB)                   = 1190700
 
 Test 041 rrfs_v1beta_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_clm_lake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_clm_lake_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_clm_lake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_clm_lake_debug_intel
 Checking test 042 rap_clm_lake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 355.983693
-The maximum resident set size (KB)                   = 1198812
+The total amount of wall time                        = 360.504495
+The maximum resident set size (KB)                   = 1199912
 
 Test 042 rap_clm_lake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_flake_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_flake_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_flake_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_flake_debug_intel
 Checking test 043 rap_flake_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 303.889432
-The maximum resident set size (KB)                   = 1197096
+The total amount of wall time                        = 306.178504
+The maximum resident set size (KB)                   = 1190492
 
 Test 043 rap_flake_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/gnv1_c96_no_nest_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/gnv1_c96_no_nest_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/gnv1_c96_no_nest_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/gnv1_c96_no_nest_debug_intel
 Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1176,14 +1176,14 @@ Checking test 044 gnv1_c96_no_nest_debug_intel results ....
  Comparing RESTART/20210322.070000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.070000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 544.799802
-The maximum resident set size (KB)                   = 1199040
+The total amount of wall time                        = 538.199589
+The maximum resident set size (KB)                   = 1202692
 
 Test 044 gnv1_c96_no_nest_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/regional_spp_sppt_shum_skeb_dyn32_phy32_intel
 Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1194,14 +1194,14 @@ Checking test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-The total amount of wall time                        = 217.444784
-The maximum resident set size (KB)                   = 1085508
+The total amount of wall time                        = 215.854562
+The maximum resident set size (KB)                   = 1085368
 
 Test 045 regional_spp_sppt_shum_skeb_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_control_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_control_dyn32_phy32_intel
 Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1248,14 +1248,14 @@ Checking test 046 rap_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 334.356928
-The maximum resident set size (KB)                   = 896756
+The total amount of wall time                        = 334.835728
+The maximum resident set size (KB)                   = 893720
 
 Test 046 rap_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_dyn32_phy32_intel
 Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1302,14 +1302,14 @@ Checking test 047 hrrr_control_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 174.471488
-The maximum resident set size (KB)                   = 888040
+The total amount of wall time                        = 179.654407
+The maximum resident set size (KB)                   = 895084
 
 Test 047 hrrr_control_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_2threads_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_2threads_dyn32_phy32_intel
 Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1356,14 +1356,14 @@ Checking test 048 rap_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 305.880407
-The maximum resident set size (KB)                   = 954144
+The total amount of wall time                        = 304.823671
+The maximum resident set size (KB)                   = 951416
 
 Test 048 rap_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_2threads_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_2threads_dyn32_phy32_intel
 Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1410,14 +1410,14 @@ Checking test 049 hrrr_control_2threads_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 162.009829
-The maximum resident set size (KB)                   = 945956
+The total amount of wall time                        = 160.067051
+The maximum resident set size (KB)                   = 938944
 
 Test 049 hrrr_control_2threads_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_decomp_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_decomp_dyn32_phy32_intel
 Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1464,14 +1464,14 @@ Checking test 050 hrrr_control_decomp_dyn32_phy32_intel results ....
  Comparing RESTART/20210322.120000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.120000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 189.159542
-The maximum resident set size (KB)                   = 894004
+The total amount of wall time                        = 194.815563
+The maximum resident set size (KB)                   = 895784
 
 Test 050 hrrr_control_decomp_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_restart_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_restart_dyn32_phy32_intel
 Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1510,28 +1510,28 @@ Checking test 051 rap_restart_dyn32_phy32_intel results ....
  Comparing RESTART/20210323.060000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210323.060000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 257.074433
-The maximum resident set size (KB)                   = 801736
+The total amount of wall time                        = 255.559202
+The maximum resident set size (KB)                   = 806056
 
 Test 051 rap_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_restart_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_restart_dyn32_phy32_intel
 Checking test 052 hrrr_control_restart_dyn32_phy32_intel results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-The total amount of wall time                        = 92.669001
-The maximum resident set size (KB)                   = 774420
+The total amount of wall time                        = 98.137281
+The maximum resident set size (KB)                   = 778524
 
 Test 052 hrrr_control_restart_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_control_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_control_intel
 Checking test 053 conus13km_control_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1547,28 +1547,28 @@ Checking test 053 conus13km_control_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 157.448692
-The maximum resident set size (KB)                   = 1071876
+The total amount of wall time                        = 184.655652
+The maximum resident set size (KB)                   = 1072000
 
 Test 053 conus13km_control_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_2threads_intel
 Checking test 054 conus13km_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 66.419654
-The maximum resident set size (KB)                   = 1192512
+The total amount of wall time                        = 64.635567
+The maximum resident set size (KB)                   = 1194972
 
 Test 054 conus13km_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_decomp_intel
 Checking test 055 conus13km_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1577,26 +1577,26 @@ Checking test 055 conus13km_decomp_intel results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 156.198898
-The maximum resident set size (KB)                   = 1072944
+The total amount of wall time                        = 166.950905
+The maximum resident set size (KB)                   = 1077008
 
 Test 055 conus13km_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_control_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_restart_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_control_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_restart_intel
 Checking test 056 conus13km_restart_intel results ....
  Comparing sfcf002.nc .........OK
  Comparing atmf002.nc .........OK
 
-The total amount of wall time                        = 91.922215
-The maximum resident set size (KB)                   = 942056
+The total amount of wall time                        = 132.803352
+The maximum resident set size (KB)                   = 945572
 
 Test 056 conus13km_restart_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_control_dyn64_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_control_dyn64_phy32_intel
 Checking test 057 rap_control_dyn64_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1643,42 +1643,42 @@ Checking test 057 rap_control_dyn64_phy32_intel results ....
  Comparing RESTART/20210322.180000.sfc_data.tile5.nc .........OK
  Comparing RESTART/20210322.180000.sfc_data.tile6.nc .........OK
 
-The total amount of wall time                        = 244.967256
-The maximum resident set size (KB)                   = 928960
+The total amount of wall time                        = 231.694234
+The maximum resident set size (KB)                   = 929152
 
 Test 057 rap_control_dyn64_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_control_debug_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_control_debug_dyn32_phy32_intel
 Checking test 058 rap_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 304.283226
-The maximum resident set size (KB)                   = 1078176
+The total amount of wall time                        = 304.060273
+The maximum resident set size (KB)                   = 1072180
 
 Test 058 rap_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/hrrr_control_debug_dyn32_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/hrrr_control_debug_dyn32_phy32_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/hrrr_control_debug_dyn32_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/hrrr_control_debug_dyn32_phy32_intel
 Checking test 059 hrrr_control_debug_dyn32_phy32_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 296.222187
-The maximum resident set size (KB)                   = 1075380
+The total amount of wall time                        = 293.891744
+The maximum resident set size (KB)                   = 1078436
 
 Test 059 hrrr_control_debug_dyn32_phy32_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_debug_intel
 Checking test 060 conus13km_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1692,14 +1692,14 @@ Checking test 060 conus13km_debug_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc .........OK
  Comparing RESTART/20210512.170000.sfc_data.nc .........OK
 
-The total amount of wall time                        = 1392.855342
-The maximum resident set size (KB)                   = 1132164
+The total amount of wall time                        = 1389.103560
+The maximum resident set size (KB)                   = 1130792
 
 Test 060 conus13km_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_debug_qr_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_debug_qr_intel
 Checking test 061 conus13km_debug_qr_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -1713,68 +1713,68 @@ Checking test 061 conus13km_debug_qr_intel results ....
  Comparing RESTART/20210512.170000.phy_data.nc ............ALT CHECK......OK
  Comparing RESTART/20210512.170000.sfc_data.nc ............ALT CHECK......OK
 
-The total amount of wall time                        = 1407.250631
-The maximum resident set size (KB)                   = 851996
+The total amount of wall time                        = 1401.969080
+The maximum resident set size (KB)                   = 849988
 
 Test 061 conus13km_debug_qr_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_debug_2threads_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_debug_2threads_intel
 Checking test 062 conus13km_debug_2threads_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 768.797367
-The maximum resident set size (KB)                   = 1247304
+The total amount of wall time                        = 768.977669
+The maximum resident set size (KB)                   = 1250272
 
 Test 062 conus13km_debug_2threads_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_debug_decomp_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_debug_decomp_intel
 Checking test 063 conus13km_debug_decomp_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 1419.595362
-The maximum resident set size (KB)                   = 1142316
+The total amount of wall time                        = 1423.102022
+The maximum resident set size (KB)                   = 1131060
 
 Test 063 conus13km_debug_decomp_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/conus13km_radar_tten_debug_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/conus13km_radar_tten_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/conus13km_radar_tten_debug_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/conus13km_radar_tten_debug_intel
 Checking test 064 conus13km_radar_tten_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 1390.826463
-The maximum resident set size (KB)                   = 1215012
+The total amount of wall time                        = 1395.030211
+The maximum resident set size (KB)                   = 1194512
 
 Test 064 conus13km_radar_tten_debug_intel PASS
 
 
-baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260227/rap_control_debug_dyn64_phy32_intel
-working dir  = /lfs/h2/emc/ptmp/matthew.pyle/FV3_RT/rt_1691353/rap_control_dyn64_phy32_debug_intel
+baseline dir = /lfs/h2/emc/lam/noscrub/emc.lam/RRFS.v1_RT/NEMSfv3gfs/develop-20260717/rap_control_debug_dyn64_phy32_intel
+working dir  = /lfs/h2/emc/ptmp/jili.dong/FV3_RT/rt_1918690/rap_control_dyn64_phy32_debug_intel
 Checking test 065 rap_control_dyn64_phy32_debug_intel results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-The total amount of wall time                        = 304.459760
-The maximum resident set size (KB)                   = 1104268
+The total amount of wall time                        = 308.376660
+The maximum resident set size (KB)                   = 1102924
 
 Test 065 rap_control_dyn64_phy32_debug_intel PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Mar 12 13:27:10 UTC 2026
-Elapsed time: 00h:32m:34s. Have a nice day!
+Tue Jul 21 04:22:16 UTC 2026
+Elapsed time: 09h:50m:40s. Have a nice day!


### PR DESCRIPTION
<!-- INSTRUCTIONS: 
- READ/FOLLOW THE DIRECTIONS IN EACH SECTION
- Complete the 'Commit Queue Requirements' below
- Use GitHub markup as much as possible (https://docs.github.com/en/get-started/writing-on-github)
- Leave your PR in a draft state until all underlying work is completed.
-->

## Commit Queue Requirements:
<!--
- Check off completed items. Use [X] for a filled in checkbox or leave it [ ] for an empty checkbox
- Your pull request (PR) will not be considered until all requirements are met.
- THIS IS YOUR RESPONSIBILITY
 -->
- [x] This PR addresses a relevant WM issue (if not, create an issue). 
- [X] All subcomponent pull requests (if any) have been reviewed by their code managers.
- [X] Run the full Intel+GNU RT suite (compared to current baselines), preferably on Ursa (Derecho or Hercules are acceptable alternatives). **Exceptions:** documentation-only PRs, CI-only PRs, etc.
   - [X] Commit log file w/full results from RT suite run (if applicable).
- [X] Fill out all sections of this template.

---

## Description:
This PR includes two physics changes to reduce instability related to REFS members:

1. Changes on Grell-Freitas cumulus convection from @delippi and discussions with Georg Grell, @haiqinli @lisa-bengtsson and @yangfanglin:

- Disable the fct1d3 convective-subsidence transport of existing cloud condensate.
  - This transport pathway was found to be problematic in columns containing very thin model layers.
  - Other GF convective processes remain active.
- Add a mass-conserving correction for cloud liquid water and cloud ice.
  - Compute the candidate liquid, ice, and total condensate values before updating the model state.
  - When the temperature-based partition makes one species negative, place the remaining nonnegative total condensate in the other species.
  - When the updated total condensate itself is negative, set both species to zero.
  - Avoid independently clipping liquid and ice in a way that can artificially increase total condensate. 

2.  Changes on NSSL microphysics from @MicroTed 
- this change limit condensation in NSSL microphysics to avoid undersaturation (overprediction of condensation)

The code changes affect regression tests using NSSL microphysics and RAP physics with Grell-Freitas convection. The baseline and regression tests log have been updated. 

### Commit Message:
<!--
Provide a concise commit message for the UFS WM and any subcomponents; delete unnecessary info.
-->
```
* UFSWM - Add CCPP changes to reduce REFS instabilities
  * UFSATM - Add CCPP changes to reduce REFS instabilities
    * ccpp-physics - Add G-F and NSSL MP changes to reduce REFS instability 
```

### Priority:
<!--
Indicate PR priority and include a justification for high/critical priority PRs; delete options that are not applicable. 
-->
- [ ] Critical Bugfix: Reason
- [x] High: Reason - reduce REFS instability for preparation of RRFS operational implementation
- [ ] Normal

## Git Tracking
### UFSWM:
<!--
Add the related UFS WM Github Issue here:
-->
* Closes #3304 

### Sub component Pull Requests:
<!--

  * UFSATM - https://github.com/NOAA-EMC/ufsatm/pull/1126
    * ccpp-physics - https://github.com/ufs-community/ccpp-physics/pull/379

### UFSWM Blocking Dependencies:
<!--
Please include any UFS WM PRs (with links) that need to be completed before this one; delete what is not needed.
-->
- [ ] Blocked by #
- [X] None

### Documentation:
<!--
Indicate what documentation, if any, is needed for this PR and who will add it (if applicable).
Delete what is not needed.
-->
- [ ] Documentation update required. 
   - [ ] Relevant updates are included with this PR. 
   - [ ] A WM issue has been opened to track the need for a documentation update; a person responsible for submitting the update has been assigned to the issue (link issue).
- [X] Documentation update NOT required. 
   - Explanation: 

---
## Changes
### Regression Test Changes (Please commit test_changes.list):
<!--
Indicate whether this PR creates new baselines, changes baselines, or not. Delete what is not needed.
For baseline changes, make sure to submit the test_changes.list file generated by a full RT run (Intel+GNU)
-->
- [ ] PR Adds New Tests/Baselines.
- [x] PR Updates/Changes Baselines.
- [ ] No Baseline Changes.

### Input data Changes:
<!--
If there are changes to input data for a test, provide information here. Delete options that are not needed.
-->
- [x] None.
- [ ] PR adds input data.
- [ ] PR changes existing input data.

### Library Changes/Upgrades:
<!-- Library updates take time. Provide library and version information here, and delete what is not needed. 
** SPECIAL INSTRUCTIONS **
- Create a separate issue in (https://github.com/JCSDA/spack-stack) asking for update to library. Include library name, library version.
- Add issue link from JCSDA/spack-stack following this item <!-- for example: "* JCSDA/spack-stack#1757"
-->
- [ ] Required
  * Library names w/versions:
  * Git Stack Issue (JCSDA/spack-stack#)
- [x] No Updates
  
---
<!-- STOP!!! THE FOLLOWING IS FOR CODE MANAGERS ONLY. PLEASE DO NOT FILL OUT -->
## Testing Log:
- RDHPCS
  - [ ] Orion
  - [ ] Hercules
  - [ ] GaeaC6
  - [ ] Derecho
  - [ ] Ursa
- WCOSS2
  - [X] Dogwood/Cactus
  - [ ] Acorn
- [ ] CI
- [ ] opnReqTest (complete task if unnecessary)

## Testing Remarks:
<!-- Lead CM: List (1) testing issues that we are bypassing (e.g., failing CI due to remarks or an early-merged component PR) 
(2) Issues that have been opened based on testing results (3) any other relevant info -->
- 
